### PR TITLE
Prevent test and story files from being bundled on build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,4 +9,9 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
   },
+  build: {
+    rollupOptions: {
+      external: new RegExp('/.+\.(test|stories)\..+')
+    }
+  }
 })


### PR DESCRIPTION
## Context

[**Set up deploy pipeline**](https://trello.com/c/D8ttijyI/235-set-up-deploy-pipeline)

In #5 we configured GitHub Actions to deploy to Firebase on merge to main. Unfortunately, we neglected to realise that `vite build` would include all files, including `test` and `stories` files, which include imports of dev dependencies. It was somewhat difficult to find information on how to exclude certain files from the Vite build, so this PR is my first attempt.

## Changes

* Add build options to Vite config intended to prevent `vite build` from including `.test.(ts|js)` and `.stories.(tsx|jsx)` files in the build

## Considerations

Vite configuration is not as straightforward as CRA configuration, and it was difficult to find information on how to exclude certain files. We won't know if this works until we merge, unfortunately.

## Manual Test Cases

If deployment is successful, follow manual test cases for #5 to verify success.