### PR TITLE
Attempt to fix Firebase stock 404 page appearing

### DIFF
--- a/src/routing/pageRoutes.tsx
+++ b/src/routing/pageRoutes.tsx
@@ -56,6 +56,11 @@ const RouteContent = ({ title, description, jsx }: BasePage) => (
 
 const PageRoutes = () => (
   <Routes>
+    <Route
+      path="*"
+      key="notFound"
+      element={<RouteContent {...notFoundPage} />}
+    />
     {pages.map(({ pageId, title, description, jsx, path }: Page) => {
       return (
         <Route
@@ -67,11 +72,6 @@ const PageRoutes = () => (
         />
       )
     })}
-    <Route
-      path="*"
-      key="notFound"
-      element={<RouteContent {...notFoundPage} />}
-    />
   </Routes>
 )
 


### PR DESCRIPTION
## Context

[**Build deployable app scaffold using new stack**](https://trello.com/c/yFori2Hb/228-build-deployable-app-scaffold-using-new-stack)

After deploying #15, which worked well in development, we found that Firebase still displayed a stock 404 page when we visited a nonexistent route. It's unclear why this is and this may be the first of multiple attempts to solve the problem.

## Changes

* Move catchall route to be the first route

## Considerations

This approach would not work with previous versions of `react-router`, however, in the current version, putting the catchall route first will not prevent the other routes from working. However, it's unclear whether this will solve the problem in Firebase.

## Manual Test Cases

This can't be tested until deployed. After deployment, visit an undefined route and ensure that our 404 page is displayed and not a stock Firebase one.
