### PR TITLE
Accommodate new response body from DELETE endpoint

### DIFF
--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -58,9 +58,9 @@ const ShoppingList = ({
 
   const toggleDetails: MouseEventHandler = (e) => {
     if (
-      deleteRef.current &&
-      deleteRef.current !== e.target &&
-      !deleteRef.current.contains(e.target as Node)
+      !deleteRef.current ||
+      (deleteRef.current !== e.target &&
+        !deleteRef.current.contains(e.target as Node))
     ) {
       setExpanded(!expanded)
     }

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -215,8 +215,6 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
             } else {
               const newShoppingLists = shoppingLists
 
-              console.warn('NEW SHOPPING LISTS: ', newShoppingLists)
-
               if (json.aggregate) newShoppingLists[0] = json.aggregate
 
               for (const deletedId of json.deleted) {

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -494,7 +494,7 @@ describe('ShoppingListsPage', () => {
 
       describe('when the user confirms deletion', () => {
         describe('when the game has no other regular shopping lists', () => {
-          test('resets the shoppingLists array to the empty response value', async () => {
+          test('removes the aggregate list too', async () => {
             const wrapper = renderAuthenticated(
               <PageProvider>
                 <GamesProvider>

--- a/src/support/msw/shoppingLists.ts
+++ b/src/support/msw/shoppingLists.ts
@@ -97,11 +97,19 @@ export const deleteShoppingList = rest.delete(
 
     const lists = shoppingListsForGame(list.game_id)
 
-    if (lists.length === 2) return res(ctx.status(200), ctx.json([]))
+    let json
+    if (lists.length === 2) {
+      json = {
+        deleted: lists.map(({ id }) => id),
+      }
+    } else {
+      json = {
+        deleted: [list.id],
+        aggregate: lists[0],
+      }
+    }
 
-    delete lists[lists.indexOf(list)]
-
-    return res(ctx.status(200), ctx.json(lists.filter((item) => !!item)))
+    return res(ctx.status(200), ctx.json(json))
   }
 )
 

--- a/src/utils/api/returnValues/shoppingLists.d.ts
+++ b/src/utils/api/returnValues/shoppingLists.d.ts
@@ -139,6 +139,11 @@ class DeleteShoppingListErrorResponse extends ApiResponse {
   }
 }
 
+interface DeleteShoppingListSuccessResponseBody {
+  deleted: number[]
+  aggregate?: ResponseShoppingList
+}
+
 export type DeleteShoppingListResponse =
   | UnauthorizedResponse
   | DeleteShoppingListSuccessResponse
@@ -146,5 +151,5 @@ export type DeleteShoppingListResponse =
   | DeleteShoppingListErrorResponse
 
 export type DeleteShoppingListReturnValue =
-  | { status: 200; json: ResponseShoppingList[] }
+  | { status: 200; json: DeleteShoppingListSuccessResponseBody }
   | { status: 405 | 500; json: ErrorObject }


### PR DESCRIPTION
## Context

[**Rewrite Shopping Lists page**](https://trello.com/c/oBVGCwU1/232-rewrite-shopping-lists-page)

Previously, we made it possible to delete a shopping list from the shopping lists page. Subsequently, however, we realised that the response bodies we were sending from the API were problematic in that they would lead to [frequent rearrangement](https://trello.com/c/GO0zCmKC/262-determine-best-approach-to-updating-aggregatable-models) of shopping lists on the page. So, we rewrote the endpoint handler on the API side to return a different response body. Now, instead of returning all shopping lists for the specified game, we return a JSON object containing a `"deleted"` array containing the IDs of all deleted shopping lists as well as an (optional) `"aggregate"` key containing the aggregate shopping list and its list items, if it still exists.

This PR updates front-end code to handle these new responses from the back end.

## Changes

* Update API data types to reflect new possible response bodies from the DELETE /shopping_lists/:id endpoint
* Update test data and MSW handlers to reflect the new body shape
* Modify the `ShoppingListsContext` to properly handle responses from the endpoint
* Update tests

## Considerations

This resulted in a lot of new code being added to the `ShoppingListsContext`, which was less than ideal. We will keep an eye on changes in other functions to see if we can extract any functions or modules that would clean this up. For now, though, there's just a good amount of extra code in the `destroyShoppingList` function. I don't love it, but I couldn't think of a better way to fulfil the requirements.

## Manual Test Cases

Go through manual tests cases for [this PR](https://github.com/danascheider/skyrim_inventory_management_frontend/pull/37). There should be no visible differences to a user.