### PR TITLE
Add ADRs for Firebase, React, Vite, and TypeScript

### DIFF
--- a/docs/adrs/0001-use-firebase.md
+++ b/docs/adrs/0001-use-firebase.md
@@ -23,8 +23,7 @@ We will use Firebase to build the new front end, and deploy to Firebase hosting 
 
 ## Context
 
-Several challenges have recently converged, pushing us to implement a full rewrite of the SIM front end. Most relevantly to this ADR, Google has deprecated its legacy Google Sign-In API, which SIM was using for authentication, and support for that API ends in March of 2023. Months of research into
-the new Sign in with Google API and a deep dive into the underlying OAuth 2.0 protocol still left us with doubts about our ability to implement the identity features we required.
+Several challenges have recently converged, pushing us to implement a full rewrite of the SIM front end. Most relevantly to this ADR, Google has deprecated its legacy Google Sign-In API, which SIM was using for authentication, and support for that API ends in March of 2023. Months of research into the new Sign in with Google API and a deep dive into the underlying OAuth 2.0 protocol still left us with doubts about our ability to implement the identity features we required.
 
 Google's Firebase SDK and hosting platform provide an out-of-the-box solution to this problem. Apps that use Firebase are able to easily integrate with Sign in with Google, providing a relatively easy solution to a problem that had been plaguing us for over a year.
 

--- a/docs/adrs/0001-use-firebase.md
+++ b/docs/adrs/0001-use-firebase.md
@@ -1,0 +1,58 @@
+# 0001. Use Firebase
+
+## Date
+
+2023-02-20
+
+## Approved By
+
+@danascheider
+
+## Decision
+
+We will use Firebase to build the new front end, and deploy to Firebase hosting instead of Heroku. The back end will stay on Heroku for now.
+
+## Glossary
+
+- **Firebase:** An [SDK and hosting platform](https://firebase.google.com) for web and mobile apps offered by Google
+- **Google Cloud Platform (GCP):** A [suite](https://cloud.google.com/) of cloud services offered by Google; competes with AWS and Microsoft Azure
+- **Google Sign-In:** A legacy identity service formerly offered by Google, used by SIM for authentication and recently replaced with Sign in with Google
+- **Heroku:** An [app hosting platform](https://heroku.com) on which the SIM back end and legacy front end are deployed\
+- **OAuth:** An [authorization protocol](https://oauth.net/2/) underlying most third-party identity services, such as those offered by Google
+- **Sign in with Google:** A new [identity service](https://developers.google.com/identity) offered by Google, replacing Google sign-in
+
+## Context
+
+Several challenges have recently converged, pushing us to implement a full rewrite of the SIM front end. Most relevantly to this ADR, Google has deprecated its legacy Google Sign-In API, which SIM was using for authentication, and support for that API ends in March of 2023. Months of research into
+the new Sign in with Google API and a deep dive into the underlying OAuth 2.0 protocol still left us with doubts about our ability to implement the identity features we required.
+
+Google's Firebase SDK and hosting platform provide an out-of-the-box solution to this problem. Apps that use Firebase are able to easily integrate with Sign in with Google, providing a relatively easy solution to a problem that had been plaguing us for over a year.
+
+## Considerations
+
+In deciding whether to make the change, we considered the following factors:
+
+- Whether we would be able to use React and TypeScript (other tools we've chosen for our tech stack) with Firebase
+- Whether we could (or should) deploy a Firebase app to Heroku
+- The cost of using Firebase and its hosting services
+- Ease of integrating with a Heroku-hosted API (if using Firebase hosting)
+
+### Use of React and TypeScript
+
+Firebase integrates easily with React and TypeScript projects.
+
+### Deployment to Heroku
+
+While it looks like it is possible to deploy a Firebase project to Heroku, hosting it on GCP seemed easiest and provided a suite of deployment tools that wouldn't be available if we hosted elsewhere.
+
+### Cost
+
+Like many cloud providers, Google doesn't make the actual cost of running a Firebase app particularly clear. However, back of the envelope, it appears that Firebase's free tier is fairly generous, whereas Heroku no longer has a free tier at all.
+
+### Integration with a Heroku-Hosted API
+
+While it's possible there would be benefits to hosting both the API and the front end on GCP, Google doesn't appear to do anything that would make integrating with a non-GCP-hosted back end more difficult.
+
+## Summary
+
+Because of its plug-and-play approach to Google identity services, Firebase was a very attractive option for SIM's new front end. Combined with its generous free tier, there seemed little disadvantage in using both its SDK and hosting services.

--- a/docs/adrs/0002-use-react.md
+++ b/docs/adrs/0002-use-react.md
@@ -1,0 +1,58 @@
+# 0002. Use React
+
+## Date
+
+2023-02-20
+
+## Approved By
+
+@danascheider
+
+## Decision
+
+We will use React as our JavaScript library for the new front end.
+
+## Glossary
+
+- **Create React App (CRA):** A lightweight, React-based [framework](https://create-react-app.dev/) enabling React apps to be created quickly and easily
+- **CSS modules:** A [CSS preprocessing solution](https://github.com/css-modules/css-modules) enabling CSS rules to be scoped to an individual component or element, all but eliminating the need to manage cascades
+- **Preact:** A lighter-weight [library](https://preactjs.com) with very similar features and API to React
+- **React:** A fully-featured [front-end JavaScript library](https://reactjs.org) enabling the use of an HTML-like syntax to create page components in isolation
+- **Storybook:** A [developer tool](https://storybook.js.org/) enabling components in React or other component-based frameworks to be viewed and interacted with in isolation from the rest of the page
+- **Svelte:** A [front-end JavaScript library](https://svelte.dev) that competes with React
+- **TypeScript:** A JavaScript-based [language](https://typescriptlang.org) that incorporates strong typing (see TypeScript ADR for details)
+- **Vue.js:** A [front-end JavaScript library](https://vuejs.org) that competes with React; Vue is currently the most popular frontend library/framework
+
+## Context
+
+Several challenges have recently converged, pushing us to implement a full rewrite of the SIM front end. The new Google identity API proved very difficult to integrate with, prompting us to consider a move to [Firebase](/docs/adrs/0001-use-firebase.md). We'd been wanting to port the app to [TypeScript](https://typescriptlang.org) for some time, and it would be easier to achieve this during a rewrite. The discovery that [Create React App](https://create-react-app.dev/) may no longer be maintained was the last straw pushing us to move to a new framework, necessitating a rewrite.
+
+Since we were contemplating a rewrite anyway, it made sense to revisit the question of whether React was the best tool for the job.
+
+## Considerations
+
+We considered React as well as three other, competing libraries:
+
+- Preact
+- Vue.js
+- Svelte
+
+In considering these libraries, we considered the following factors:
+
+- **Similarity to React:** Much of our tech stack is changing significantly for this rewrite, and as such, we want to ensure that the learning curve for a new library is minimal, unless there are truly compelling reasons to accept a steeper one.
+- **Application state management:** We're using React contexts to handle application state. These have worked so far, however, they are a bit cumbersome. We were interested to know if any of the other libraries offered more elegant solutions to this problem.
+- **Compatibility with Firebase:** Since we'd already decided to use [Firebase](https://firebase.google.com), any solution we chose needed to be interoperable with Firebase.
+- **TypeScript support:** We needed to be sure that we would be able to use TypeScript to its fullest advantage in whichever library we chose.
+- **Testing options:** Front-end testing is always a pain point, and we need any solution we use to be at least as testable as React.
+- **Accessibility features:** One of our priorities is accessibility, which is an afterthought in many cases in frontend development. Out-of-the-box accessibility features would be a big bonus.
+- **Security features:** Security is another priority, and one that can be difficult to get right. Sensible default settings around security are important.
+- **Available documentation and resources:** Documentation determines whether an implementation will go smoothly or be very painful. We were looking for well-documented solutions with enough adoption to have resources available on blogs, StackOverflow, and more.
+- **CSS module support:** In the legacy front end, we used CSS modules, and they worked great. If possible, we'd like to use them again. If they are not supported, we would need to investigate the best styling alternatives for whatever library we chose.
+- **Storybook support:** Storybook is an exceptional development tool. Support for Storybook is all but a hard-and-fast requirement.
+- **Additional or missing features:** We also wanted to consider any outstanding features a library offered that differentiated it from its competitors, even if it didn't fit neatly into the criteria we were prioritising. Likewise, we needed to consider any features we're using that were missing from a given solution.
+
+These are a lot of factors to cover in a single ADR, however, there is a [Google doc](https://docs.google.com/document/d/1w0BbmBMs_55QBtHEndTHq7tPYHQObrq3R2_qwbnKbgw/edit?usp=sharing) summarising the comparisons between the libraries we considered.
+
+## Summary
+
+Preact was clearly inadequate for our use case since it was simply meant for projects of more limited scope. Vue and Svelte had some compelling points and met most of our criteria, however, they are dissimilar to React to such an extent that we would need to invest significant time in learning. Their advantages over React were insufficient to justify putting in that effort.

--- a/docs/adrs/0002-use-react.md
+++ b/docs/adrs/0002-use-react.md
@@ -33,9 +33,9 @@ Since we were contemplating a rewrite anyway, it made sense to revisit the quest
 
 We considered React as well as three other, competing libraries:
 
-- Preact
-- Vue.js
-- Svelte
+- [Preact](https://preactjs.com)
+- [Vue.js](https://vuejs.org)
+- [Svelte](https://svelte.dev)
 
 In considering these libraries, we considered the following factors:
 

--- a/docs/adrs/0003-use-vite.md
+++ b/docs/adrs/0003-use-vite.md
@@ -1,0 +1,38 @@
+# 0003. Use Vite
+
+## Date
+
+2023-02-20
+
+## Approved By
+
+@danascheider
+
+## Decision
+
+We will use [Vite](https://vitejs.dev) as our build tool to replace Create React App.
+
+## Glossary
+
+- **Create React App (CRA):** A lightweight, React-based [framework](https://create-react-app.dev/) enabling React apps to be created quickly and easily
+- **React:** A fully-featured [front-end JavaScript library](https://reactjs.org) enabling the use of an HTML-like syntax to create page components in isolation
+- **Vite:** A lightweight framework and [build tool](https://vitejs.dev) that can replace both CRA and WebPack (a build tool on which CRA relies)
+
+## Context
+
+Several challenges have recently converged, pushing us to implement a full rewrite of the SIM front end. One of these was the realisation that Create React App, the lightweight framework we were using with React for the existing front end, may no longer be maintained or releasing new versions. Combined with challenges reimplementing our auth system [see context here](/docs/adrs/0001-use-firebase.md) and desire to migrate to [TypeScript](https://typescriptlang.org), a rewrite made sense. However, we still needed to choose a new framework.
+
+[Vite](https://vitejs.dev) was the best option we were able to find.
+
+## Considerations
+
+We considered the following React-based frameworks in addition to Vite:
+
+- [Next.js](https://nextjs.org)
+- [Gatsby](https://gatsbyjs.com)
+
+While each of these had certain convenient features, it was clear that they were overengineered relative to what we needed. We were looking for something that would allow us to manage most of the code in our app, providing only basic boilerplate and build utilities. These frameworks provided that but also extensive features we don't forsee needing, such as those pertaining to scalability (Next.js) when we don't except SIM to substantially scale, and those pertaining to cloud deployments (Gatsby), which are already easy with Firebase.
+
+## Summary
+
+Because of its fast and lightweight nature and ease of deployment to Firebase, we opted for Vite over Gatsby or Next.js.

--- a/docs/adrs/0004-use-typescript.md
+++ b/docs/adrs/0004-use-typescript.md
@@ -1,0 +1,36 @@
+# 0004. Use TypeScript
+
+## Date
+
+2023-02-20
+
+## Approved By
+
+@danascheider
+
+## Decision
+
+We will use [TypeScript](https://typescriptlang.org) instead of ES6 JavaScript to build the next generation front end.
+
+## Glossary
+
+- **Static Typing:** A feature of (primarily) object-oriented languages where objects are assigned a type - the most basic examples being `string` or `number` - and functions expect arguments and return values of a defined type; this prevents numerous unexpected runtime errors
+- **TypeScript:** A language, actually a superset of JavaScript syntax and functionality, that imposes static typing in development and compiles to JavaScript that can be run in the browser; TypeScript includes type checking in development environments as well as an optional compiler (other tools may also be used for compilation) to translate to JavaScript
+
+## Context
+
+We've had an open epic to migrate to TypeScript for a long time. While there is an established way to port a JavaScript code base to TypeScript, the process can be onerous and take time to see benefits. Now that we're doing a full rewrite, it makes more sense to introduce TypeScript from the beginning. The primary disadvantages to TypeScript are (1) the possibility for poorly organised projects to make finding type definitions difficult and (2) difficulty of integrating with third-party tools that don't provide types.
+
+As TypeScript is becoming a standard in front-end development, more and more packages are providing TypeScript support. Most major projects, including React, Vite, Testing Library, and Storybook already provide out-of-the-box support for TypeScript.
+
+Effectively, the decision to eventually use TypeScript for these reasons was made a long time ago.
+
+## Considerations
+
+Although, as mentioned above, the decision to use TypeScript had already been made in the past, we did consider whether now would be the right time to add it given we were already considering whether to use [Firebase](/docs/adrs/0001-use-firebase.md), another [React framework](/docs/adrs/0003-use-vite.md), and even a [library other than React](/docs/adrs/0002-use-react.md). Each of these would potentially involve a learning curve. Likewise, as our lead maintainer was not at all proficient in TypeScript, it would take a concerted effort to not only learn the language but also piece it all together.
+
+Ultimately, we decided the upfront learning curve was worth it to reduce the amount of work we'd have to do later to port an existing JavaScript project to TypeScript. Doing it this way, we can start off with strict compiler options that enable TypeScript to be the most useful.
+
+## Summary
+
+Primarily because of the ease of adding TypeScript to a new project relative to porting over a project using plain JavaScript, it made sense to start off our frontend rewrite using TypeScript with all the configuration options we would ultimately want.


### PR DESCRIPTION
## Context

[**Write ADRs on choice of React, Vite, and Firebase**](https://trello.com/c/koX5e1zX/243-write-adrs-on-choice-of-react-vite-and-firebase)

We've made a number of choices about our tech stack for the rewrite that differ from the stack of the original front end. We should document these decisions and why we made them using architectural decision records (ADRs). While the card only calls for ADRs for Firebase, React, and Vite, I've also added an ADR for TypeScript as well.

## Changes

* ADR for decision to use Firebase
* ADR for decision to use React
* ADR for decision to use Vite
* ADR for decision to use TypeScript

## Manual Test Cases

This PR contains no code changes.