### PR TITLE
Set up Firebase deploys again to attempt troubleshooting

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn && yarn build
+      - run: yarn build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,11 @@
 {
   "hosting": {
     "public": "dist",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "rewrites": [
       {
         "source": "**",


### PR DESCRIPTION
## Context

Firebase deploys are broken. When we deploy to Firebase, the page won't load because of errors. We think the issue is `VITE_` prefixed environment variables, but it's hard to really tell. In an attempt to fix deploys, we removed the `FIREBASE_SERVICE_ACCOUNT_SKYRIM_INVENTORY_MANAGEMENT` secret from GitHub and attempted to set up Firebase deploys again using `firebase init hosting:github`. We're not sure this will work but it's our first attempt.

## Changes

* Re-initialise deploys to Firebase hosting
