### PR TITLE
Tweak list creation logic to reflect new response bodies from API

### DIFF
--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -114,7 +114,14 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
         postShoppingLists(activeGame, attributes, token)
           .then(({ json }) => {
             if (Array.isArray(json)) {
-              setShoppingLists(json)
+              if (json.length == 2) {
+                setShoppingLists(json)
+              } else {
+                const newShoppingLists = shoppingLists
+                newShoppingLists.splice(1, 0, json[0])
+                setShoppingLists(newShoppingLists)
+              }
+
               setFlashProps({
                 hidden: false,
                 type: 'success',
@@ -139,7 +146,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
           })
       }
     },
-    [user, token, activeGame]
+    [user, token, activeGame, shoppingLists]
   )
 
   /**

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -312,6 +312,37 @@ describe('ShoppingListsPage', () => {
             expect(wrapper.getByText('Smithing Materials')).toBeTruthy()
           })
         })
+
+        test("doesn't remove existing lists", async () => {
+          const wrapper = renderAuthenticated(
+            <PageProvider>
+              <GamesProvider>
+                <ShoppingListsProvider>
+                  <ShoppingListsPage />
+                </ShoppingListsProvider>
+              </GamesProvider>
+            </PageProvider>
+          )
+
+          const input = wrapper.getByPlaceholderText('Title')
+          const button = wrapper.getByText('Create')
+
+          await waitFor(() => {
+            expect(input.attributes.getNamedItem('disabled')).toBeFalsy()
+
+            fireEvent.change(input, { target: { value: 'Smithing Materials' } })
+          })
+
+          act(() => fireEvent.click(button))
+
+          await waitFor(() => {
+            expect(
+              wrapper.getByText('Success! Your shopping list has been created.')
+            ).toBeTruthy()
+            expect(wrapper.getByText('All Items')).toBeTruthy()
+            expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
+          })
+        })
       })
 
       describe('when there is no existing aggregate list', () => {

--- a/src/support/msw/helpers/data.ts
+++ b/src/support/msw/helpers/data.ts
@@ -29,20 +29,18 @@ export const newShoppingList = (
       'Cannot generate single list for game without existing aggregate'
     )
 
-  const newList = {
-    id: 93,
-    game_id: gameId,
-    aggregate: false,
-    aggregate_list_id: existingLists[0].id,
-    title: attributes.title || 'New Shopping List',
-    list_items: [],
-    created_at: new Date(),
-    updated_at: new Date(),
-  }
-
-  existingLists.splice(1, 0, newList)
-
-  return existingLists
+  return [
+    {
+      id: 93,
+      game_id: gameId,
+      aggregate: false,
+      aggregate_list_id: existingLists[0].id,
+      title: attributes.title || 'New Shopping List',
+      list_items: [],
+      created_at: new Date(),
+      updated_at: new Date(),
+    },
+  ]
 }
 
 export const newShoppingListWithAggregate = (

--- a/src/support/msw/shoppingLists.ts
+++ b/src/support/msw/shoppingLists.ts
@@ -1,8 +1,4 @@
 import { rest } from 'msw'
-import {
-  type RequestShoppingList,
-  type ResponseShoppingList,
-} from '../../types/apiData'
 import { allGames } from '../data/games'
 import { allShoppingLists } from '../data/shoppingLists'
 import { shoppingListsForGame } from '../data/shoppingLists'
@@ -10,7 +6,6 @@ import { newShoppingList, newShoppingListWithAggregate } from './helpers/data'
 
 const BASE_URI = 'http://localhost:3000'
 const gameIds = allGames.map(({ id }) => id)
-const shoppingListIds = allShoppingLists.map(({ id }) => id)
 
 /**
  *


### PR DESCRIPTION
## Context

[**Return only created shopping lists from creation endpoint**](263-return-only-created-shopping-lists-from-creation-endpoint)

We realised that the newly-minted front-end request bodies in danascheider/skyrim_inventory_management#147 would result in the page getting rearranged a lot when users update lists before creating new ones, since the server would reorder results in order of most recently updated. We don't want shopping lists getting moved around constantly and they should only really change positions on page reload. For that reason, we decided the `POST /games/:game_id/shopping_lists` endpoint should only return the shopping list(s) created during the course of handling the request. This necessitated adding a little front-end logic to either set the `shoppingLists` array to both returned lists (if an aggregate list is also created at the same time) or to insert the newly created lists in the `shoppingLists` array just after the aggregate list.

## Changes

* Update `createShoppingList` function to handle new API response bodies
* Update tests and test data

## Manual Test Cases

You will want to test four basic cases:

1. Creating a shopping list on the default game (i.e., when the `gameId` query param is not set) when it has no other shopping lists
2. Creating a shopping list on the default game (i.e., when the `gameId` query param is not set) when it has other shopping lists
3. Creating a shopping list with the `gameId` query param set when there are no other shopping lists for that game
4. Creating a shopping list with the `gameId` query param set when there are other shopping lists for that game

If you want the default game to not having shopping lists, you can either delete all the shopping lists for an existing game or create a new game that will be created with no shopping lists and bumped to the top of the list.

### Without Existing Shopping Lists

In both tests, what you are looking for is that both the list you've requested to create and the new aggregate ("All Items") list appear on the page when the request resolves. The aggregate list should come first. If it does not, this could be a problem with the back end as well as the front end, so you will want to investigate both.

### With Existing Shopping Lists

In both tests, what you are looking for is that the new list you've requested to create is added to the page just below the aggregate list. The colour scheme order should remain the same - i.e., the `All Items` list should be yellow, your new list should be pink, the next-most-recently updated list should be blue, then green, then aqua, after which the cycle should repeat for any new lists.

## Screenshots and GIFs

Changes made in this PR have no visible representation on the current app. They will only make a visible difference once the capability to manage list items has been added.