### PR TITLE
Implement error handling for games page

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,9 +1,12 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Quattrocento+Sans&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=Quattrocento+Sans:wght@400;700&display=swap"
   rel="stylesheet"
 />
+
 <style>
   .sb-main-padded {
     padding: 0 !important;

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,5 +1,3 @@
-<link rel="preconnect" href="https://fonts.gstatic.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link

--- a/docs/contexts/README.md
+++ b/docs/contexts/README.md
@@ -1,9 +1,17 @@
 # Contexts in SIM
 
-SIM uses [React contexts](https://reactjs.org/docs/context.html) for state management. This prevents "smart" components that fetch data or control state from having to pass through props to their children, their children's children, and so on. There is currently one context:
+SIM uses [React contexts](https://reactjs.org/docs/context.html) for state management. This prevents "smart" components that fetch data or control state from having to pass through props to their children, their children's children, and so on. There are currently four contexts:
 
 - [`ColorContext`](/docs/contexts/color-context.md)
+- [`GamesContext`](/docs/contexts/games-context.md)
+- [`LoginContext`](/docs/contexts/login-context.md)
+- [`PageContext`](/docs/contexts/page-context.md)
 
-For each context, there is a [custom hook](/src/hooks/contexts.js) that can be used to invoke it in consumers. The custom hooks are:
+For each context, there is a [custom hook](/src/hooks/contexts.js) that can be used to invoke it in consumers. The custom hooks, in order of the contexts above, are:
 
-- `useColorScheme`
+- `useColorScheme()`
+- `useGamesContext()`
+- `useGoogleLogin()`
+- `usePageContext()`
+
+You can learn more about these hooks by reading the docs linked above.

--- a/docs/contexts/color-context.md
+++ b/docs/contexts/color-context.md
@@ -3,7 +3,12 @@
 The `ColorContext` keeps track of colour schemes. Set the colour scheme in the provider and then access it in the child/consumer component:
 
 ```tsx
-// /src/components/parent/parent.tsx
+/*
+ *
+ * /src/components/parent/parent.tsx
+ *
+ */
+
 import { ColorProvider } from '../../contexts/colorContext'
 import { GREEN } from '../../utils/colorSchemes'
 import Child from '../child/child'
@@ -16,7 +21,12 @@ const Parent = () => (
 
 export default Parent
 
-// /src/components/child/child.tsx
+/*
+ *
+ * /src/components/child/child.tsx
+ *
+ */
+
 import { useColorScheme } from '../../hooks/contexts'
 import styles from './child.module.css'
 
@@ -44,6 +54,7 @@ The variables you set in `styleVars` can then be used in the child's CSS:
 
 ```css
 /* /src/components/child/child.module.css */
+
 .root {
   color: var(--text-color);
   background-color: var(--background-color);

--- a/docs/contexts/games-context.md
+++ b/docs/contexts/games-context.md
@@ -10,7 +10,11 @@ Accessing games requires a user to be authenticated, so the `GamesProvider` can 
 ## Example
 
 ```tsx
-// /src/components/parent/parent.tsx
+/*
+ *
+ * /src/components/parent/parent.tsx
+ *
+ */
 
 import { LoginProvider } from './contexts/loginContext'
 import { GamesProvider } from './contexts/gamesContext'
@@ -26,7 +30,11 @@ const Parent = () => (
 
 export default Parent
 
-// /src/components/child/child.tsx
+/*
+ *
+ * /src/components/child/child.tsx
+ *
+ */
 
 import { type Game } from '../../types/games.d.ts'
 import { useGamesContext } from '../../hooks/contexts'

--- a/docs/contexts/games-context.md
+++ b/docs/contexts/games-context.md
@@ -1,0 +1,56 @@
+# Games Context
+
+The `GamesContext` enables us to keep track of all of a user's games as well as creating, editing, and destroying them. The `GamesProvider` makes the following values available to consumers:
+
+- `games`: array of [`Game`](/src/types/games.d.ts) objects, the games returned from the API for the signed-in user, initialized as an empty array (i.e., this object will never be `null` or `undefined`)
+- `gamesLoadingStatus`: string of either `'LOADING'`, `'ERROR'`, or `'DONE'`, indicating whether games have loaded successfully from the API, initialized as `'LOADING'`
+
+Accessing games requires a user to be authenticated, so the `GamesProvider` can only be rendered inside a [`LoginProvider`](/docs/contexts/login-context.md). Note that the `GamesProvider` itself calls the `requireLogin` function provided by the login context, so this function should not be called in any `GamesContext` consumers.
+
+## Example
+
+```tsx
+// /src/components/parent/parent.tsx
+
+import { LoginProvider } from './contexts/loginContext'
+import { GamesProvider } from './contexts/gamesContext'
+import Child from '../child/child'
+
+const Parent = () => (
+  <LoginProvider>
+    <GamesProvider>
+      <Child />
+    </GamesProvider>
+  </LoginProvider>
+)
+
+export default Parent
+
+// /src/components/child/child.tsx
+
+import { type Game } from '../../types/games.d.ts'
+import { useGamesContext } from '../../hooks/contexts'
+import { PulseLoader } from 'react-spinners'
+import styles from './child.module.css'
+
+const Child = () => {
+  const { games, gamesLoadingState } = useGamesContext()
+
+  return (
+    {gamesLoadingState === 'LOADING' ? <PulseLoader /> : (
+      <div className={styles.root}>
+        {games.map(({ id, description, name }: Game) => (
+          <div className={styles.game} key={id}>
+            <h3 className={styles.title}>{name}</h3>
+            <p className={styles.description}>{description || 'This game has no description.'}</p>
+          </div>
+        ))}
+      </div>
+    )}
+  )
+}
+
+export default Child
+```
+
+In this example, the child component takes the games retrieved from the context, displaying a loading component if the games are loading and information about each game if the games have loaded. (Note that this minimal example does not handle the case where the `gamesLoadingState` is `'ERROR'`.)

--- a/docs/contexts/login-context.md
+++ b/docs/contexts/login-context.md
@@ -1,0 +1,63 @@
+# Login Context
+
+The `LoginContext` keeps track of the logged in user, manages their tokens, signs out in the event of authentication errors, and provides a `requireLogin` function that can be used in the `useEffect` hook of any component using the context to sign out and redirect to the homepage if login is unsuccessful or no user is logged in.
+
+The `LoginProvider`'s value makes the following values available:
+
+- `user`: User (type defined in Firebase)
+- `token`: string
+- `authLoading`: boolean
+- `requireLogin`: function
+
+## Example
+
+```tsx
+// /src/components/parent/parent.tsx
+
+import { LoginProvider } from '../../contexts/loginContext'
+import Child from '../child/child'
+
+const Parent = () => (
+  <LoginProvider>
+    <Child />
+  </LoginProvider>
+)
+
+export default Parent
+
+// /src/components/child/child.tsx
+import { useEffect } from 'react'
+import { useGoogleLogin } from '../../hooks/contexts'
+import { PulseLoader } from 'react-spinners'
+import styles from './child/module.css'
+
+const Child = () => {
+  const { user, authLoading, requireLogin } = useGoogleLogin()
+
+  useEffect(() => {
+    requireLogin()
+  }, [requireLogin])
+
+  if (authLoading) {
+    return <PulseLoader />
+  } else {
+    return (
+      <div className={styles.root}>
+        <img src={user.photoURL} />
+        <span className={styles.info}>
+          <h3 className={styles.name}>{user.displayName}</h3>
+          <p className={styles.email}>{user.email}</h3>
+        </span>
+      </div>
+    )
+  }
+}
+
+export default Child
+```
+
+In this example, the login context identifies the signed-in user, if any, and provides that value and the `requireLogin` function to the child component. The component displays a loading component if the auth state hasn't fully loaded and, when it has, displays the user's information and profile photo. If there turns out not to be a user signed in, the page redirects to the homepage using the `requireLogin` function in the `useEffect` hook.
+
+## Types
+
+The `LoginProvider` takes no props other than `children`, which can be react elements or string types.

--- a/docs/contexts/login-context.md
+++ b/docs/contexts/login-context.md
@@ -12,7 +12,11 @@ The `LoginProvider`'s value makes the following values available:
 ## Example
 
 ```tsx
-// /src/components/parent/parent.tsx
+/*
+ *
+ * /src/components/parent/parent.tsx
+ *
+ */
 
 import { LoginProvider } from '../../contexts/loginContext'
 import Child from '../child/child'
@@ -25,7 +29,12 @@ const Parent = () => (
 
 export default Parent
 
-// /src/components/child/child.tsx
+/*
+ *
+ * /src/components/child/child.tsx
+ *
+ */
+
 import { useEffect } from 'react'
 import { useGoogleLogin } from '../../hooks/contexts'
 import { PulseLoader } from 'react-spinners'
@@ -60,4 +69,4 @@ In this example, the login context identifies the signed-in user, if any, and pr
 
 ## Types
 
-The `LoginProvider` takes no props other than `children`, which can be react elements or string types.
+The `LoginProvider` takes no props other than `children`, which can be React (TSX) elements or string types.

--- a/docs/contexts/page-context.md
+++ b/docs/contexts/page-context.md
@@ -32,7 +32,11 @@ The `PageProvider` ensures that the flash message is hidden after a period of ti
 ## Example
 
 ```tsx
-// /src/components/parent/parent.tsx
+/*
+ *
+ * /src/components/parent/parent.tsx
+ *
+ */
 
 import { PageProvider } from '../../contexts/pageContext'
 import { LoginProvider } from '../../contexts/loginContext'
@@ -48,7 +52,11 @@ const Parent = () => (
 
 export default Parent
 
-// /src/components/child/child.tsx
+/*
+ *
+ * /src/components/child/child.tsx
+ *
+ */
 
 import { useState, useEffect } from 'react'
 import { signOutWithGoogle } from '../../firebase'

--- a/docs/contexts/page-context.md
+++ b/docs/contexts/page-context.md
@@ -1,0 +1,97 @@
+# Page Context
+
+The `PageContext` controls the display of global (dashboard) elements like flash messages and modals. It makes sense to control the appearance and disappearance of these components centrally in a context since they can be used by multiple elements on the page concurrently, allowing for problems if each individual element controls its own flash message or modal. Eventually, this context may be used to control other aspects of the global UI.
+
+## The `FlashMessage` Component
+
+Currently, the only such global element is the `FlashMessage` component. This component displays information relevant to the user, such as error messages or success messages. It has four `types`, passed in as props, which affect the colour presented to the user:
+
+- `success` (green)
+- `info` (blue)
+- `warning` (yellow)
+- `error` (red)
+
+The other props of the component are:
+
+- `message`: a string or array of strings to be displayed to the user
+- `heading` (optional): a string that will be displayed in bold type above the message
+- `hidden`: a boolean indicating whether the flash message should be hidden
+
+If the message passed is an array, each string in the array will be displayed as a bullet point on a list.
+
+**The `FlashMessage` component should only be present in the `DashboardLayout` component and should exclusively be controlled through the values provided by the `PageContext`.**
+
+## The `PageContext`
+
+The `PageProvider` exposes two values to the user: `flashProps` (an object of type `FlashMessageProps`) and `setFlashProps` (a function taking such an object as an argument), both of which are implemented as state variables within the context provider. Because of required values in the `FlashMessageProps` type, there is a default value of `flashProps` that includes an empty string as the message, a type of `'info'`, and, most importantly, `hidden: true`.
+
+When an individual component needs to display a flash message, it can access these values using the `usePageContext()` hook. To display the message, it should call `setFlashProps` with the desired type, message, and (optionally) header. The `hidden` value should also be set to `false`.
+
+The `PageProvider` ensures that the flash message is hidden after a period of time, so there is no need for a user to manually dismiss it or for a component using it to ensure it disappears.
+
+## Example
+
+```tsx
+// /src/components/parent/parent.tsx
+
+import { PageProvider } from '../../contexts/pageContext'
+import { LoginProvider } from '../../contexts/loginContext'
+import Child from '../child/child'
+
+const Parent = () => (
+  <LoginProvider>
+    <PageProvider>
+      <Child />
+    </PageProvider>
+  </LoginProvider>
+)
+
+export default Parent
+
+// /src/components/child/child.tsx
+
+import { useState, useEffect } from 'react'
+import { signOutWithGoogle } from '../../firebase'
+import { type Game } from '../../types/games'
+import { type ApiError } from '../../types/errors'
+import { useGoogleLogin, usePageContext } from '../../hooks/contexts'
+import { getGames } from '../../utils/simApi'
+import DashboardLayout from '../../layouts/dashboardLayout/dashboardLayout'
+import styles from './child.module.css'
+
+const Child = () => {
+  const { user, token, authLoading } = useGoogleLogin()
+  const { setFlashProps } = usePageContext()
+  const [games, setGames] = useState<Game[]>([])
+
+  useEffect(() => {
+    if (authLoading) return
+
+    if (user && token) {
+      getGames(token)
+        .then(({ json }) => {
+          setGames(json)
+        })
+        .catch((e: ApiError) => {
+          if (e.status === 401) signOutWithGoogle()
+
+          setFlashProps({
+            type: 'error',
+            message: e.message,
+            hidden: false,
+          })
+        })
+    }
+  }, [user, token, authLoading])
+
+  return (
+    <DashboardLayout title="Games">
+      /* TSX to display retrieved games */
+    </DashboardLayout>
+  )
+}
+
+export default Child
+```
+
+Notice the use of the `DashboardLayout` in the `Child` component. It is essential that any component that makes use of flash messages be nested, at any level of nesting, inside a layout component that includes a `FlashMessage`. Currently, `DashboardLayout` is the only such component.

--- a/src/components/flashMessage/__snapshots__/flashMessage.test.tsx.snap
+++ b/src/components/flashMessage/__snapshots__/flashMessage.test.tsx.snap
@@ -1,0 +1,393 @@
+// Vitest Snapshot v1
+
+exports[`FlashMessage > when there is a string message > matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="_root_91d025"
+        style="--text-color: #4e6d83;"
+      >
+        Hello world.
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="_root_91d025"
+      style="--text-color: #4e6d83;"
+    >
+      Hello world.
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`FlashMessage > when there is a string message > when there is a header > matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="_root_91d025"
+        style="--text-color: #4e6d83;"
+      >
+        <p
+          class="_header_91d025"
+        >
+          Greetings!
+        </p>
+        Hello world.
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="_root_91d025"
+      style="--text-color: #4e6d83;"
+    >
+      <p
+        class="_header_91d025"
+      >
+        Greetings!
+      </p>
+      Hello world.
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`FlashMessage > when there is an array message > matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="_root_91d025"
+        style="--text-color: #4e6d83;"
+      >
+        <ul
+          class="_list_91d025"
+        >
+          <li
+            class="_msg_91d025"
+          >
+            You will be assimilated.
+          </li>
+          <li
+            class="_msg_91d025"
+          >
+            Your biological and technological distinctiveness will be added to our own.
+          </li>
+          <li
+            class="_msg_91d025"
+          >
+            Resistance is futile.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="_root_91d025"
+      style="--text-color: #4e6d83;"
+    >
+      <ul
+        class="_list_91d025"
+      >
+        <li
+          class="_msg_91d025"
+        >
+          You will be assimilated.
+        </li>
+        <li
+          class="_msg_91d025"
+        >
+          Your biological and technological distinctiveness will be added to our own.
+        </li>
+        <li
+          class="_msg_91d025"
+        >
+          Resistance is futile.
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`FlashMessage > when there is an array message > when there is a header > matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="_root_91d025"
+        style="--text-color: #4e6d83;"
+      >
+        <p
+          class="_header_91d025"
+        >
+          We are the Borg.
+        </p>
+        <ul
+          class="_list_91d025"
+        >
+          <li
+            class="_msg_91d025"
+          >
+            You will be assimilated.
+          </li>
+          <li
+            class="_msg_91d025"
+          >
+            Your biological and technological distinctiveness will be added to our own.
+          </li>
+          <li
+            class="_msg_91d025"
+          >
+            Resistance is futile.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="_root_91d025"
+      style="--text-color: #4e6d83;"
+    >
+      <p
+        class="_header_91d025"
+      >
+        We are the Borg.
+      </p>
+      <ul
+        class="_list_91d025"
+      >
+        <li
+          class="_msg_91d025"
+        >
+          You will be assimilated.
+        </li>
+        <li
+          class="_msg_91d025"
+        >
+          Your biological and technological distinctiveness will be added to our own.
+        </li>
+        <li
+          class="_msg_91d025"
+        >
+          Resistance is futile.
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/flashMessage/flashMessage.module.css
+++ b/src/components/flashMessage/flashMessage.module.css
@@ -1,0 +1,63 @@
+.root {
+  font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  font-size: 1.1rem;
+  color: var(--text-color);
+  line-height: 1.25;
+  background-color: rgba(255, 255, 2550.92);
+  border: 1px solid #dedede;
+  padding: 16px;
+  text-align: center;
+  border-radius: 8px;
+  box-shadow: 1px 1px 8px #dedede;
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 128px;
+  z-index: 1001;
+  width: 82%;
+}
+
+.hidden {
+  visibility: hidden;
+  transition: visibility 300ms linear;
+}
+
+.header {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-weight: 700;
+}
+
+.list {
+  padding-left: 0;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.msg {
+  list-style-position: inside;
+}
+
+@media (min-width: 601px) {
+  .root {
+    max-width: 50%;
+  }
+}
+
+@media (min-width: 769px) {
+  .root {
+    max-width: 40%;
+  }
+}
+
+@media (min-width: 1025px) {
+  .root {
+    max-width: 30%;
+  }
+}
+
+@media (min-width: 1405px) {
+  .root {
+    max-width: 25%;
+  }
+}

--- a/src/components/flashMessage/flashMessage.module.css
+++ b/src/components/flashMessage/flashMessage.module.css
@@ -3,7 +3,7 @@
   font-size: 1.1rem;
   color: var(--text-color);
   line-height: 1.25;
-  background-color: rgba(255, 255, 2550.92);
+  background-color: rgba(255, 255, 255, 0.85);
   border: 1px solid #dedede;
   padding: 16px;
   text-align: center;
@@ -19,7 +19,8 @@
 
 .hidden {
   visibility: hidden;
-  transition: visibility 300ms linear;
+  opacity: 0;
+  transition: opacity 500ms linear, visibility 500ms linear;
 }
 
 .header {

--- a/src/components/flashMessage/flashMessage.stories.tsx
+++ b/src/components/flashMessage/flashMessage.stories.tsx
@@ -1,0 +1,115 @@
+import FlashMessage from './flashMessage'
+
+export default { title: 'FlashMessage' }
+
+const messageString = 'You will be assimilated.'
+
+const messageArray = [
+  'You will be assimilated.',
+  'Your biological and technological distinctiveness will be added to our own.',
+  'Resistance is futile.',
+]
+
+export const SuccessWithStringMessage = () => (
+  <FlashMessage type="success" message={messageString} hidden={false} />
+)
+
+export const SuccessWithStringMessageAndHeader = () => (
+  <FlashMessage
+    type="success"
+    message={messageString}
+    hidden={false}
+    header="Success!"
+  />
+)
+
+export const SuccessWithArrayMessage = () => (
+  <FlashMessage type="success" message={messageArray} hidden={false} />
+)
+
+export const SuccessWithArrayMessageAndHeader = () => (
+  <FlashMessage
+    type="success"
+    message={messageArray}
+    hidden={false}
+    header="Success!"
+  />
+)
+
+export const InfoWithStringMessage = () => (
+  <FlashMessage type="info" message={messageString} hidden={false} />
+)
+
+export const InfoWithStringMessageAndHeader = () => (
+  <FlashMessage
+    type="info"
+    message={messageString}
+    hidden={false}
+    header="For Your Information:"
+  />
+)
+
+export const InfoWithArrayMessage = () => (
+  <FlashMessage type="info" message={messageArray} hidden={false} />
+)
+
+export const InfoWithArrayMessageAndHeader = () => (
+  <FlashMessage
+    type="info"
+    message={messageArray}
+    hidden={false}
+    header="For Your Information:"
+  />
+)
+
+export const WarningWithStringMessage = () => (
+  <FlashMessage type="warning" message={messageString} hidden={false} />
+)
+
+export const WarningWithStringMessageAndHeader = () => (
+  <FlashMessage
+    type="warning"
+    message={messageString}
+    hidden={false}
+    header="Warning:"
+  />
+)
+
+export const WarningWithArrayMessage = () => (
+  <FlashMessage type="warning" message={messageArray} hidden={false} />
+)
+
+export const WarningWithArrayMessageAndHeader = () => (
+  <FlashMessage
+    type="warning"
+    message={messageArray}
+    hidden={false}
+    header="Warning:"
+  />
+)
+
+export const ErrorWithStringMessage = () => (
+  <FlashMessage type="error" message={messageString} hidden={false} />
+)
+
+export const ErrorWithStringMessageAndHeader = () => (
+  <FlashMessage
+    type="error"
+    message={messageString}
+    hidden={false}
+    header="We are the Borg."
+  />
+)
+
+export const ErrorWithArrayMessage = () => (
+  <FlashMessage type="error" message={messageArray} hidden={false} />
+)
+
+export const ErrorWithArrayMessageAndHeader = () => (
+  <FlashMessage
+    type="error"
+    message={messageArray}
+    hidden={false}
+    header="We are the Borg."
+  />
+)

--- a/src/components/flashMessage/flashMessage.test.tsx
+++ b/src/components/flashMessage/flashMessage.test.tsx
@@ -1,0 +1,115 @@
+import { describe, test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import FlashMessage from './flashMessage'
+
+describe('FlashMessage', () => {
+  describe('when there is a string message', () => {
+    test('there is no list', () => {
+      const wrapper = render(
+        <FlashMessage type="info" hidden={false} message="Hello world." />
+      )
+      expect(wrapper).toBeTruthy()
+
+      expect(screen.getByText('Hello world.')).toBeTruthy()
+    })
+
+    test('matches snapshot', () => {
+      const wrapper = render(
+        <FlashMessage type="info" hidden={false} message="Hello world." />
+      )
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    describe('when there is a header', () => {
+      test('the header and message are displayed', () => {
+        render(
+          <FlashMessage
+            type="info"
+            hidden={false}
+            header="Greetings!"
+            message="Hello world."
+          />
+        )
+
+        expect(screen.getByText('Greetings!')).toBeTruthy()
+        expect(screen.getByText('Hello world.')).toBeTruthy()
+      })
+
+      test('matches snapshot', () => {
+        const wrapper = render(
+          <FlashMessage
+            type="info"
+            hidden={false}
+            header="Greetings!"
+            message="Hello world."
+          />
+        )
+        expect(wrapper).toMatchSnapshot()
+      })
+    })
+  })
+
+  describe('when there is an array message', () => {
+    const msg = [
+      'You will be assimilated.',
+      'Your biological and technological distinctiveness will be added to our own.',
+      'Resistance is futile.',
+    ]
+
+    test('displays all messages', () => {
+      const wrapper = render(
+        <FlashMessage type="info" hidden={false} message={msg} />
+      )
+      expect(wrapper).toBeTruthy()
+
+      expect(screen.getByText('You will be assimilated.')).toBeTruthy()
+      expect(
+        screen.getByText(
+          'Your biological and technological distinctiveness will be added to our own.'
+        )
+      ).toBeTruthy()
+      expect(screen.getByText('Resistance is futile.')).toBeTruthy()
+    })
+
+    test('matches snapshot', () => {
+      const wrapper = render(
+        <FlashMessage type="info" hidden={false} message={msg} />
+      )
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    describe('when there is a header', () => {
+      test('displays the header text', () => {
+        render(
+          <FlashMessage
+            type="info"
+            hidden={false}
+            header="We are the Borg."
+            message={msg}
+          />
+        )
+
+        expect(screen.getByText('We are the Borg.')).toBeTruthy()
+        expect(screen.getByText('You will be assimilated.')).toBeTruthy()
+        expect(
+          screen.getByText(
+            'Your biological and technological distinctiveness will be added to our own.'
+          )
+        ).toBeTruthy()
+        expect(screen.getByText('Resistance is futile.')).toBeTruthy()
+      })
+
+      test('matches snapshot', () => {
+        const wrapper = render(
+          <FlashMessage
+            type="info"
+            hidden={false}
+            header="We are the Borg."
+            message={msg}
+          />
+        )
+        expect(wrapper).toMatchSnapshot()
+      })
+    })
+  })
+})

--- a/src/components/flashMessage/flashMessage.tsx
+++ b/src/components/flashMessage/flashMessage.tsx
@@ -1,0 +1,37 @@
+import { CSSProperties } from 'react'
+import classNames from 'classnames'
+import { type FlashColors, type FlashProps } from '../../types/flashMessages'
+import styles from './flashMessage.module.css'
+
+const colors: FlashColors = {
+  success: '#329932',
+  info: '#4e6d83',
+  error: '#cc0000',
+  warning: '#b0a723',
+}
+
+const FlashMessage = ({ type, header, message, hidden }: FlashProps) => {
+  const colorVars = { '--text-color': colors[type] } as CSSProperties
+
+  return (
+    <div
+      className={classNames(styles.root, { [styles.hidden]: hidden })}
+      style={colorVars}
+    >
+      {header && <p className={styles.header}>{header}</p>}
+      {typeof message === 'string' ? (
+        message
+      ) : (
+        <ul className={styles.list}>
+          {message.map((msg, index) => (
+            <li key={`message-${index}`} className={styles.msg}>
+              {msg}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default FlashMessage

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -2,10 +2,10 @@ import { createContext, useCallback, useEffect, useState } from 'react'
 import { signOutWithGoogle } from '../firebase'
 import { type Game } from '../types/games'
 import { type ProviderProps } from '../types/contexts'
+import { useGoogleLogin, usePageContext } from '../hooks/contexts'
 import { ApiError } from '../types/errors'
 import { LOADING, DONE, ERROR, type LoadingState } from '../utils/loadingStates'
 import { getGames } from '../utils/simApi'
-import { useGoogleLogin } from '../hooks/contexts'
 
 // TODO: Add default values for context provider as follows:
 //       const createGame = (game: Game) => {
@@ -31,6 +31,7 @@ const GamesProvider = ({ children }: ProviderProps) => {
   const { user, token, authLoading, requireLogin } = useGoogleLogin()
   const [gamesLoadingState, setGamesLoadingState] = useState(LOADING)
   const [games, setGames] = useState<Game[]>([])
+  const { setFlashProps } = usePageContext()
 
   const fetchGames = useCallback(() => {
     if (user && token) {
@@ -48,6 +49,11 @@ const GamesProvider = ({ children }: ProviderProps) => {
           } else {
             setGames([])
             setGamesLoadingState(ERROR)
+            setFlashProps({
+              type: 'error',
+              message: e.message,
+              hidden: false,
+            })
           }
         })
     }

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -24,7 +24,7 @@ const PageProvider = ({ children }: ProviderProps) => {
   const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
 
   useEffect(() => {
-    if (flashProps.hidden == false) {
+    if (flashProps.hidden === false) {
       setTimeout(() => setFlashProps({ ...flashProps, hidden: true }), 3000)
     }
   }, [flashProps])

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useState, useEffect } from 'react'
+import { ProviderProps } from '../types/contexts'
+import { type FlashProps } from '../types/flashMessages'
+
+interface PageContextType {
+  flashProps: FlashProps
+  setFlashProps: (props: FlashProps) => void
+}
+
+const defaultFlashProps: FlashProps = {
+  type: 'info',
+  message: '',
+  hidden: true,
+}
+
+const PageContext = createContext<PageContextType>({
+  flashProps: defaultFlashProps,
+  setFlashProps(this: PageContextType, props: FlashProps) {
+    this.flashProps = props
+  },
+})
+
+const PageProvider = ({ children }: ProviderProps) => {
+  const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
+
+  useEffect(() => {
+    if (flashProps.hidden == false) {
+      setTimeout(() => setFlashProps({ ...flashProps, hidden: true }), 3000)
+    }
+  }, [flashProps])
+
+  return (
+    <PageContext.Provider value={{ flashProps, setFlashProps }}>
+      {children}
+    </PageContext.Provider>
+  )
+}
+
+export { PageContext, PageProvider }

--- a/src/hooks/contexts.ts
+++ b/src/hooks/contexts.ts
@@ -2,6 +2,7 @@ import { useContext } from 'react'
 import { ColorContext } from '../contexts/colorContext'
 import { GamesContext } from '../contexts/gamesContext'
 import { LoginContext } from '../contexts/loginContext'
+import { PageContext } from '../contexts/pageContext'
 
 const useCustomContext = <T>(cxt: React.Context<T>, msg: string) => {
   const context = useContext(cxt)
@@ -27,4 +28,10 @@ export const useGamesContext = () =>
   useCustomContext(
     GamesContext,
     'useGamesContext must be used within a GamesProvider'
+  )
+
+export const usePageContext = () =>
+  useCustomContext(
+    PageContext,
+    'usePageContext must be used within a PageProvider'
   )

--- a/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
+++ b/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
@@ -126,6 +126,10 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
             </span>
           </div>
         </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
       </main>
     </div>
   </body>,
@@ -251,6 +255,10 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
           </span>
         </div>
       </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
     </main>
   </div>,
   "debug": [Function],
@@ -425,6 +433,10 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
             </span>
           </div>
         </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
       </main>
     </div>
   </body>,
@@ -542,6 +554,10 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
           </span>
         </div>
       </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
     </main>
   </div>,
   "debug": [Function],

--- a/src/layouts/dashboardLayout/dashboardLayout.tsx
+++ b/src/layouts/dashboardLayout/dashboardLayout.tsx
@@ -1,5 +1,7 @@
 import { type ReactElement } from 'react'
+import { usePageContext } from '../../hooks/contexts'
 import DashboardHeader from '../../components/dashboardHeader/dashboardHeader'
+import FlashMessage from '../../components/flashMessage/flashMessage'
 import styles from './dashboardLayout.module.css'
 
 interface DashboardLayoutProps {
@@ -7,19 +9,24 @@ interface DashboardLayoutProps {
   children: ReactElement | string
 }
 
-const DashboardLayout = ({ title, children }: DashboardLayoutProps) => (
-  <main className={styles.root}>
-    <section className={styles.container}>
-      {title ? (
-        <>
-          <h2 className={styles.title}>{title}</h2>
-          <hr className={styles.hr} />
-        </>
-      ) : null}
-      {children}
-    </section>
-    <DashboardHeader />
-  </main>
-)
+const DashboardLayout = ({ title, children }: DashboardLayoutProps) => {
+  const { flashProps } = usePageContext()
+
+  return (
+    <main className={styles.root}>
+      <section className={styles.container}>
+        {title ? (
+          <>
+            <h2 className={styles.title}>{title}</h2>
+            <hr className={styles.hr} />
+          </>
+        ) : null}
+        {children}
+      </section>
+      <DashboardHeader />
+      <FlashMessage {...flashProps} />
+    </main>
+  )
+}
 
 export default DashboardLayout

--- a/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
+++ b/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
@@ -180,6 +180,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
             </span>
           </div>
         </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
       </main>
     </div>
   </body>,
@@ -359,6 +363,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
           </span>
         </div>
       </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
     </main>
   </div>,
   "debug": [Function],
@@ -505,6 +513,10 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
             </div>
           </div>
         </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
       </main>
     </div>
   </body>,
@@ -594,6 +606,10 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
           </div>
         </div>
       </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
     </main>
   </div>,
   "debug": [Function],

--- a/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
+++ b/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               >
                 <a
                   class="_root_396ea1"
-                  href="blank"
+                  href="/games"
                   style="--background-color: #ffbf00; --hover-color: #e5ab00; --text-color: #4c3900;"
                 >
                   Your Games
@@ -205,7 +205,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
             >
               <a
                 class="_root_396ea1"
-                href="blank"
+                href="/games"
                 style="--background-color: #ffbf00; --hover-color: #e5ab00; --text-color: #4c3900;"
               >
                 Your Games

--- a/src/pages/dashboardPage/dashboardPage.stories.tsx
+++ b/src/pages/dashboardPage/dashboardPage.stories.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter } from 'react-router-dom'
 import { LoginContext } from '../../contexts/loginContext'
+import { PageProvider } from '../../contexts/pageContext'
 import { testUser, requireLogin } from '../../support/testUtils'
 import DashboardPage from './dashboardPage'
 
@@ -15,7 +16,9 @@ export const Default = () => (
         requireLogin,
       }}
     >
-      <DashboardPage />
+      <PageProvider>
+        <DashboardPage />
+      </PageProvider>
     </LoginContext.Provider>
   </BrowserRouter>
 )
@@ -25,7 +28,9 @@ export const AuthLoading = () => (
     <LoginContext.Provider
       value={{ user: null, token: null, authLoading: true, requireLogin }}
     >
-      <DashboardPage />
+      <PageProvider>
+        <DashboardPage />
+      </PageProvider>
     </LoginContext.Provider>
   </BrowserRouter>
 )

--- a/src/pages/dashboardPage/dashboardPage.test.tsx
+++ b/src/pages/dashboardPage/dashboardPage.test.tsx
@@ -1,11 +1,16 @@
 import { describe, test, expect } from 'vitest'
 import { screen } from '@testing-library/react'
 import { renderAuthenticated, renderAuthLoading } from '../../support/testUtils'
+import { PageProvider } from '../../contexts/pageContext'
 import DashboardPage from './dashboardPage'
 
 describe('<DashboardPage />', () => {
   test('DashboardPage displays the header', () => {
-    const wrapper = renderAuthenticated(<DashboardPage />)
+    const wrapper = renderAuthenticated(
+      <PageProvider>
+        <DashboardPage />
+      </PageProvider>
+    )
     expect(wrapper).toBeTruthy()
 
     const h1 = wrapper.container.querySelector('h1')
@@ -17,7 +22,11 @@ describe('<DashboardPage />', () => {
   })
 
   test('DashboardPage displays user info', () => {
-    const wrapper = renderAuthenticated(<DashboardPage />)
+    const wrapper = renderAuthenticated(
+      <PageProvider>
+        <DashboardPage />
+      </PageProvider>
+    )
 
     expect(screen.getByText('Edna St. Vincent Millay')).toBeTruthy()
     expect(screen.getByText('edna@gmail.com')).toBeTruthy()
@@ -28,7 +37,11 @@ describe('<DashboardPage />', () => {
   })
 
   test('DashboardPage displays the navigation mosaic', () => {
-    renderAuthenticated(<DashboardPage />)
+    renderAuthenticated(
+      <PageProvider>
+        <DashboardPage />
+      </PageProvider>
+    )
 
     expect(screen.getByText('Your Games')).toBeTruthy()
     expect(screen.getByText('Your Shopping Lists')).toBeTruthy()
@@ -38,19 +51,31 @@ describe('<DashboardPage />', () => {
   })
 
   test('matches snapshot', () => {
-    const wrapper = renderAuthenticated(<DashboardPage />)
+    const wrapper = renderAuthenticated(
+      <PageProvider>
+        <DashboardPage />
+      </PageProvider>
+    )
     expect(wrapper).toMatchSnapshot()
   })
 
   describe('when auth is loading', () => {
     test('DashboardPage displays the pulse loader', () => {
-      renderAuthLoading(<DashboardPage />)
+      renderAuthLoading(
+        <PageProvider>
+          <DashboardPage />
+        </PageProvider>
+      )
 
       expect(screen.getByTestId('pulseLoader')).toBeTruthy()
     })
 
     test('matches snapshot', () => {
-      const wrapper = renderAuthLoading(<DashboardPage />)
+      const wrapper = renderAuthLoading(
+        <PageProvider>
+          <DashboardPage />
+        </PageProvider>
+      )
 
       expect(wrapper).toMatchSnapshot()
     })

--- a/src/pages/dashboardPage/dashboardPage.tsx
+++ b/src/pages/dashboardPage/dashboardPage.tsx
@@ -5,6 +5,7 @@ import { YELLOW, PINK, BLUE, GREEN, AQUA } from '../../utils/colorSchemes'
 import { useGoogleLogin } from '../../hooks/contexts'
 import DashboardLayout from '../../layouts/dashboardLayout/dashboardLayout'
 import NavigationMosaic from '../../components/navigationMosaic/navigationMosaic'
+import paths from '../../routing/paths'
 import styles from './dashboardPage.module.css'
 
 const PLACEHOLDER_HREF: RelativePath = '#'
@@ -12,7 +13,7 @@ const PLACEHOLDER_HREF: RelativePath = '#'
 const navigationCards = [
   {
     colorScheme: YELLOW,
-    href: PLACEHOLDER_HREF,
+    href: paths.dashboard.games,
     children: 'Your Games',
     key: 'games',
   },

--- a/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
+++ b/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
@@ -96,6 +96,10 @@ exports[`<GamesPage /> > when loading > matches snapshot 1`] = `
             </div>
           </div>
         </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
       </main>
     </div>
   </body>,
@@ -191,6 +195,10 @@ exports[`<GamesPage /> > when loading > matches snapshot 1`] = `
           </div>
         </div>
       </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
     </main>
   </div>,
   "debug": [Function],
@@ -388,6 +396,10 @@ exports[`<GamesPage /> > when there are multiple games > matches snapshot 1`] = 
             </span>
           </div>
         </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
       </main>
     </div>
   </body>,
@@ -528,6 +540,10 @@ exports[`<GamesPage /> > when there are multiple games > matches snapshot 1`] = 
           </span>
         </div>
       </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
     </main>
   </div>,
   "debug": [Function],
@@ -725,6 +741,10 @@ exports[`<GamesPage /> > when there are no games > matches snapshot 1`] = `
             </span>
           </div>
         </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
       </main>
     </div>
   </body>,
@@ -865,6 +885,10 @@ exports[`<GamesPage /> > when there are no games > matches snapshot 1`] = `
           </span>
         </div>
       </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
     </main>
   </div>,
   "debug": [Function],

--- a/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
+++ b/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
@@ -255,6 +255,351 @@ exports[`<GamesPage /> > when loading > matches snapshot 1`] = `
 }
 `;
 
+exports[`<GamesPage /> > when the server returns an error > matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <main
+        class="_root_03d657"
+      >
+        <section
+          class="_container_03d657"
+        >
+          <h2
+            class="_title_03d657"
+          >
+            Your Games
+          </h2>
+          <hr
+            class="_hr_03d657"
+          />
+          <div>
+            <span
+              data-testid="pulseLoader"
+              style="display: inherit; text-align: center;"
+            >
+              <span
+                style="background-color: #ffcb32; width: 15px; height: 15px; margin: 2px; border-radius: 100%; display: inline-block; animation: react-spinners-PulseLoader-pulse 0.75s 0.12s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); animation-fill-mode: both;"
+              />
+              <span
+                style="background-color: #ffcb32; width: 15px; height: 15px; margin: 2px; border-radius: 100%; display: inline-block; animation: react-spinners-PulseLoader-pulse 0.75s 0.24s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); animation-fill-mode: both;"
+              />
+              <span
+                style="background-color: #ffcb32; width: 15px; height: 15px; margin: 2px; border-radius: 100%; display: inline-block; animation: react-spinners-PulseLoader-pulse 0.75s 0.36s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); animation-fill-mode: both;"
+              />
+            </span>
+          </div>
+        </section>
+        <header
+          class="_root_c29812"
+        >
+          <div
+            class="_bar_c29812"
+          >
+            <span
+              class="_headerContainer_c29812"
+            >
+              <h1
+                class="_header_c29812"
+              >
+                <a
+                  class="_headerLinkLarge_c29812"
+                  href="/dashboard"
+                >
+                  Skyrim Inventory
+                  <br
+                    class="_bp_c29812"
+                  />
+                   Management
+                </a>
+                <a
+                  class="_headerLinkSmall_c29812"
+                  href="/dashboard"
+                >
+                  S. I. M.
+                </a>
+              </h1>
+            </span>
+            <span
+              class="_root_d263fb"
+            >
+              <div
+                class="_main_d263fb"
+              >
+                <div
+                  class="_button_d263fb"
+                  role="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    data-icon="bars"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span
+                    class="_info_d263fb"
+                  >
+                    <p
+                      class="_name_d263fb"
+                    >
+                      Edna St. Vincent Millay
+                    </p>
+                    <p
+                      class="_email_d263fb"
+                    >
+                      edna@gmail.com
+                    </p>
+                  </span>
+                  <img
+                    alt="User profile image"
+                    class="_img_d263fb"
+                    src="/src/support/testProfileImg.png"
+                  />
+                </div>
+              </div>
+              <menu
+                class="_dropdown_d263fb"
+              >
+                <div>
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-right-from-bracket "
+                    data-icon="right-from-bracket"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M377.9 105.9L500.7 228.7c7.2 7.2 11.3 17.1 11.3 27.3s-4.1 20.1-11.3 27.3L377.9 406.1c-6.4 6.4-15 9.9-24 9.9c-18.7 0-33.9-15.2-33.9-33.9l0-62.1-128 0c-17.7 0-32-14.3-32-32l0-64c0-17.7 14.3-32 32-32l128 0 0-62.1c0-18.7 15.2-33.9 33.9-33.9c9 0 17.6 3.6 24 9.9zM160 96L96 96c-17.7 0-32 14.3-32 32l0 256c0 17.7 14.3 32 32 32l64 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-64 0c-53 0-96-43-96-96L0 128C0 75 43 32 96 32l64 0c17.7 0 32 14.3 32 32s-14.3 32-32 32z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <p
+                    class="_signOutText_d263fb"
+                  >
+                    Sign Out
+                  </p>
+                </div>
+              </menu>
+            </span>
+          </div>
+        </header>
+        <div
+          class="_root_91d025 _hidden_91d025"
+          style="--text-color: #4e6d83;"
+        />
+      </main>
+    </div>
+  </body>,
+  "container": <div>
+    <main
+      class="_root_03d657"
+    >
+      <section
+        class="_container_03d657"
+      >
+        <h2
+          class="_title_03d657"
+        >
+          Your Games
+        </h2>
+        <hr
+          class="_hr_03d657"
+        />
+        <div>
+          <span
+            data-testid="pulseLoader"
+            style="display: inherit; text-align: center;"
+          >
+            <span
+              style="background-color: #ffcb32; width: 15px; height: 15px; margin: 2px; border-radius: 100%; display: inline-block; animation: react-spinners-PulseLoader-pulse 0.75s 0.12s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); animation-fill-mode: both;"
+            />
+            <span
+              style="background-color: #ffcb32; width: 15px; height: 15px; margin: 2px; border-radius: 100%; display: inline-block; animation: react-spinners-PulseLoader-pulse 0.75s 0.24s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); animation-fill-mode: both;"
+            />
+            <span
+              style="background-color: #ffcb32; width: 15px; height: 15px; margin: 2px; border-radius: 100%; display: inline-block; animation: react-spinners-PulseLoader-pulse 0.75s 0.36s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); animation-fill-mode: both;"
+            />
+          </span>
+        </div>
+      </section>
+      <header
+        class="_root_c29812"
+      >
+        <div
+          class="_bar_c29812"
+        >
+          <span
+            class="_headerContainer_c29812"
+          >
+            <h1
+              class="_header_c29812"
+            >
+              <a
+                class="_headerLinkLarge_c29812"
+                href="/dashboard"
+              >
+                Skyrim Inventory
+                <br
+                  class="_bp_c29812"
+                />
+                 Management
+              </a>
+              <a
+                class="_headerLinkSmall_c29812"
+                href="/dashboard"
+              >
+                S. I. M.
+              </a>
+            </h1>
+          </span>
+          <span
+            class="_root_d263fb"
+          >
+            <div
+              class="_main_d263fb"
+            >
+              <div
+                class="_button_d263fb"
+                role="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  data-icon="bars"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span
+                  class="_info_d263fb"
+                >
+                  <p
+                    class="_name_d263fb"
+                  >
+                    Edna St. Vincent Millay
+                  </p>
+                  <p
+                    class="_email_d263fb"
+                  >
+                    edna@gmail.com
+                  </p>
+                </span>
+                <img
+                  alt="User profile image"
+                  class="_img_d263fb"
+                  src="/src/support/testProfileImg.png"
+                />
+              </div>
+            </div>
+            <menu
+              class="_dropdown_d263fb"
+            >
+              <div>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-right-from-bracket "
+                  data-icon="right-from-bracket"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M377.9 105.9L500.7 228.7c7.2 7.2 11.3 17.1 11.3 27.3s-4.1 20.1-11.3 27.3L377.9 406.1c-6.4 6.4-15 9.9-24 9.9c-18.7 0-33.9-15.2-33.9-33.9l0-62.1-128 0c-17.7 0-32-14.3-32-32l0-64c0-17.7 14.3-32 32-32l128 0 0-62.1c0-18.7 15.2-33.9 33.9-33.9c9 0 17.6 3.6 24 9.9zM160 96L96 96c-17.7 0-32 14.3-32 32l0 256c0 17.7 14.3 32 32 32l64 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-64 0c-53 0-96-43-96-96L0 128C0 75 43 32 96 32l64 0c17.7 0 32 14.3 32 32s-14.3 32-32 32z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <p
+                  class="_signOutText_d263fb"
+                >
+                  Sign Out
+                </p>
+              </div>
+            </menu>
+          </span>
+        </div>
+      </header>
+      <div
+        class="_root_91d025 _hidden_91d025"
+        style="--text-color: #4e6d83;"
+      />
+    </main>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`<GamesPage /> > when there are multiple games > matches snapshot 1`] = `
 {
   "asFragment": [Function],

--- a/src/pages/gamesPage/gamesPage.stories.tsx
+++ b/src/pages/gamesPage/gamesPage.stories.tsx
@@ -1,9 +1,11 @@
 import { BrowserRouter } from 'react-router-dom'
 import { testUser, requireLogin } from '../../support/testUtils'
 import { allGames, emptyGames } from '../../support/data/games'
+import { internalServerErrorResponse } from '../../support/data/errors'
 import { LoginContext } from '../../contexts/loginContext'
-import GamesPage from './gamesPage'
+import { PageProvider } from '../../contexts/pageContext'
 import { GamesProvider } from '../../contexts/gamesContext'
+import GamesPage from './gamesPage'
 
 const GAMES_URI = 'http://localhost:3000/games'
 
@@ -21,9 +23,11 @@ export const NoGames = () => (
         requireLogin,
       }}
     >
-      <GamesProvider>
-        <GamesPage />
-      </GamesProvider>
+      <PageProvider>
+        <GamesProvider>
+          <GamesPage />
+        </GamesProvider>
+      </PageProvider>
     </LoginContext.Provider>
   </BrowserRouter>
 )
@@ -49,9 +53,11 @@ export const WithGames = () => (
         requireLogin,
       }}
     >
-      <GamesProvider>
-        <GamesPage />
-      </GamesProvider>
+      <PageProvider>
+        <GamesProvider>
+          <GamesPage />
+        </GamesProvider>
+      </PageProvider>
     </LoginContext.Provider>
   </BrowserRouter>
 )
@@ -72,9 +78,41 @@ export const AuthLoading = () => (
     <LoginContext.Provider
       value={{ user: null, token: null, authLoading: true, requireLogin }}
     >
-      <GamesProvider>
-        <GamesPage />
-      </GamesProvider>
+      <PageProvider>
+        <GamesProvider>
+          <GamesPage />
+        </GamesProvider>
+      </PageProvider>
     </LoginContext.Provider>
   </BrowserRouter>
 )
+
+export const ServerError = () => (
+  <BrowserRouter>
+    <LoginContext.Provider
+      value={{
+        user: testUser,
+        token: 'xxxxxxx',
+        authLoading: false,
+        requireLogin,
+      }}
+    >
+      <PageProvider>
+        <GamesProvider>
+          <GamesPage />
+        </GamesProvider>
+      </PageProvider>
+    </LoginContext.Provider>
+  </BrowserRouter>
+)
+
+ServerError.parameters = {
+  mockData: [
+    {
+      url: GAMES_URI,
+      method: 'GET',
+      status: 500,
+      response: internalServerErrorResponse,
+    },
+  ],
+}

--- a/src/pages/gamesPage/gamesPage.test.tsx
+++ b/src/pages/gamesPage/gamesPage.test.tsx
@@ -124,7 +124,9 @@ describe('<GamesPage />', () => {
 
   describe('when the server returns an error', () => {
     beforeEach(() => {
-      fetch.mockResponseOnce(JSON.stringify(internalServerErrorResponse), { status: 500 })
+      fetch.mockResponseOnce(JSON.stringify(internalServerErrorResponse), {
+        status: 500,
+      })
     })
 
     test('displays error content', async () => {

--- a/src/pages/gamesPage/gamesPage.test.tsx
+++ b/src/pages/gamesPage/gamesPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import { renderAuthenticated, renderAuthLoading } from '../../support/testUtils'
+import { PageProvider } from '../../contexts/pageContext'
 import { GamesProvider } from '../../contexts/gamesContext'
 import GamesPage from './gamesPage'
 import { emptyGames, allGames } from '../../support/data/games'
@@ -13,9 +14,11 @@ describe('<GamesPage />', () => {
   describe('when loading', () => {
     test('displays the loader', () => {
       const wrapper = renderAuthLoading(
-        <GamesProvider>
-          <GamesPage />
-        </GamesProvider>
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
       )
       expect(wrapper).toBeTruthy()
 
@@ -24,9 +27,11 @@ describe('<GamesPage />', () => {
 
     test('matches snapshot', () => {
       const wrapper = renderAuthLoading(
-        <GamesProvider>
-          <GamesPage />
-        </GamesProvider>
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
       )
 
       expect(wrapper).toMatchSnapshot()
@@ -40,9 +45,11 @@ describe('<GamesPage />', () => {
 
     test('games page displays a message that there are no games', async () => {
       const wrapper = renderAuthenticated(
-        <GamesProvider>
-          <GamesPage />
-        </GamesProvider>
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
       )
       expect(wrapper).toBeTruthy()
 
@@ -54,9 +61,11 @@ describe('<GamesPage />', () => {
 
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
-        <GamesProvider>
-          <GamesPage />
-        </GamesProvider>
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
       )
       expect(wrapper).toMatchSnapshot()
     })
@@ -71,9 +80,11 @@ describe('<GamesPage />', () => {
     // that, as noted in the test file for the GameLineItem component.
     test('displays the title and description of each game', async () => {
       renderAuthenticated(
-        <GamesProvider>
-          <GamesPage />
-        </GamesProvider>
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
       )
 
       const firstTitle = await screen.findByText('My Game 1')
@@ -100,9 +111,11 @@ describe('<GamesPage />', () => {
 
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
-        <GamesProvider>
-          <GamesPage />
-        </GamesProvider>
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
       )
       expect(wrapper).toMatchSnapshot()
     })

--- a/src/pages/gamesPage/gamesPage.test.tsx
+++ b/src/pages/gamesPage/gamesPage.test.tsx
@@ -1,10 +1,11 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import { renderAuthenticated, renderAuthLoading } from '../../support/testUtils'
+import { emptyGames, allGames } from '../../support/data/games'
+import { internalServerErrorResponse } from '../../support/data/errors'
 import { PageProvider } from '../../contexts/pageContext'
 import { GamesProvider } from '../../contexts/gamesContext'
 import GamesPage from './gamesPage'
-import { emptyGames, allGames } from '../../support/data/games'
 
 describe('<GamesPage />', () => {
   beforeEach(() => {
@@ -117,6 +118,50 @@ describe('<GamesPage />', () => {
           </GamesProvider>
         </PageProvider>
       )
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('when the server returns an error', () => {
+    beforeEach(() => {
+      fetch.mockResponseOnce(JSON.stringify(internalServerErrorResponse), { status: 500 })
+    })
+
+    test('displays error content', async () => {
+      renderAuthenticated(
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
+      )
+
+      await waitFor(() => {
+        expect(screen.findByText('500 Internal Server Error')).toBeTruthy()
+      })
+    })
+
+    test("doesn't break the dashboard", () => {
+      renderAuthenticated(
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
+      )
+
+      expect(screen.getByText('Your Games')).toBeTruthy()
+    })
+
+    test('matches snapshot', () => {
+      const wrapper = renderAuthenticated(
+        <PageProvider>
+          <GamesProvider>
+            <GamesPage />
+          </GamesProvider>
+        </PageProvider>
+      )
+
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/routing/pageRoutes.tsx
+++ b/src/routing/pageRoutes.tsx
@@ -9,6 +9,7 @@ import NotFoundPage from '../pages/notFoundPage/notFoundPage'
 import DashboardPage from '../pages/dashboardPage/dashboardPage'
 import GamesPage from '../pages/gamesPage/gamesPage'
 import paths from './paths'
+import { PageProvider } from '../contexts/pageContext'
 
 const siteTitle = 'Skyrim Inventory Management |'
 
@@ -41,7 +42,11 @@ const pages: Page[] = [
     pageId: 'dashboard-main',
     title: `${siteTitle} Dashboard`,
     description: 'Skyrim Inventory Management User Dashboard',
-    jsx: <DashboardPage />,
+    jsx: (
+      <PageProvider>
+        <DashboardPage />
+      </PageProvider>
+    ),
     path: paths.dashboard.main,
   },
   {
@@ -49,9 +54,11 @@ const pages: Page[] = [
     title: `${siteTitle} Your Games`,
     description: 'Manage Skyrim Games',
     jsx: (
-      <GamesProvider>
-        <GamesPage />
-      </GamesProvider>
+      <PageProvider>
+        <GamesProvider>
+          <GamesPage />
+        </GamesProvider>
+      </PageProvider>
     ),
     path: paths.dashboard.games,
   },

--- a/src/types/flashMessages.d.ts
+++ b/src/types/flashMessages.d.ts
@@ -1,0 +1,15 @@
+export type FlashMessageType = 'success' | 'error' | 'warning' | 'info'
+
+export interface FlashProps {
+  type: FlashMessageType
+  message: string | string[]
+  hidden: boolean
+  header?: string
+}
+
+export interface FlashColors {
+  success: `#${string}`
+  error: `#${string}`
+  warning: `#${string}`
+  info: `#${string}`
+}

--- a/src/utils/simApi.ts
+++ b/src/utils/simApi.ts
@@ -22,7 +22,6 @@ export const getGames = (token: string) => {
 
   return fetch(uri, { headers }).then((res: Response) => {
     if (res.status === 401) throw new AuthorizationError()
-    if (res.status === 404) throw new NotFoundError()
     if (res.status === 500) throw new InternalServerError()
     return res.json().then((json: Game[]) => ({ status: res.status, json }))
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
           },
           {
             name: 'Quattrocento Sans',
+            styles: 'wght@400;700',
           },
         ],
       },


### PR DESCRIPTION
## Context

[**Rewrite Games page**](https://trello.com/c/P1WhcSOq/231-rewrite-games-page)

In #28, I added a basic Games page with a context that would fetch a user's games from the server to be displayed on the page. However, displaying error messages on this page would involve both creating a `FlashMessage` component and finding a good way to control showing and hiding it, given that it could eventually appear on any part of the dashboard. Normally I would consider this a premature optimisation, however, the code for this got ugly on the original front end and I wanted to aim for a better implementation this time. This PR adds that component and enables it to be displayed on the Games page in the event that the API call returns a 500 error.

Note that, although the attached screenshots suggest a static element, the actual flash message fades out after 3 seconds. Capturing this behaviour in a gif of reasonable length proved impractical, so I just used screenshots. The fadeout functionality can be viewed in Storybook.

## Changes

* Create `FlashMessage` component to display error messages and other messages to the user
* Add `PageContext` to enable controlling the appearance (and disappearance) of this element for the entire dashboard
* Add the `FlashMessage` component to the `DashboardLayout`
* Add story and test for dashboard games page illustrating the case where the API call to fetch games results in a 500 error
* Remove ability of `getGames` function from `simApi` module to throw a 404 error since this isn't a possible response from the server
* Add docs on new contexts

## Considerations

Since the `FlashMessage` element is always present on the `DashboardLayout` (albeit usually with `visibility: hidden` and `opacity: 0`), it has to have props passed in. I've made the default props include an `'info'` type and an empty string as the message. These props are never expected to be displayed - when a component needs to display a flash message, it will set the props to include the appropriate type and message.

## Manual Test Cases

Like other PRs on this feature branch, this cannot yet be tested in a dev environment as the back end is not ready to validate tokens. Instead, it is tested in Vitest and Storybook (mainly Storybook due to limitations of Vitest around CSS rendering). There is a new story for the `GamesPage`, called "ServerError", that illustrates the flash error that should appear on this page when the server returns a 500 error.

## Screenshots and GIFs

### 320px

<img width="320" alt="GamesPageError-320" src="https://user-images.githubusercontent.com/5115928/223366938-0c2ccf68-a91d-4707-ba53-ffe1ec293e82.png">

### 481px

<img width="481" alt="GamesPageError-481" src="https://user-images.githubusercontent.com/5115928/223366984-5ed3a4f5-c619-4a3f-825a-23a9d4738bae.png">

### 601px

<img width="601" alt="GamesPageError-601" src="https://user-images.githubusercontent.com/5115928/223367033-83b37c7b-94c3-4f4e-bb42-c79cfeb5922d.png">

### 769px

<img width="770" alt="GamesPageError-769" src="https://user-images.githubusercontent.com/5115928/223367078-74cdfeb5-030d-41f1-83ca-03ecd33fef30.png">

### 1025px

<img width="1026" alt="GamesPageError-1025" src="https://user-images.githubusercontent.com/5115928/223367108-a6e5f34b-ac9a-4f65-93eb-73102506bc6e.png">

### 1201px

<img width="1201" alt="GamesPageError-1201" src="https://user-images.githubusercontent.com/5115928/223367150-b3c21262-e385-4b21-b300-5eb81dd942f9.png">

### 1405px

<img width="1405" alt="GamesPageError-1405" src="https://user-images.githubusercontent.com/5115928/223367199-20309404-a919-405c-9f41-48124a4c38f8.png">


### Large Desktop

<img width="1917" alt="GamesPageError-Full" src="https://user-images.githubusercontent.com/5115928/223367260-3c3984ab-5749-4c11-bd33-3793444cd99c.png">

