### PR TITLE
Make sure dashboard header text stays white on hover

### DIFF
--- a/src/components/dashboardHeader/dashboardHeader.module.css
+++ b/src/components/dashboardHeader/dashboardHeader.module.css
@@ -33,6 +33,7 @@
 }
 
 .headerLinkLarge:hover {
+  color: #fff;
   text-decoration: underline;
 }
 
@@ -42,6 +43,7 @@
 }
 
 .headerLinkSmall:hover {
+  color: #fff;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Context

Same bug as #20 but with the text in the dashboard header

## Changes

* Ensure dashboard header text stays white on hover

## Manual Test Cases

Running the site locally, visit `http://localhost:5173/dashboard`. Hover the mouse over the text in the dashboard header ("Skyrim Inventory Management" or "S. I. M.", depending on viewport width). See that the text adds an underline and stays white.