### PR TITLE
Fix bug where hover color for nav cards was blue

### DIFF
--- a/src/components/navigationCard/navigationCard.module.css
+++ b/src/components/navigationCard/navigationCard.module.css
@@ -16,6 +16,7 @@
 .root:hover {
   text-decoration: underline;
   background-color: var(--hover-color);
+  color: var(--text-color);
 }
 
 @media (min-width: 481px) {


### PR DESCRIPTION
## Context

After deploying #19, I realised that the text colour on the nav cards, while correct when not being hovered over, turned blue on hover.

## Changes

* Ensure text colour on nav cards doesn't change on hover

## Considerations

Because an underline is already added on hover, we don't really need an additional visual cue that the text is a link being hovered over.

## Manual Test Cases

Running the site locally, visit `http://localhost:5173/dashboard`. Hover over each of the navigation cards and see that the text colour does not change.