### PR TITLE
Move 'rewrites' key properly under 'hosting' in firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,12 +1,12 @@
 {
   "hosting": {
     "public": "dist",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
-  },
-  "rewrites": [
-    {
-      "source": "**",
-      "destination": "/index.html"
-    }
-  ]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Context

In #17 we added a "rewrites" key to the `firebase.json` file, however, we neglected to nest this key under the "hosting" key as intended.

## Changes

* Nest "rewrites" under "hosting" in `firebase.json`

## Considerations

This may or may not end up being the fix we need.

## Manual Test Cases

See #17