### PR TITLE
Configure Firebase to use React 404 pages instead of its own

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,5 +2,11 @@
   "hosting": {
     "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
-  }
+  },
+  "rewrites": [
+    {
+      "source": "**",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
## Context

[**Build deployable app scaffold using new stack**](https://trello.com/c/yFori2Hb/228-build-deployable-app-scaffold-using-new-stack)

The fix in #16 failed to force Firebase to use custom 404 pages instead of its own stock ones. This PR attempts to achieve this using Firebase configuration.

## Changes

* Configure Firebase to send traffic to unknown routes to `/index.html` instead of its own destination

## Considerations

This may or may not work. There's minimal information available on how to do this.

## Manual Test Cases

After deploy, visit https://sim.danascheider.com/someroute and see that the SIM-branded 404 page appears, not the stock Firebase page.