### PR TITLE
Destroy shopping lists from shopping lists page

### DIFF
--- a/docs/contexts/shopping-lists-context.md
+++ b/docs/contexts/shopping-lists-context.md
@@ -8,6 +8,10 @@ The `ShoppingListsContext` keeps track of the active game and its shopping lists
   - `attributes`: an object containing an optional `title` key with a string value, the attributes of the shopping list to create
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
+- `destroyShoppingList`: a function that destroys the selected shopping list at the API, taking the following arguments:
+  - `listId`: the `id` of the shopping list to be destroyed
+  - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
+  - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
 
 Note that, while the context tracks the active game, this information is internal to the context. The active game is identified using the `gameId` query string parameter, which is typically set using the games dropdown component found on the `DashboardLayout`.
 

--- a/src/components/shoppingList/__snapshots__/shoppingList.test.tsx.snap
+++ b/src/components/shoppingList/__snapshots__/shoppingList.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ShoppingList > when there are list items > matches snapshot 1`] = `
+exports[`ShoppingList > displaying a list > when the list is not editable > matches snapshot 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>
@@ -10,11 +10,35 @@ exports[`ShoppingList > when there are list items > matches snapshot 1`] = `
         style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
       >
         <div
-          aria-controls="list32Details"
+          aria-controls="list3Details"
           aria-expanded="false"
           class="_trigger_62bc73"
           role="button"
         >
+          <span
+            class="_icons_62bc73"
+          >
+            <button
+              class="_icon_62bc73"
+              data-testid="destroyShoppingList3"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark _fa_62bc73"
+                data-icon="xmark"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </span>
           <h3
             class="_title_62bc73"
           >
@@ -24,7 +48,192 @@ exports[`ShoppingList > when there are list items > matches snapshot 1`] = `
         <div
           aria-hidden="true"
           class="rah-static rah-static--height-zero "
-          id="list32Details"
+          id="list3Details"
+          style="height: 0px; overflow: hidden;"
+        >
+          <div
+            style="display: none;"
+          >
+            <div
+              class="_details_62bc73"
+            >
+              <p
+                class="_emptyList_62bc73"
+              >
+                This shopping list has no list items.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="_root_62bc73"
+      style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
+    >
+      <div
+        aria-controls="list3Details"
+        aria-expanded="false"
+        class="_trigger_62bc73"
+        role="button"
+      >
+        <span
+          class="_icons_62bc73"
+        >
+          <button
+            class="_icon_62bc73"
+            data-testid="destroyShoppingList3"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark _fa_62bc73"
+              data-icon="xmark"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 320 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </span>
+        <h3
+          class="_title_62bc73"
+        >
+          My Shopping List
+        </h3>
+      </div>
+      <div
+        aria-hidden="true"
+        class="rah-static rah-static--height-zero "
+        id="list3Details"
+        style="height: 0px; overflow: hidden;"
+      >
+        <div
+          style="display: none;"
+        >
+          <div
+            class="_details_62bc73"
+          >
+            <p
+              class="_emptyList_62bc73"
+            >
+              This shopping list has no list items.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`ShoppingList > displaying a list > when there are list items > matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="_root_62bc73"
+        style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
+      >
+        <div
+          aria-controls="list4Details"
+          aria-expanded="false"
+          class="_trigger_62bc73"
+          role="button"
+        >
+          <span
+            class="_icons_62bc73"
+          >
+            <button
+              class="_icon_62bc73"
+              data-testid="destroyShoppingList4"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark _fa_62bc73"
+                data-icon="xmark"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </span>
+          <h3
+            class="_title_62bc73"
+          >
+            My Shopping List
+          </h3>
+        </div>
+        <div
+          aria-hidden="true"
+          class="rah-static rah-static--height-zero "
+          id="list4Details"
           style="height: 0px; overflow: hidden;"
         >
           <div
@@ -167,11 +376,35 @@ exports[`ShoppingList > when there are list items > matches snapshot 1`] = `
       style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
     >
       <div
-        aria-controls="list32Details"
+        aria-controls="list4Details"
         aria-expanded="false"
         class="_trigger_62bc73"
         role="button"
       >
+        <span
+          class="_icons_62bc73"
+        >
+          <button
+            class="_icon_62bc73"
+            data-testid="destroyShoppingList4"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark _fa_62bc73"
+              data-icon="xmark"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 320 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </span>
         <h3
           class="_title_62bc73"
         >
@@ -181,7 +414,7 @@ exports[`ShoppingList > when there are list items > matches snapshot 1`] = `
       <div
         aria-hidden="true"
         class="rah-static rah-static--height-zero "
-        id="list32Details"
+        id="list4Details"
         style="height: 0px; overflow: hidden;"
       >
         <div
@@ -371,7 +604,7 @@ exports[`ShoppingList > when there are list items > matches snapshot 1`] = `
 }
 `;
 
-exports[`ShoppingList > when there are no list items > matches snapshot 1`] = `
+exports[`ShoppingList > displaying a list > when there are no list items > matches snapshot 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>
@@ -381,11 +614,35 @@ exports[`ShoppingList > when there are no list items > matches snapshot 1`] = `
         style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
       >
         <div
-          aria-controls="list32Details"
+          aria-controls="list4Details"
           aria-expanded="false"
           class="_trigger_62bc73"
           role="button"
         >
+          <span
+            class="_icons_62bc73"
+          >
+            <button
+              class="_icon_62bc73"
+              data-testid="destroyShoppingList4"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark _fa_62bc73"
+                data-icon="xmark"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </span>
           <h3
             class="_title_62bc73"
           >
@@ -395,7 +652,7 @@ exports[`ShoppingList > when there are no list items > matches snapshot 1`] = `
         <div
           aria-hidden="true"
           class="rah-static rah-static--height-zero "
-          id="list32Details"
+          id="list4Details"
           style="height: 0px; overflow: hidden;"
         >
           <div
@@ -421,11 +678,35 @@ exports[`ShoppingList > when there are no list items > matches snapshot 1`] = `
       style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
     >
       <div
-        aria-controls="list32Details"
+        aria-controls="list4Details"
         aria-expanded="false"
         class="_trigger_62bc73"
         role="button"
       >
+        <span
+          class="_icons_62bc73"
+        >
+          <button
+            class="_icon_62bc73"
+            data-testid="destroyShoppingList4"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark _fa_62bc73"
+              data-icon="xmark"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 320 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </span>
         <h3
           class="_title_62bc73"
         >
@@ -435,7 +716,7 @@ exports[`ShoppingList > when there are no list items > matches snapshot 1`] = `
       <div
         aria-hidden="true"
         class="rah-static rah-static--height-zero "
-        id="list32Details"
+        id="list4Details"
         style="height: 0px; overflow: hidden;"
       >
         <div

--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -14,12 +14,29 @@
 
 .trigger {
   cursor: pointer;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+}
+
+.icons {
+  margin: 8px 0;
+  display: grid;
+}
+
+.icon {
+  color: var(--text-color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 4px;
+  margin-right: 4px;
 }
 
 .title {
   font-size: 1.25rem;
   line-height: 1.25;
-  margin: 8px 0 8px 16px;
+  margin: 8px 0 8px 8px;
 }
 
 .details {

--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -33,6 +33,10 @@
   margin-right: 4px;
 }
 
+.icon:hover {
+  color: var(--scheme-color-lightest);
+}
+
 .title {
   font-size: 1.25rem;
   line-height: 1.25;

--- a/src/components/shoppingList/shoppingList.stories.tsx
+++ b/src/components/shoppingList/shoppingList.stories.tsx
@@ -1,32 +1,95 @@
-import { PINK, YELLOW } from '../../utils/colorSchemes'
+import { type ReactElement } from 'react'
+import { PINK, YELLOW, AQUA, GREEN } from '../../utils/colorSchemes'
+import { BrowserRouter } from 'react-router-dom'
+import {
+  gamesContextValue,
+  loginContextValue,
+  shoppingListsContextValue,
+} from '../../support/data/contextValues'
+import { LoginContext } from '../../contexts/loginContext'
+import { PageProvider } from '../../contexts/pageContext'
+import { GamesContext } from '../../contexts/gamesContext'
+import { ShoppingListsContext } from '../../contexts/shoppingListsContext'
 import { ColorProvider } from '../../contexts/colorContext'
 import ShoppingListItem from '../shoppingListItem/shoppingListItem'
 import ShoppingList from './shoppingList'
 
-export default { title: 'ShoppingList' }
+interface Props {
+  children: ReactElement | ReactElement[]
+}
 
-export const NoListItems = () => (
-  <ColorProvider colorScheme={PINK}>
-    <ShoppingList listId={32} title="Proudspire Manor" />
-  </ColorProvider>
+const Providers = ({ children }: Props) => (
+  <BrowserRouter>
+    <LoginContext.Provider value={loginContextValue}>
+      <PageProvider>
+        <GamesContext.Provider value={gamesContextValue}>
+          <ShoppingListsContext.Provider value={shoppingListsContextValue}>
+            {children}
+          </ShoppingListsContext.Provider>
+        </GamesContext.Provider>
+      </PageProvider>
+    </LoginContext.Provider>
+  </BrowserRouter>
 )
 
-export const WithListItems = () => (
-  <ColorProvider colorScheme={YELLOW}>
-    <ShoppingList listId={32} title="Proudspire Manor">
-      <ShoppingListItem
-        itemId={1}
-        description="Steel Ingot"
-        quantity={5}
-        unitWeight={1.0}
-      />
-      <ShoppingListItem
-        itemId={2}
-        description="This item has a really really really really really long description for testing purposes"
-        quantity={200000000000}
-        unitWeight={400000000000}
-        notes="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet velit adipsci"
-      />
-    </ShoppingList>
-  </ColorProvider>
+export default { title: 'ShoppingList' }
+
+export const EditableNoListItems = () => (
+  <Providers>
+    <ColorProvider colorScheme={AQUA}>
+      <ShoppingList listId={32} title="Proudspire Manor" canEdit />
+    </ColorProvider>
+  </Providers>
+)
+
+export const EditableWithListItems = () => (
+  <Providers>
+    <ColorProvider colorScheme={GREEN}>
+      <ShoppingList listId={32} title="Proudspire Manor" canEdit>
+        <ShoppingListItem
+          itemId={1}
+          description="Steel Ingot"
+          quantity={5}
+          unitWeight={1.0}
+        />
+        <ShoppingListItem
+          itemId={2}
+          description="This item has a really really really really really long description for testing purposes"
+          quantity={200000000000}
+          unitWeight={400000000000}
+          notes="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet velit adipsci"
+        />
+      </ShoppingList>
+    </ColorProvider>
+  </Providers>
+)
+
+export const NotEditableNoListItems = () => (
+  <Providers>
+    <ColorProvider colorScheme={PINK}>
+      <ShoppingList listId={32} title="Proudspire Manor" />
+    </ColorProvider>
+  </Providers>
+)
+
+export const NotEditableWithListItems = () => (
+  <Providers>
+    <ColorProvider colorScheme={YELLOW}>
+      <ShoppingList listId={32} title="Proudspire Manor">
+        <ShoppingListItem
+          itemId={1}
+          description="Steel Ingot"
+          quantity={5}
+          unitWeight={1.0}
+        />
+        <ShoppingListItem
+          itemId={2}
+          description="This item has a really really really really really long description for testing purposes"
+          quantity={200000000000}
+          unitWeight={400000000000}
+          notes="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet velit adipsci"
+        />
+      </ShoppingList>
+    </ColorProvider>
+  </Providers>
 )

--- a/src/components/shoppingList/shoppingList.test.tsx
+++ b/src/components/shoppingList/shoppingList.test.tsx
@@ -1,83 +1,192 @@
+import { ReactElement } from 'react'
 import { describe, test, expect } from 'vitest'
-import { renderWithRouter } from '../../support/testUtils'
+import { act, fireEvent, waitFor } from '@testing-library/react'
+import { renderAuthenticated } from '../../support/testUtils'
+import {
+  gamesContextValue,
+  shoppingListsContextValue,
+} from '../../support/data/contextValues'
 import { GREEN } from '../../utils/colorSchemes'
+import { PageProvider } from '../../contexts/pageContext'
+import { GamesContext } from '../../contexts/gamesContext'
+import { ShoppingListsContext } from '../../contexts/shoppingListsContext'
 import { ColorProvider } from '../../contexts/colorContext'
 import ShoppingListItem from '../shoppingListItem/shoppingListItem'
 import ShoppingList from './shoppingList'
 
-describe('ShoppingList', () => {
-  describe('when there are no list items', () => {
-    test('displays the name of the shopping list', () => {
-      const wrapper = renderWithRouter(
-        <ColorProvider colorScheme={GREEN}>
-          <ShoppingList listId={32} title="My Shopping List" />
-        </ColorProvider>
-      )
+let listContextValue = shoppingListsContextValue
 
-      expect(wrapper).toBeTruthy()
-      expect(wrapper.getByText('My Shopping List')).toBeTruthy()
-      expect(
-        wrapper.getByText('This shopping list has no list items.')
-      ).toBeTruthy()
+const renderWithContexts = (ui: ReactElement) =>
+  renderAuthenticated(
+    <PageProvider>
+      <GamesContext.Provider value={gamesContextValue}>
+        <ShoppingListsContext.Provider value={listContextValue}>
+          <ColorProvider colorScheme={GREEN}>{ui}</ColorProvider>
+        </ShoppingListsContext.Provider>
+      </GamesContext.Provider>
+    </PageProvider>
+  )
+
+describe('ShoppingList', () => {
+  describe('displaying a list', () => {
+    describe('when there are no list items', () => {
+      test('displays the name of the shopping list', () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit />
+        )
+
+        expect(wrapper).toBeTruthy()
+        expect(wrapper.getByText('My Shopping List')).toBeTruthy()
+        expect(
+          wrapper.getByText('This shopping list has no list items.')
+        ).toBeTruthy()
+      })
+
+      test('has a destroy icon', () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit />
+        )
+
+        expect(wrapper.getByTestId('destroyShoppingList4')).toBeTruthy()
+      })
+
+      test('matches snapshot', () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit />
+        )
+        expect(wrapper).toMatchSnapshot()
+      })
     })
 
-    test('matches snapshot', () => {
-      const wrapper = renderWithRouter(
-        <ColorProvider colorScheme={GREEN}>
-          <ShoppingList listId={32} title="My Shopping List" />
-        </ColorProvider>
-      )
-      expect(wrapper).toMatchSnapshot()
+    describe('when there are list items', () => {
+      test("doesn't display the message about no list items", () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit>
+            <ShoppingListItem
+              key="unique-key-1"
+              itemId={1}
+              description="List Item 1"
+              quantity={4}
+            />
+            <ShoppingListItem
+              key="unique-key-2"
+              itemId={2}
+              description="List Item 2"
+              quantity={1}
+            />
+          </ShoppingList>
+        )
+
+        expect(
+          wrapper.queryByText('This shopping list has no list items.')
+        ).toBeFalsy()
+      })
+
+      test('has a destroy icon', () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit>
+            <ShoppingListItem
+              key="unique-key-1"
+              itemId={1}
+              description="List Item 1"
+              quantity={4}
+            />
+            <ShoppingListItem
+              key="unique-key-2"
+              itemId={2}
+              description="List Item 2"
+              quantity={1}
+            />
+          </ShoppingList>
+        )
+
+        expect(wrapper.getByTestId('destroyShoppingList4')).toBeTruthy()
+      })
+
+      test('matches snapshot', () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit>
+            <ShoppingListItem
+              key="unique-key-1"
+              itemId={1}
+              description="List Item 1"
+              quantity={4}
+            />
+            <ShoppingListItem
+              key="unique-key-2"
+              itemId={2}
+              description="List Item 2"
+              quantity={1}
+            />
+          </ShoppingList>
+        )
+
+        expect(wrapper).toMatchSnapshot()
+      })
+    })
+
+    describe('when the list is not editable', () => {
+      test("doesn't have a destroy icon", () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={3} title="My Shopping List" />
+        )
+
+        expect(wrapper.queryByTestId('destroyShoppingList3')).toBeFalsy()
+      })
+
+      test('matches snapshot', () => {
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={3} title="My Shopping List" canEdit />
+        )
+
+        expect(wrapper).toMatchSnapshot()
+      })
     })
   })
 
-  describe('when there are list items', () => {
-    test("doesn't display the message about no list items", () => {
-      const wrapper = renderWithRouter(
-        <ColorProvider colorScheme={GREEN}>
-          <ShoppingList listId={32} title="My Shopping List">
-            <ShoppingListItem
-              key="unique-key-1"
-              itemId={1}
-              description="List Item 1"
-              quantity={4}
-            />
-            <ShoppingListItem
-              key="unique-key-2"
-              itemId={2}
-              description="List Item 2"
-              quantity={1}
-            />
-          </ShoppingList>
-        </ColorProvider>
-      )
+  describe('destroying the list', () => {
+    describe('when the user confirms deletion', () => {
+      test("calls the context's destroyShoppingList function with its listId", () => {
+        const destroyShoppingList = vitest.fn()
+        listContextValue = { ...shoppingListsContextValue, destroyShoppingList }
 
-      expect(
-        wrapper.queryByText('This shopping list has no list items.')
-      ).toBeFalsy()
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit />
+        )
+
+        window.confirm = vitest.fn().mockImplementation(() => true)
+
+        const destroyIcon = wrapper.getByTestId('destroyShoppingList4')
+
+        act(() => fireEvent.click(destroyIcon))
+
+        expect(window.confirm).toHaveBeenCalledWith(
+          'Are you sure you want to delete the list "My Shopping List"? You will also lose any list items on the list. This action cannot be undone.'
+        )
+        expect(destroyShoppingList).toHaveBeenCalledWith(4)
+      })
     })
 
-    test('matches snapshot', () => {
-      const wrapper = renderWithRouter(
-        <ColorProvider colorScheme={GREEN}>
-          <ShoppingList listId={32} title="My Shopping List">
-            <ShoppingListItem
-              key="unique-key-1"
-              itemId={1}
-              description="List Item 1"
-              quantity={4}
-            />
-            <ShoppingListItem
-              key="unique-key-2"
-              itemId={2}
-              description="List Item 2"
-              quantity={1}
-            />
-          </ShoppingList>
-        </ColorProvider>
-      )
+    describe('when the user cancels deletion', () => {
+      test("calls the context's destroyShoppingList function with its listId", () => {
+        const destroyShoppingList = vitest.fn()
+        listContextValue = { ...shoppingListsContextValue, destroyShoppingList }
 
-      expect(wrapper).toMatchSnapshot()
+        const wrapper = renderWithContexts(
+          <ShoppingList listId={4} title="My Shopping List" canEdit />
+        )
+
+        window.confirm = vitest.fn().mockImplementation(() => false)
+
+        const destroyIcon = wrapper.getByTestId('destroyShoppingList4')
+
+        act(() => fireEvent.click(destroyIcon))
+
+        expect(window.confirm).toHaveBeenCalledWith(
+          'Are you sure you want to delete the list "My Shopping List"? You will also lose any list items on the list. This action cannot be undone.'
+        )
+        expect(destroyShoppingList).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -1,5 +1,6 @@
 import {
   useState,
+  useRef,
   type MouseEventHandler,
   type ReactElement,
   type CSSProperties,
@@ -28,6 +29,8 @@ const ShoppingList = ({
   const { destroyShoppingList } = useShoppingListsContext()
   const [expanded, setExpanded] = useState(false)
 
+  const deleteRef = useRef<HTMLButtonElement>(null)
+
   const {
     schemeColorDarkest,
     borderColor,
@@ -48,8 +51,14 @@ const ShoppingList = ({
     '--scheme-color-lightest': schemeColorLightest,
   } as CSSProperties
 
-  const toggleDetails = () => {
-    setExpanded(!expanded)
+  const toggleDetails: MouseEventHandler = (e) => {
+    if (
+      deleteRef.current &&
+      deleteRef.current !== e.target &&
+      !deleteRef.current.contains(e.target as Node)
+    ) {
+      setExpanded(!expanded)
+    }
   }
 
   const destroy: MouseEventHandler = (e) => {
@@ -72,6 +81,7 @@ const ShoppingList = ({
         {canEdit && (
           <span className={styles.icons}>
             <button
+              ref={deleteRef}
               className={styles.icon}
               onClick={destroy}
               data-testid={`destroyShoppingList${listId}`}

--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -1,15 +1,31 @@
-import { ReactElement, useState, type CSSProperties } from 'react'
+import {
+  useState,
+  type MouseEventHandler,
+  type ReactElement,
+  type CSSProperties,
+} from 'react'
 import AnimateHeight from 'react-animate-height'
-import { useColorScheme } from '../../hooks/contexts'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faXmark } from '@fortawesome/free-solid-svg-icons'
+import { useColorScheme, useShoppingListsContext } from '../../hooks/contexts'
 import styles from './shoppingList.module.css'
 
 interface ShoppingListProps {
   listId: number
   title: string
+  canEdit?: boolean
   children?: ReactElement | ReactElement[] | null
 }
 
-const ShoppingList = ({ listId, title, children }: ShoppingListProps) => {
+const ShoppingList = ({
+  listId,
+  title,
+  canEdit = false,
+  children,
+}: ShoppingListProps) => {
+  const DELETE_CONFIRMATION = `Are you sure you want to delete the list "${title}"? You will also lose any list items on the list. This action cannot be undone.`
+
+  const { destroyShoppingList } = useShoppingListsContext()
   const [expanded, setExpanded] = useState(false)
 
   const {
@@ -36,6 +52,14 @@ const ShoppingList = ({ listId, title, children }: ShoppingListProps) => {
     setExpanded(!expanded)
   }
 
+  const destroy: MouseEventHandler = (e) => {
+    e.preventDefault()
+
+    const shouldDestroy = window.confirm(DELETE_CONFIRMATION)
+
+    if (shouldDestroy) destroyShoppingList(listId)
+  }
+
   return (
     <div className={styles.root} style={styleVars}>
       <div
@@ -45,6 +69,17 @@ const ShoppingList = ({ listId, title, children }: ShoppingListProps) => {
         aria-expanded={expanded}
         aria-controls={`list${listId}Details`}
       >
+        {canEdit && (
+          <span className={styles.icons}>
+            <button
+              className={styles.icon}
+              onClick={destroy}
+              data-testid={`destroyShoppingList${listId}`}
+            >
+              <FontAwesomeIcon className={styles.fa} icon={faXmark} />
+            </button>
+          </span>
+        )}
         <h3 className={styles.title}>{title}</h3>
       </div>
       <AnimateHeight

--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -8,7 +8,11 @@ import {
 import AnimateHeight from 'react-animate-height'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faXmark } from '@fortawesome/free-solid-svg-icons'
-import { useColorScheme, useShoppingListsContext } from '../../hooks/contexts'
+import {
+  useColorScheme,
+  usePageContext,
+  useShoppingListsContext,
+} from '../../hooks/contexts'
 import styles from './shoppingList.module.css'
 
 interface ShoppingListProps {
@@ -27,6 +31,7 @@ const ShoppingList = ({
   const DELETE_CONFIRMATION = `Are you sure you want to delete the list "${title}"? You will also lose any list items on the list. This action cannot be undone.`
 
   const { destroyShoppingList } = useShoppingListsContext()
+  const { setFlashProps } = usePageContext()
   const [expanded, setExpanded] = useState(false)
 
   const deleteRef = useRef<HTMLButtonElement>(null)
@@ -66,7 +71,15 @@ const ShoppingList = ({
 
     const shouldDestroy = window.confirm(DELETE_CONFIRMATION)
 
-    if (shouldDestroy) destroyShoppingList(listId)
+    if (shouldDestroy) {
+      destroyShoppingList(listId)
+    } else {
+      setFlashProps({
+        hidden: false,
+        type: 'info',
+        message: 'OK, your shopping list will not be destroyed.',
+      })
+    }
   }
 
   return (

--- a/src/components/shoppingListGrouping/__snapshots__/shoppingListGrouping.test.tsx.snap
+++ b/src/components/shoppingListGrouping/__snapshots__/shoppingListGrouping.test.tsx.snap
@@ -252,6 +252,30 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
               class="_trigger_62bc73"
               role="button"
             >
+              <span
+                class="_icons_62bc73"
+              >
+                <button
+                  class="_icon_62bc73"
+                  data-testid="destroyShoppingList4"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-xmark _fa_62bc73"
+                    data-icon="xmark"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </span>
               <h3
                 class="_title_62bc73"
               >
@@ -410,6 +434,30 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
               class="_trigger_62bc73"
               role="button"
             >
+              <span
+                class="_icons_62bc73"
+              >
+                <button
+                  class="_icon_62bc73"
+                  data-testid="destroyShoppingList5"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-xmark _fa_62bc73"
+                    data-icon="xmark"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </span>
               <h3
                 class="_title_62bc73"
               >
@@ -489,6 +537,71 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                       </div>
                     </div>
                   </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="_shoppingList_92c834"
+        >
+          <div
+            class="_root_62bc73"
+            style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
+          >
+            <div
+              aria-controls="list6Details"
+              aria-expanded="false"
+              class="_trigger_62bc73"
+              role="button"
+            >
+              <span
+                class="_icons_62bc73"
+              >
+                <button
+                  class="_icon_62bc73"
+                  data-testid="destroyShoppingList6"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-xmark _fa_62bc73"
+                    data-icon="xmark"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </span>
+              <h3
+                class="_title_62bc73"
+              >
+                Hjerim
+              </h3>
+            </div>
+            <div
+              aria-hidden="true"
+              class="rah-static rah-static--height-zero "
+              id="list6Details"
+              style="height: 0px; overflow: hidden;"
+            >
+              <div
+                style="display: none;"
+              >
+                <div
+                  class="_details_62bc73"
+                >
+                  <p
+                    class="_emptyList_62bc73"
+                  >
+                    This shopping list has no list items.
+                  </p>
                 </div>
               </div>
             </div>
@@ -672,6 +785,30 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
             class="_trigger_62bc73"
             role="button"
           >
+            <span
+              class="_icons_62bc73"
+            >
+              <button
+                class="_icon_62bc73"
+                data-testid="destroyShoppingList4"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-xmark _fa_62bc73"
+                  data-icon="xmark"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </span>
             <h3
               class="_title_62bc73"
             >
@@ -830,6 +967,30 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
             class="_trigger_62bc73"
             role="button"
           >
+            <span
+              class="_icons_62bc73"
+            >
+              <button
+                class="_icon_62bc73"
+                data-testid="destroyShoppingList5"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-xmark _fa_62bc73"
+                  data-icon="xmark"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </span>
             <h3
               class="_title_62bc73"
             >
@@ -909,6 +1070,71 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="_shoppingList_92c834"
+      >
+        <div
+          class="_root_62bc73"
+          style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
+        >
+          <div
+            aria-controls="list6Details"
+            aria-expanded="false"
+            class="_trigger_62bc73"
+            role="button"
+          >
+            <span
+              class="_icons_62bc73"
+            >
+              <button
+                class="_icon_62bc73"
+                data-testid="destroyShoppingList6"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-xmark _fa_62bc73"
+                  data-icon="xmark"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </span>
+            <h3
+              class="_title_62bc73"
+            >
+              Hjerim
+            </h3>
+          </div>
+          <div
+            aria-hidden="true"
+            class="rah-static rah-static--height-zero "
+            id="list6Details"
+            style="height: 0px; overflow: hidden;"
+          >
+            <div
+              style="display: none;"
+            >
+              <div
+                class="_details_62bc73"
+              >
+                <p
+                  class="_emptyList_62bc73"
+                >
+                  This shopping list has no list items.
+                </p>
               </div>
             </div>
           </div>

--- a/src/components/shoppingListGrouping/shoppingListGrouping.test.tsx
+++ b/src/components/shoppingListGrouping/shoppingListGrouping.test.tsx
@@ -28,6 +28,7 @@ describe('ShoppingListGrouping', () => {
       expect(wrapper.getByText('All Items')).toBeTruthy()
       expect(wrapper.getByText('Honeyside')).toBeTruthy()
       expect(wrapper.getByText('Breezehome')).toBeTruthy()
+      expect(wrapper.getByText('Hjerim')).toBeTruthy()
 
       // There should be list items on each list
       expect(wrapper.getAllByText('Dwarven Cog').length).toEqual(3)
@@ -36,6 +37,25 @@ describe('ShoppingListGrouping', () => {
           'This item has a really really really really really long description for testing purposes'
         ).length
       ).toEqual(2)
+    })
+
+    test('displays the destroy icon for editable lists only', () => {
+      const wrapper = renderAuthenticated(
+        <PageProvider>
+          <GamesContext.Provider value={gamesContextValue}>
+            <ShoppingListsContext.Provider value={shoppingListsContextValue}>
+              <ShoppingListGrouping />
+            </ShoppingListsContext.Provider>
+          </GamesContext.Provider>
+        </PageProvider>
+      )
+
+      expect(wrapper.getByTestId('destroyShoppingList4')).toBeTruthy()
+      expect(wrapper.getByTestId('destroyShoppingList5')).toBeTruthy()
+      expect(wrapper.getByTestId('destroyShoppingList6')).toBeTruthy()
+
+      // The aggregate list should not be editable
+      expect(wrapper.queryByTestId('destroyShoppingList3')).toBeFalsy()
     })
 
     test('matches snapshot', () => {

--- a/src/components/shoppingListGrouping/shoppingListGrouping.tsx
+++ b/src/components/shoppingListGrouping/shoppingListGrouping.tsx
@@ -13,7 +13,7 @@ const ShoppingListGrouping = () => {
 
   return (
     <div className={styles.root}>
-      {shoppingLists.map(({ id, title, list_items }, index) => {
+      {shoppingLists.map(({ id, title, aggregate, list_items }, index) => {
         const colorIndex =
           index < colorSchemes.length ? index : index % colorSchemes.length
         const itemKey = title.toLowerCase().replace(' ', '-')
@@ -21,7 +21,7 @@ const ShoppingListGrouping = () => {
         return (
           <ColorProvider key={itemKey} colorScheme={colorSchemes[colorIndex]}>
             <div className={styles.shoppingList}>
-              <ShoppingList listId={id} title={title}>
+              <ShoppingList listId={id} title={title} canEdit={!aggregate}>
                 {(list_items.length &&
                   list_items.map(
                     ({ id, description, quantity, unit_weight, notes }) => {

--- a/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
+++ b/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
@@ -684,6 +684,30 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                     class="_trigger_62bc73"
                     role="button"
                   >
+                    <span
+                      class="_icons_62bc73"
+                    >
+                      <button
+                        class="_icon_62bc73"
+                        data-testid="destroyShoppingList4"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-xmark _fa_62bc73"
+                          data-icon="xmark"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 320 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <h3
                       class="_title_62bc73"
                     >
@@ -836,6 +860,30 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                     class="_trigger_62bc73"
                     role="button"
                   >
+                    <span
+                      class="_icons_62bc73"
+                    >
+                      <button
+                        class="_icon_62bc73"
+                        data-testid="destroyShoppingList5"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-xmark _fa_62bc73"
+                          data-icon="xmark"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 320 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                    </span>
                     <h3
                       class="_title_62bc73"
                     >
@@ -911,6 +959,69 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                             </div>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="_shoppingList_92c834"
+              >
+                <div
+                  class="_root_62bc73"
+                  style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
+                >
+                  <div
+                    aria-controls="list6Details"
+                    aria-expanded="false"
+                    class="_trigger_62bc73"
+                    role="button"
+                  >
+                    <span
+                      class="_icons_62bc73"
+                    >
+                      <button
+                        class="_icon_62bc73"
+                        data-testid="destroyShoppingList6"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-xmark _fa_62bc73"
+                          data-icon="xmark"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 320 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <h3
+                      class="_title_62bc73"
+                    >
+                      Hjerim
+                    </h3>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="rah-static rah-static--height-zero "
+                    id="list6Details"
+                    style="height: 0px; overflow: hidden;"
+                  >
+                    <div>
+                      <div
+                        class="_details_62bc73"
+                      >
+                        <p
+                          class="_emptyList_62bc73"
+                        >
+                          This shopping list has no list items.
+                        </p>
                       </div>
                     </div>
                   </div>
@@ -1297,6 +1408,30 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                   class="_trigger_62bc73"
                   role="button"
                 >
+                  <span
+                    class="_icons_62bc73"
+                  >
+                    <button
+                      class="_icon_62bc73"
+                      data-testid="destroyShoppingList4"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-xmark _fa_62bc73"
+                        data-icon="xmark"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 320 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </button>
+                  </span>
                   <h3
                     class="_title_62bc73"
                   >
@@ -1449,6 +1584,30 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                   class="_trigger_62bc73"
                   role="button"
                 >
+                  <span
+                    class="_icons_62bc73"
+                  >
+                    <button
+                      class="_icon_62bc73"
+                      data-testid="destroyShoppingList5"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-xmark _fa_62bc73"
+                        data-icon="xmark"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 320 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </button>
+                  </span>
                   <h3
                     class="_title_62bc73"
                   >
@@ -1524,6 +1683,69 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                           </div>
                         </div>
                       </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="_shoppingList_92c834"
+            >
+              <div
+                class="_root_62bc73"
+                style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3;"
+              >
+                <div
+                  aria-controls="list6Details"
+                  aria-expanded="false"
+                  class="_trigger_62bc73"
+                  role="button"
+                >
+                  <span
+                    class="_icons_62bc73"
+                  >
+                    <button
+                      class="_icon_62bc73"
+                      data-testid="destroyShoppingList6"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-xmark _fa_62bc73"
+                        data-icon="xmark"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 320 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M310.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L160 210.7 54.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L114.7 256 9.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 301.3 265.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L205.3 256 310.6 150.6z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </button>
+                  </span>
+                  <h3
+                    class="_title_62bc73"
+                  >
+                    Hjerim
+                  </h3>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="rah-static rah-static--height-zero "
+                  id="list6Details"
+                  style="height: 0px; overflow: hidden;"
+                >
+                  <div>
+                    <div
+                      class="_details_62bc73"
+                    >
+                      <p
+                        class="_emptyList_62bc73"
+                      >
+                        This shopping list has no list items.
+                      </p>
                     </div>
                   </div>
                 </div>

--- a/src/pages/shoppingListsPage/shoppingListsPage.stories.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.stories.tsx
@@ -62,7 +62,7 @@ WithShoppingLists.parameters = {
       url: '/api/games/32/shopping_lists',
       method: 'GET',
       status: 200,
-      response: shoppingListsForGame(32),
+      response: shoppingListsForGame(77),
     },
   ],
 }

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -477,7 +477,9 @@ describe('ShoppingListsPage', () => {
 
             window.confirm = vitest.fn().mockImplementation(() => true)
 
-            const destroyIcon = await wrapper.findByTestId('destroyShoppingList2')
+            const destroyIcon = await wrapper.findByTestId(
+              'destroyShoppingList2'
+            )
 
             act(() => {
               fireEvent.click(destroyIcon)
@@ -510,7 +512,9 @@ describe('ShoppingListsPage', () => {
 
             window.confirm = vitest.fn().mockImplementation(() => true)
 
-            const destroyIcon = await wrapper.findByTestId('destroyShoppingList2')
+            const destroyIcon = await wrapper.findByTestId(
+              'destroyShoppingList2'
+            )
 
             act(() => {
               fireEvent.click(destroyIcon)
@@ -522,7 +526,9 @@ describe('ShoppingListsPage', () => {
 
             await waitFor(() => {
               expect(
-                wrapper.getByText('Success! Your shopping list has been deleted.')
+                wrapper.getByText(
+                  'Success! Your shopping list has been deleted.'
+                )
               ).toBeTruthy()
             })
           })
@@ -543,7 +549,9 @@ describe('ShoppingListsPage', () => {
 
             window.confirm = vitest.fn().mockImplementation(() => true)
 
-            const destroyIcon = await wrapper.findByTestId('destroyShoppingList6')
+            const destroyIcon = await wrapper.findByTestId(
+              'destroyShoppingList6'
+            )
 
             act(() => {
               fireEvent.click(destroyIcon)
@@ -575,7 +583,9 @@ describe('ShoppingListsPage', () => {
 
             window.confirm = vitest.fn().mockImplementation(() => true)
 
-            const destroyIcon = await wrapper.findByTestId('destroyShoppingList6')
+            const destroyIcon = await wrapper.findByTestId(
+              'destroyShoppingList6'
+            )
 
             act(() => {
               fireEvent.click(destroyIcon)
@@ -587,7 +597,9 @@ describe('ShoppingListsPage', () => {
 
             await waitFor(() => {
               expect(
-                wrapper.getByText('Success! Your shopping list has been deleted.')
+                wrapper.getByText(
+                  'Success! Your shopping list has been deleted.'
+                )
               ).toBeTruthy()
             })
           })
@@ -662,7 +674,11 @@ describe('ShoppingListsPage', () => {
         await waitFor(() => {
           expect(wrapper.getByText('All Items')).toBeTruthy()
           expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
-          expect(wrapper.getByText("Oops! Something unexpected went wrong. We're sorry! Please try again later.")).toBeTruthy()
+          expect(
+            wrapper.getByText(
+              "Oops! Something unexpected went wrong. We're sorry! Please try again later."
+            )
+          ).toBeTruthy()
         })
       })
     })

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -9,6 +9,7 @@ import {
   getGamesAllSuccess,
   getShoppingLists,
   deleteShoppingList,
+  deleteShoppingListServerError,
 } from '../../support/msw/handlers'
 import { PageProvider } from '../../contexts/pageContext'
 import { GamesProvider } from '../../contexts/gamesContext'
@@ -24,6 +25,12 @@ import ShoppingListsPage from './shoppingListsPage'
  *     another tab while it is set to that game without refreshing. In the test environment, these
  *     conditions are hard to create since there would first be a 404 error when fetching the
  *     shopping lists in the first place.
+ * - 404 response when destroying a shopping list (similar reasons to above)
+ * - 405 response when destroying a shopping list
+ *   - This response from the API occurs when the client makes a PUT, PATCH, or DELETE request
+ *     on an aggregate list. In the UI, aggregate lists are always uneditable and won't have a
+ *     button, so the only way to get this response would be to intercept the request, change the
+ *     list ID, and send it on to the server.
  * - That the create form input is cleared after request completion or not
  * - Flash warning being shown and no request made if, somehow, the user submits the create form
  *   before an active game has been set
@@ -443,19 +450,152 @@ describe('ShoppingListsPage', () => {
   })
 
   describe('destroying a shopping list', () => {
-    const mockServer = setupServer(
-      getGamesAllSuccess,
-      getShoppingLists,
-      deleteShoppingList
-    )
+    describe('when successful', () => {
+      const mockServer = setupServer(
+        getGamesAllSuccess,
+        getShoppingLists,
+        deleteShoppingList
+      )
 
-    beforeAll(() => mockServer.listen())
-    beforeEach(() => mockServer.resetHandlers())
-    afterAll(() => mockServer.close())
+      beforeAll(() => mockServer.listen())
+      beforeEach(() => mockServer.resetHandlers())
+      afterAll(() => mockServer.close())
 
-    describe('when the user confirms deletion', () => {
-      describe('when the game has no other regular shopping lists', () => {
-        test('removes both lists', async () => {
+      describe('when the user confirms deletion', () => {
+        describe('when the game has no other regular shopping lists', () => {
+          test('resets the shoppingLists array to the empty response value', async () => {
+            const wrapper = renderAuthenticated(
+              <PageProvider>
+                <GamesProvider>
+                  <ShoppingListsProvider>
+                    <ShoppingListsPage />
+                  </ShoppingListsProvider>
+                </GamesProvider>
+              </PageProvider>,
+              'http://localhost:5173/shopping_lists?gameId=32'
+            )
+
+            window.confirm = vitest.fn().mockImplementation(() => true)
+
+            const destroyIcon = await wrapper.findByTestId('destroyShoppingList2')
+
+            act(() => {
+              fireEvent.click(destroyIcon)
+            })
+
+            expect(window.confirm).toHaveBeenCalledWith(
+              'Are you sure you want to delete the list "My Shopping List 1"? You will also lose any list items on the list. This action cannot be undone.'
+            )
+
+            await waitFor(() => {
+              expect(wrapper.queryByText('All Items')).toBeFalsy()
+              expect(wrapper.queryByText('My Shopping List 1')).toBeFalsy()
+              expect(
+                wrapper.getByText('This game has no shopping lists.')
+              ).toBeTruthy()
+            })
+          })
+
+          test('displays a flash success message', async () => {
+            const wrapper = renderAuthenticated(
+              <PageProvider>
+                <GamesProvider>
+                  <ShoppingListsProvider>
+                    <ShoppingListsPage />
+                  </ShoppingListsProvider>
+                </GamesProvider>
+              </PageProvider>,
+              'http://localhost:5173/shopping_lists?gameId=32'
+            )
+
+            window.confirm = vitest.fn().mockImplementation(() => true)
+
+            const destroyIcon = await wrapper.findByTestId('destroyShoppingList2')
+
+            act(() => {
+              fireEvent.click(destroyIcon)
+            })
+
+            expect(window.confirm).toHaveBeenCalledWith(
+              'Are you sure you want to delete the list "My Shopping List 1"? You will also lose any list items on the list. This action cannot be undone.'
+            )
+
+            await waitFor(() => {
+              expect(
+                wrapper.getByText('Success! Your shopping list has been deleted.')
+              ).toBeTruthy()
+            })
+          })
+        })
+
+        describe('when the game has other regular shopping lists', () => {
+          test('resets the shoppingLists array to the response value', async () => {
+            const wrapper = renderAuthenticated(
+              <PageProvider>
+                <GamesProvider>
+                  <ShoppingListsProvider>
+                    <ShoppingListsPage />
+                  </ShoppingListsProvider>
+                </GamesProvider>
+              </PageProvider>,
+              'http://localhost:5173/shopping_lists?gameId=77'
+            )
+
+            window.confirm = vitest.fn().mockImplementation(() => true)
+
+            const destroyIcon = await wrapper.findByTestId('destroyShoppingList6')
+
+            act(() => {
+              fireEvent.click(destroyIcon)
+            })
+
+            expect(window.confirm).toHaveBeenCalledWith(
+              'Are you sure you want to delete the list "Hjerim"? You will also lose any list items on the list. This action cannot be undone.'
+            )
+
+            await waitFor(() => {
+              expect(wrapper.getByText('All Items')).toBeTruthy()
+              expect(wrapper.getByText('Honeyside')).toBeTruthy()
+              expect(wrapper.getByText('Breezehome')).toBeTruthy()
+              expect(wrapper.queryByText('Hjerim')).toBeFalsy()
+            })
+          })
+
+          test('displays a flash success message', async () => {
+            const wrapper = renderAuthenticated(
+              <PageProvider>
+                <GamesProvider>
+                  <ShoppingListsProvider>
+                    <ShoppingListsPage />
+                  </ShoppingListsProvider>
+                </GamesProvider>
+              </PageProvider>,
+              'http://localhost:5173/shopping_lists?gameId=77'
+            )
+
+            window.confirm = vitest.fn().mockImplementation(() => true)
+
+            const destroyIcon = await wrapper.findByTestId('destroyShoppingList6')
+
+            act(() => {
+              fireEvent.click(destroyIcon)
+            })
+
+            expect(window.confirm).toHaveBeenCalledWith(
+              'Are you sure you want to delete the list "Hjerim"? You will also lose any list items on the list. This action cannot be undone.'
+            )
+
+            await waitFor(() => {
+              expect(
+                wrapper.getByText('Success! Your shopping list has been deleted.')
+              ).toBeTruthy()
+            })
+          })
+        })
+      })
+
+      describe('when the user cancels deletion', () => {
+        test("doesn't remove the lists", async () => {
           const wrapper = renderAuthenticated(
             <PageProvider>
               <GamesProvider>
@@ -467,7 +607,7 @@ describe('ShoppingListsPage', () => {
             'http://localhost:5173/shopping_lists?gameId=32'
           )
 
-          window.confirm = vitest.fn().mockImplementation(() => true)
+          window.confirm = vitest.fn().mockImplementation(() => false)
 
           const destroyIcon = await wrapper.findByTestId('destroyShoppingList2')
 
@@ -475,51 +615,54 @@ describe('ShoppingListsPage', () => {
             fireEvent.click(destroyIcon)
           })
 
-          expect(window.confirm).toHaveBeenCalledWith(
-            'Are you sure you want to delete the list "My Shopping List 1"? You will also lose any list items on the list. This action cannot be undone.'
-          )
+          expect(window.confirm).toHaveBeenCalled()
 
           await waitFor(() => {
-            expect(wrapper.queryByText('All Items')).toBeFalsy()
-            expect(wrapper.queryByText('My Shopping List 1')).toBeFalsy()
-            expect(
-              wrapper.getByText('This game has no shopping lists.')
-            ).toBeTruthy()
+            expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
           })
         })
       })
+    })
 
-      describe('when the game has other regular shopping lists', () => {
-        test('resets the shoppingLists array to the response value', async () => {
-          const wrapper = renderAuthenticated(
-            <PageProvider>
-              <GamesProvider>
-                <ShoppingListsProvider>
-                  <ShoppingListsPage />
-                </ShoppingListsProvider>
-              </GamesProvider>
-            </PageProvider>,
-            'http://localhost:5173/shopping_lists?gameId=77'
-          )
+    describe('when unsuccessful', () => {
+      const mockServer = setupServer(
+        getGamesAllSuccess,
+        getShoppingLists,
+        deleteShoppingListServerError
+      )
 
-          window.confirm = vitest.fn().mockImplementation(() => true)
+      beforeAll(() => mockServer.listen())
+      beforeEach(() => mockServer.resetHandlers())
+      afterAll(() => mockServer.close())
 
-          const destroyIcon = await wrapper.findByTestId('destroyShoppingList6')
+      test("doesn't remove the list and displays a flash error", async () => {
+        const wrapper = renderAuthenticated(
+          <PageProvider>
+            <GamesProvider>
+              <ShoppingListsProvider>
+                <ShoppingListsPage />
+              </ShoppingListsProvider>
+            </GamesProvider>
+          </PageProvider>,
+          'http://localhost:5173/shopping_lists?gameId=32'
+        )
 
-          act(() => {
-            fireEvent.click(destroyIcon)
-          })
+        window.confirm = vitest.fn().mockImplementation(() => true)
 
-          expect(window.confirm).toHaveBeenCalledWith(
-            'Are you sure you want to delete the list "Hjerim"? You will also lose any list items on the list. This action cannot be undone.'
-          )
+        const destroyIcon = await wrapper.findByTestId('destroyShoppingList2')
 
-          await waitFor(() => {
-            expect(wrapper.getByText('All Items')).toBeTruthy()
-            expect(wrapper.getByText('Honeyside')).toBeTruthy()
-            expect(wrapper.getByText('Breezehome')).toBeTruthy()
-            expect(wrapper.queryByText('Hjerim')).toBeFalsy()
-          })
+        act(() => {
+          fireEvent.click(destroyIcon)
+        })
+
+        expect(window.confirm).toHaveBeenCalledWith(
+          'Are you sure you want to delete the list "My Shopping List 1"? You will also lose any list items on the list. This action cannot be undone.'
+        )
+
+        await waitFor(() => {
+          expect(wrapper.getByText('All Items')).toBeTruthy()
+          expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
+          expect(wrapper.getByText("Oops! Something unexpected went wrong. We're sorry! Please try again later.")).toBeTruthy()
         })
       })
     })

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -633,6 +633,35 @@ describe('ShoppingListsPage', () => {
             expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
           })
         })
+
+        test('displays a flash info message', async () => {
+          const wrapper = renderAuthenticated(
+            <PageProvider>
+              <GamesProvider>
+                <ShoppingListsProvider>
+                  <ShoppingListsPage />
+                </ShoppingListsProvider>
+              </GamesProvider>
+            </PageProvider>,
+            'http://localhost:5173/shopping_lists?gameId=32'
+          )
+
+          window.confirm = vitest.fn().mockImplementation(() => false)
+
+          const destroyIcon = await wrapper.findByTestId('destroyShoppingList2')
+
+          act(() => {
+            fireEvent.click(destroyIcon)
+          })
+
+          expect(window.confirm).toHaveBeenCalled()
+
+          await waitFor(() => {
+            expect(
+              wrapper.getByText('OK, your shopping list will not be destroyed.')
+            ).toBeTruthy()
+          })
+        })
       })
     })
 

--- a/src/support/data/contextValues.ts
+++ b/src/support/data/contextValues.ts
@@ -83,22 +83,26 @@ export const shoppingListsContextValueEmpty: ShoppingListsContextType = {
   shoppingLists: emptyShoppingLists,
   shoppingListsLoadingState: DONE,
   createShoppingList: noop,
+  destroyShoppingList: noop,
 }
 
 export const shoppingListsContextValue: ShoppingListsContextType = {
   shoppingLists: shoppingListsForGame(77),
   shoppingListsLoadingState: DONE,
   createShoppingList: noop,
+  destroyShoppingList: noop,
 }
 
 export const shoppingListsContextValueLoading: ShoppingListsContextType = {
   shoppingLists: emptyShoppingLists,
   shoppingListsLoadingState: LOADING,
   createShoppingList: noop,
+  destroyShoppingList: noop,
 }
 
 export const shoppingListsContextValueError: ShoppingListsContextType = {
   shoppingLists: emptyShoppingLists,
   shoppingListsLoadingState: ERROR,
   createShoppingList: noop,
+  destroyShoppingList: noop,
 }

--- a/src/support/data/shoppingLists.ts
+++ b/src/support/data/shoppingLists.ts
@@ -68,6 +68,16 @@ export const allShoppingLists: ShoppingList[] = [
     created_at: new Date('2023-02-12T15:17:33'),
     updated_at: new Date('2023-02-12T15:17:33'),
   },
+  {
+    id: 6,
+    game_id: 77,
+    aggregate_list_id: 3,
+    aggregate: false,
+    title: 'Hjerim',
+    list_items: emptyListItems,
+    created_at: new Date('2023-01-03T12:47:55'),
+    updated_at: new Date('2023-01-03T12:47:55'),
+  },
 ]
 
 export const shoppingListsForGame = (gameId: number) =>

--- a/src/support/msw/handlers.ts
+++ b/src/support/msw/handlers.ts
@@ -19,7 +19,6 @@ import {
   postShoppingListsServerError,
   getShoppingLists,
   deleteShoppingList,
-  deleteShoppingListNotAllowed,
   deleteShoppingListServerError,
 } from './shoppingLists'
 
@@ -42,6 +41,5 @@ export {
   postShoppingListsServerError,
   getShoppingLists,
   deleteShoppingList,
-  deleteShoppingListNotAllowed,
   deleteShoppingListServerError,
 }

--- a/src/support/msw/handlers.ts
+++ b/src/support/msw/handlers.ts
@@ -18,6 +18,9 @@ import {
   postShoppingListsUnprocessable,
   postShoppingListsServerError,
   getShoppingLists,
+  deleteShoppingList,
+  deleteShoppingListNotAllowed,
+  deleteShoppingListServerError,
 } from './shoppingLists'
 
 export {
@@ -38,4 +41,7 @@ export {
   postShoppingListsUnprocessable,
   postShoppingListsServerError,
   getShoppingLists,
+  deleteShoppingList,
+  deleteShoppingListNotAllowed,
+  deleteShoppingListServerError,
 }

--- a/src/support/msw/shoppingLists.ts
+++ b/src/support/msw/shoppingLists.ts
@@ -110,18 +110,6 @@ export const deleteShoppingList = rest.delete(
   }
 )
 
-export const deleteShoppingListNotAllowed = rest.delete(
-  `${BASE_URI}/shopping_lists/:listId`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(405),
-      ctx.json({
-        errors: ['Cannot manually destroy an aggregate list'],
-      })
-    )
-  }
-)
-
 export const deleteShoppingListServerError = rest.delete(
   `${BASE_URI}/shopping_lists/:listId`,
   (_req, res, ctx) => {

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -1,4 +1,4 @@
 export interface ApiError extends Error {
   message: string | string[]
-  code: 401 | 404 | 422 | 500
+  code: 401 | 404 | 405 | 422 | 500
 }

--- a/src/utils/api/apiErrors.ts
+++ b/src/utils/api/apiErrors.ts
@@ -28,6 +28,20 @@ export class NotFoundError implements ApiError {
   }
 }
 
+export class MethodNotAllowedError implements ApiError {
+  readonly code: 405
+  readonly message: string
+  readonly name: 'MethodNotAllowedError'
+
+  constructor(message: string = '405 Method Not Allowed') {
+    this.code = 405
+    this.name = 'MethodNotAllowedError'
+    this.message = message
+
+    Object.setPrototypeOf(this, MethodNotAllowedError.prototype)
+  }
+}
+
 export class UnprocessableEntityError implements ApiError {
   readonly code: 422
   readonly message: string | string[]

--- a/src/utils/api/returnValues/shoppingLists.d.ts
+++ b/src/utils/api/returnValues/shoppingLists.d.ts
@@ -99,3 +99,52 @@ export type GetShoppingListsResponse =
 export type GetShoppingListsReturnValue =
   | { status: 200; json: ResponseShoppingList[] }
   | { status: 500; json: ErrorObject }
+
+/**
+ *
+ * Types used for DELETE /shopping_lists/:id endpoint
+ *
+ */
+
+class DeleteShoppingListSuccessResponse extends ApiResponse {
+  status: 200
+
+  constructor(
+    body,
+    options: { status: 200; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteShoppingListNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteShoppingListErrorResponse extends ApiResponse {
+  status: 405 | 500
+
+  constructor(
+    body,
+    options: { status: 405 | 500; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+export type DeleteShoppingListResponse =
+  | UnauthorizedResponse
+  | DeleteShoppingListSuccessResponse
+  | DeleteShoppingListNotFoundResponse
+  | DeleteShoppingListErrorResponse
+
+export type DeleteShoppingListReturnValue =
+  | { status: 200; json: ResponseShoppingList[] }
+  | { status: 405 | 500; json: ErrorObject }

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -7,6 +7,7 @@ import {
 import {
   postShoppingLists,
   getShoppingLists,
+  deleteShoppingList,
 } from './wrapper/shoppingListEndpoints'
 
 export {
@@ -16,4 +17,5 @@ export {
   deleteGame,
   postShoppingLists,
   getShoppingLists,
+  deleteShoppingList,
 }

--- a/src/utils/api/wrapper/shoppingListEndpoints.ts
+++ b/src/utils/api/wrapper/shoppingListEndpoints.ts
@@ -5,12 +5,15 @@ import {
   type PostShoppingListsReturnValue,
   type GetShoppingListsResponse,
   type GetShoppingListsReturnValue,
+  type DeleteShoppingListResponse,
+  type DeleteShoppingListReturnValue,
 } from '../returnValues/shoppingLists'
 import {
   AuthorizationError,
-  InternalServerError,
   NotFoundError,
+  MethodNotAllowedError,
   UnprocessableEntityError,
+  InternalServerError,
 } from '../apiErrors'
 
 /**
@@ -72,6 +75,38 @@ export const getShoppingLists = (
     return response.json().then((json) => {
       const returnValue = { status: response.status, json }
 
+      if (returnValue.status === 500)
+        throw new InternalServerError(json.errors.join(', '))
+
+      return returnValue
+    })
+  })
+}
+
+/**
+ *
+ * DELETE /shopping_lists/:id endpoint
+ *
+ */
+
+export const deleteShoppingList = (
+  listId: number,
+  token: string
+): Promise<DeleteShoppingListReturnValue> | never => {
+  const uri = `${BASE_URI}/shopping_lists/${listId}`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, { method: 'DELETE', headers }).then((res) => {
+    const response = res as DeleteShoppingListResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+
+    return response.json().then((json) => {
+      const returnValue = { status: response.status, json }
+
+      if (returnValue.status === 405)
+        throw new MethodNotAllowedError(json.errors.join(', '))
       if (returnValue.status === 500)
         throw new InternalServerError(json.errors.join(', '))
 


### PR DESCRIPTION
## Context

[**Rewrite Shopping Lists page**](https://trello.com/c/oBVGCwU1/232-rewrite-shopping-lists-page)

The next step on the rewrite of the shopping lists page is to allow shopping lists to be deleted from that page. This PR adds that capability.

## Changes

* Add the `canEdit` prop to the `ShoppingList` component
* Give shopping lists a delete icon if `canEdit` is true
* Update the `ShoppingListGrouping` component to set `canEdit` to `true` on all non-aggregate lists
* Add functions to the `simApi` module and `ShoppingListsContext` to destroy lists
* Add additional response types and return value type for shopping list deletion
* Create new `MethodNotAllowedError` class to handle 405 responses (which should never actually be received when destroying lists through the UI)
* Add and update tests and Storybook stories

## Manual Test Cases

For each test case, you will need to have games in the SIM back end. Some of these games will need to have shopping lists. You can create the games and their shopping lists either through the UI. The test cases do not indicate that you will need to do this - they only tell how many shopping lists a game should have

### Cancelling 

1. Log into the front end
2. Visit the shopping lists page
3. Select a game with shopping lists
5. See that there is an X icon to the left of the titles of all regular (non-aggregate) shopping lists
7. See that there is no X icon next to the aggregate list's title
8. Click the X icon for one of the shopping lists
9. See that you are prompted to confirm whether you want to delete the list
10. Click cancel
11. See that all lists are still present on the page
12. See that there is a flash info message saying your list will not be destroyed
13. Verify on the back end that no DELETE request was made

### Destroying the Last Regular List

1. Log into the front end
2. Visit the shopping lists page
3. Select a game with two shopping lists (i.e., one regular, one aggregate)
4. Click the X icon next to the title of the regular shopping list
5. When you are prompted to confirm, click OK
6. See that both shopping lists are deleted and replaced by a message that the game has no shopping lists
7. See a flash success message indicating your list was successfully deleted
8. Verify in the Rails console that the list and its aggregate list have been destroyed

### Destroying One of Multiple Regular Lists

1. Log into the front end
2. Visit the shopping lists page
3. Select a game with multiple regular (non-aggregate) shopping lists
4. Click the X icon next to the title of one shopping list
5. When you are prompted to confirm, click OK
6. See that the shopping list you deleted has been deleted
7. See that the aggregate list and other shopping list(s) are still there
8. See a flash success message indicating your list was successfully destroyed

### Handling a 404 Error

This has to be tested manually because there's no practical way to test it on an automated basis.

1. Log into the front end
2. Visit the shopping lists page
3. Select a game with shopping lists
4. Open a new tab and do the same, selecting the same game
5. In the first tab, delete one of the shopping lists
6. In the second tab, without refreshing, delete the same shopping list
7. See that the shopping list is not removed
8. See a flash error message indicating the shopping list requested does not exist or does not belong to you and advising you to refresh

An alternative approach would be, instead of opening two tabs, to load the shopping lists page in one tab and then delete one of that game's shopping lists in the Rails console. However, the approach given in the steps above mimics how this would affect an actual user, so it is the preferred approach

### Handling a 500 error

1. Log into the front end
2. Visit the shopping lists page
3. Select a game with shopping lists
4. On the back end, edit the `ShoppingListsController::DestroyService` so that its `perform` method always raises a standard error with a particular message
5. Click the X icon next to the title of one of the game's shopping lists
6. When prompted to confirm, click OK
7. See that no lists are removed from the page
8. See a flash error message indicating something unexpected has gone wrong
9. See that the error message is friendly to a nontechnical user and doesn't include the error message sent from the server

## Screenshots and GIFs

### 320px

<img width="320" alt="ShoppingLists-320" src="https://user-images.githubusercontent.com/5115928/226217019-1770b7e7-c8c6-4057-8426-1f15acf43e4e.png">

### 481px

<img width="481" alt="ShoppingLists-481" src="https://user-images.githubusercontent.com/5115928/226217027-03847b89-8471-468c-86cc-40918f542696.png">

### 601px

<img width="602" alt="ShoppingLists-601" src="https://user-images.githubusercontent.com/5115928/226217039-c26c2de9-2420-4238-94b5-d1248d4714eb.png">

### 769px

<img width="769" alt="ShoppingLists-769" src="https://user-images.githubusercontent.com/5115928/226217041-a1094938-81f2-4fa2-bec7-6832ce0e7c85.png">

### 1025px

<img width="1025" alt="ShoppingLists-1025" src="https://user-images.githubusercontent.com/5115928/226217048-1d503b98-97c9-4216-8b67-fd096b0b98fc.png">

### 1201px

<img width="1201" alt="ShoppingLists-1201" src="https://user-images.githubusercontent.com/5115928/226217055-0af8e3a8-ed7e-4f12-a8ed-29535e8ab2eb.png">

### 1405px

<img width="1405" alt="ShoppingLists-1405" src="https://user-images.githubusercontent.com/5115928/226217061-91908fcd-ec55-493d-9abc-2c8c2d19b133.png">

### Large Desktop

<img width="1920" alt="ShoppingLists-Full" src="https://user-images.githubusercontent.com/5115928/226217071-a6e8cf4e-a917-445f-88e8-081e743b3021.png">
