### PR TITLE
Enable shopping list items to be destroyed from shopping lists page

### DIFF
--- a/docs/contexts/shopping-lists-context.md
+++ b/docs/contexts/shopping-lists-context.md
@@ -17,6 +17,15 @@ The `ShoppingListsContext` keeps track of the active game and its shopping lists
   - `listId`: the `id` of the shopping list to be destroyed
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
+- `createShoppingListItem`: a function that creates a shopping list item on the selected shopping list at the API, taking the following arguments:
+  - `listId`: the `id` of the list on which to create the shopping list item
+  - `attributes`: the attributes of the item to be created (required attributes are `description` (string) and `quantity` (number))
+  - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
+  - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
+- `destroyShoppingListItem`: a function that destroys the selected shopping list at the API, taking the following arguments:
+  - `itemId`: the `id` of the shopping list item to be destroyed
+  - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
+  - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
 
 Note that, while the context tracks the active game, this information is internal to the context. The active game is identified using the `gameId` query string parameter, which is typically set using the games dropdown component found on the `DashboardLayout`.
 

--- a/src/components/shoppingList/shoppingList.stories.tsx
+++ b/src/components/shoppingList/shoppingList.stories.tsx
@@ -51,6 +51,7 @@ export const EditableWithListItems = () => (
           description="Steel Ingot"
           quantity={5}
           unitWeight={1.0}
+          canEdit
         />
         <ShoppingListItem
           itemId={2}
@@ -58,6 +59,7 @@ export const EditableWithListItems = () => (
           quantity={200000000000}
           unitWeight={400000000000}
           notes="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet velit adipsci"
+          canEdit
         />
       </ShoppingList>
     </ColorProvider>

--- a/src/components/shoppingList/shoppingList.test.tsx
+++ b/src/components/shoppingList/shoppingList.test.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vitest } from 'vitest'
 import { act, fireEvent } from '@testing-library/react'
 import { renderAuthenticated } from '../../support/testUtils'
 import {
@@ -217,7 +217,7 @@ describe('ShoppingList', () => {
     })
 
     describe('when the user cancels deletion', () => {
-      test("calls the context's destroyShoppingList function with its listId", () => {
+      test("doesn't call the destroyShoppingList function", () => {
         const destroyShoppingList = vitest.fn()
         listContextValue = { ...shoppingListsContextValue, destroyShoppingList }
 

--- a/src/components/shoppingListGrouping/__snapshots__/shoppingListGrouping.test.tsx.snap
+++ b/src/components/shoppingListGrouping/__snapshots__/shoppingListGrouping.test.tsx.snap
@@ -417,8 +417,32 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                       role="button"
                     >
                       <span
-                        class="_descriptionContainer_fccc8d"
+                        class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                       >
+                        <span
+                          class="_editIcons_fccc8d"
+                        >
+                          <button
+                            class="_icon_fccc8d"
+                            data-testid="destroyShoppingListItem8"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="svg-inline--fa fa-xmark _fa_fccc8d"
+                              data-icon="xmark"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 384 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                         <h3
                           class="_description_fccc8d"
                         >
@@ -478,8 +502,32 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                       role="button"
                     >
                       <span
-                        class="_descriptionContainer_fccc8d"
+                        class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                       >
+                        <span
+                          class="_editIcons_fccc8d"
+                        >
+                          <button
+                            class="_icon_fccc8d"
+                            data-testid="destroyShoppingListItem5"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="svg-inline--fa fa-xmark _fa_fccc8d"
+                              data-icon="xmark"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 384 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                         <h3
                           class="_description_fccc8d"
                         >
@@ -711,8 +759,32 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                       role="button"
                     >
                       <span
-                        class="_descriptionContainer_fccc8d"
+                        class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                       >
+                        <span
+                          class="_editIcons_fccc8d"
+                        >
+                          <button
+                            class="_icon_fccc8d"
+                            data-testid="destroyShoppingListItem7"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="svg-inline--fa fa-xmark _fa_fccc8d"
+                              data-icon="xmark"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 384 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                         <h3
                           class="_description_fccc8d"
                         >
@@ -1281,8 +1353,32 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                     role="button"
                   >
                     <span
-                      class="_descriptionContainer_fccc8d"
+                      class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                     >
+                      <span
+                        class="_editIcons_fccc8d"
+                      >
+                        <button
+                          class="_icon_fccc8d"
+                          data-testid="destroyShoppingListItem8"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-xmark _fa_fccc8d"
+                            data-icon="xmark"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 384 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </button>
+                      </span>
                       <h3
                         class="_description_fccc8d"
                       >
@@ -1342,8 +1438,32 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                     role="button"
                   >
                     <span
-                      class="_descriptionContainer_fccc8d"
+                      class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                     >
+                      <span
+                        class="_editIcons_fccc8d"
+                      >
+                        <button
+                          class="_icon_fccc8d"
+                          data-testid="destroyShoppingListItem5"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-xmark _fa_fccc8d"
+                            data-icon="xmark"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 384 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </button>
+                      </span>
                       <h3
                         class="_description_fccc8d"
                       >
@@ -1575,8 +1695,32 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                     role="button"
                   >
                     <span
-                      class="_descriptionContainer_fccc8d"
+                      class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                     >
+                      <span
+                        class="_editIcons_fccc8d"
+                      >
+                        <button
+                          class="_icon_fccc8d"
+                          data-testid="destroyShoppingListItem7"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-xmark _fa_fccc8d"
+                            data-icon="xmark"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 384 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </button>
+                      </span>
                       <h3
                         class="_description_fccc8d"
                       >

--- a/src/components/shoppingListGrouping/shoppingListGrouping.test.tsx
+++ b/src/components/shoppingListGrouping/shoppingListGrouping.test.tsx
@@ -58,6 +58,24 @@ describe('ShoppingListGrouping', () => {
       expect(wrapper.queryByTestId('destroyShoppingList3')).toBeFalsy()
     })
 
+    test('displays the destroy icon for editable list items only', () => {
+      const wrapper = renderAuthenticated(
+        <PageProvider>
+          <GamesContext.Provider value={gamesContextValue}>
+            <ShoppingListsContext.Provider value={shoppingListsContextValue}>
+              <ShoppingListGrouping />
+            </ShoppingListsContext.Provider>
+          </GamesContext.Provider>
+        </PageProvider>
+      )
+
+      expect(wrapper.queryByTestId('destroyShoppingListItem6')).toBeFalsy()
+      expect(wrapper.queryByTestId('destroyShoppingListItem9')).toBeFalsy()
+      expect(wrapper.getByTestId('destroyShoppingListItem7')).toBeTruthy()
+      expect(wrapper.getByTestId('destroyShoppingListItem8')).toBeTruthy()
+      expect(wrapper.getByTestId('destroyShoppingListItem5')).toBeTruthy()
+    })
+
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>

--- a/src/components/shoppingListGrouping/shoppingListGrouping.tsx
+++ b/src/components/shoppingListGrouping/shoppingListGrouping.tsx
@@ -35,6 +35,7 @@ const ShoppingListGrouping = () => {
                           quantity={quantity}
                           unitWeight={unit_weight}
                           notes={notes}
+                          canEdit={!aggregate}
                         />
                       )
                     }

--- a/src/components/shoppingListItem/__snapshots__/shoppingListItem.test.tsx.snap
+++ b/src/components/shoppingListItem/__snapshots__/shoppingListItem.test.tsx.snap
@@ -1,6 +1,239 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ShoppingListItem > matches snapshot 1`] = `
+exports[`ShoppingListItem > displaying the list item > when the list item is editable > matches snapshot 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="_root_fccc8d"
+        style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
+      >
+        <div
+          aria-controls="shoppingListItem2Details"
+          aria-expanded="false"
+          class="_trigger_fccc8d"
+          role="button"
+        >
+          <span
+            class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
+          >
+            <span
+              class="_editIcons_fccc8d"
+            >
+              <button
+                class="_icon_fccc8d"
+                data-testid="destroyShoppingListItem2"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-xmark _fa_fccc8d"
+                  data-icon="xmark"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 384 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </span>
+            <h3
+              class="_description_fccc8d"
+            >
+              Silver Necklace
+            </h3>
+          </span>
+          <span
+            class="_quantity_fccc8d"
+          >
+            2
+          </span>
+        </div>
+        <div
+          aria-hidden="true"
+          class="rah-static rah-static--height-zero "
+          id="shoppingListItem2Details"
+          style="height: 0px; overflow: hidden;"
+        >
+          <div
+            style="display: none;"
+          >
+            <div
+              class="_details_fccc8d"
+            >
+              <h4
+                class="_label_fccc8d"
+              >
+                Unit Weight:
+              </h4>
+              <p
+                class="_value_fccc8d"
+              >
+                0.3
+              </p>
+              <h4
+                class="_label_fccc8d"
+              >
+                Notes:
+              </h4>
+              <p
+                class="_value_fccc8d"
+              >
+                To enchant
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="_root_fccc8d"
+      style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
+    >
+      <div
+        aria-controls="shoppingListItem2Details"
+        aria-expanded="false"
+        class="_trigger_fccc8d"
+        role="button"
+      >
+        <span
+          class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
+        >
+          <span
+            class="_editIcons_fccc8d"
+          >
+            <button
+              class="_icon_fccc8d"
+              data-testid="destroyShoppingListItem2"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark _fa_fccc8d"
+                data-icon="xmark"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 384 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </span>
+          <h3
+            class="_description_fccc8d"
+          >
+            Silver Necklace
+          </h3>
+        </span>
+        <span
+          class="_quantity_fccc8d"
+        >
+          2
+        </span>
+      </div>
+      <div
+        aria-hidden="true"
+        class="rah-static rah-static--height-zero "
+        id="shoppingListItem2Details"
+        style="height: 0px; overflow: hidden;"
+      >
+        <div
+          style="display: none;"
+        >
+          <div
+            class="_details_fccc8d"
+          >
+            <h4
+              class="_label_fccc8d"
+            >
+              Unit Weight:
+            </h4>
+            <p
+              class="_value_fccc8d"
+            >
+              0.3
+            </p>
+            <h4
+              class="_label_fccc8d"
+            >
+              Notes:
+            </h4>
+            <p
+              class="_value_fccc8d"
+            >
+              To enchant
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`ShoppingListItem > displaying the list item > when the list item is not editable > matches snapshot 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>

--- a/src/components/shoppingListItem/shoppingListItem.module.css
+++ b/src/components/shoppingListItem/shoppingListItem.module.css
@@ -17,7 +17,7 @@
   border-bottom: 1px solid var(--border-color);
   cursor: pointer;
   display: grid;
-  grid-template-columns: 60% 40%;
+  grid-template-columns: 70% 30%;
 }
 
 .quantity {
@@ -32,6 +32,35 @@
 
 .descriptionContainer {
   border-right: 1px solid var(--border-color);
+}
+
+.descriptionContainerEditable {
+  display: grid;
+  grid-template-columns: 15% 85%;
+  align-items: center;
+}
+
+.editIcons {
+  display: flex;
+  flex-direction: row;
+  padding: 4px 8px;
+}
+
+.icon {
+  display: inline-block;
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.icon:hover .fa {
+  color: var(--body-background-color);
+}
+
+.fa {
+  color: var(--title-text-color);
 }
 
 .description {
@@ -59,8 +88,14 @@
   line-height: 1.25;
 }
 
-@media (min-width: 769px) {
-  .trigger {
-    grid-template-columns: 70% 30%;
+@media (min-width: 481px) {
+  .descriptionContainerEditable {
+    grid-template-columns: 10% 90%;
+  }
+}
+
+@media (min-width: 1025px) {
+  .descriptionContainerEditable {
+    grid-template-columns: 7% 93%;
   }
 }

--- a/src/components/shoppingListItem/shoppingListItem.stories.tsx
+++ b/src/components/shoppingListItem/shoppingListItem.stories.tsx
@@ -89,23 +89,27 @@ export const LongValuesNotEditable = () => (
 )
 
 export const EmptyFields = () => (
-  <ColorProvider colorScheme={GREEN}>
-    <ShoppingListItem
-      itemId={1}
-      description="Dwarven metal ingot"
-      quantity={5}
-    />
-  </ColorProvider>
+  <ContextProviders>
+    <ColorProvider colorScheme={GREEN}>
+      <ShoppingListItem
+        itemId={1}
+        description="Dwarven metal ingot"
+        quantity={5}
+      />
+    </ColorProvider>
+  </ContextProviders>
 )
 
 export const UnitWeightWithDecimal = () => (
-  <ColorProvider colorScheme={PINK}>
-    <ShoppingListItem
-      itemId={1}
-      description="Necklace"
-      quantity={1}
-      unitWeight={0.3}
-      notes="To enchant with fire resistance"
-    />
-  </ColorProvider>
+  <ContextProviders>
+    <ColorProvider colorScheme={PINK}>
+      <ShoppingListItem
+        itemId={1}
+        description="Necklace"
+        quantity={1}
+        unitWeight={0.3}
+        notes="To enchant with fire resistance"
+      />
+    </ColorProvider>
+  </ContextProviders>
 )

--- a/src/components/shoppingListItem/shoppingListItem.stories.tsx
+++ b/src/components/shoppingListItem/shoppingListItem.stories.tsx
@@ -1,31 +1,91 @@
-import { AQUA, BLUE, GREEN, PINK } from '../../utils/colorSchemes'
+import {
+  loginContextValue,
+  gamesContextValue,
+  shoppingListsContextValue,
+} from '../../support/data/contextValues'
+import { AQUA, BLUE, GREEN, PINK, YELLOW } from '../../utils/colorSchemes'
+import { LoginContext } from '../../contexts/loginContext'
+import { PageProvider } from '../../contexts/pageContext'
+import { ReactElement } from 'react'
+import { GamesContext } from '../../contexts/gamesContext'
+import { ShoppingListsContext } from '../../contexts/shoppingListsContext'
 import { ColorProvider } from '../../contexts/colorContext'
 import ShoppingListItem from './shoppingListItem'
 
-export default { title: 'ShoppingListItem' }
+interface ProviderProps {
+  children: ReactElement
+}
 
-export const Default = () => (
-  <ColorProvider colorScheme={AQUA}>
-    <ShoppingListItem
-      itemId={1}
-      description="Dwarven metal ingot"
-      quantity={5}
-      unitWeight={1.0}
-      notes="To make bolts"
-    />
-  </ColorProvider>
+const ContextProviders = ({ children }: ProviderProps) => (
+  <LoginContext.Provider value={loginContextValue}>
+    <PageProvider>
+      <GamesContext.Provider value={gamesContextValue}>
+        <ShoppingListsContext.Provider value={shoppingListsContextValue}>
+          {children}
+        </ShoppingListsContext.Provider>
+      </GamesContext.Provider>
+    </PageProvider>
+  </LoginContext.Provider>
 )
 
-export const LongValues = () => (
-  <ColorProvider colorScheme={BLUE}>
-    <ShoppingListItem
-      itemId={1}
-      description="This item has a really really really really really long description for testing purposes"
-      quantity={200000000000000000}
-      unitWeight={4000000000000000.0}
-      notes="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit"
-    />
-  </ColorProvider>
+export default { title: 'ShoppingListItem' }
+
+export const Editable = () => (
+  <ContextProviders>
+    <ColorProvider colorScheme={AQUA}>
+      <ShoppingListItem
+        itemId={1}
+        description="Dwarven metal ingot"
+        quantity={5}
+        unitWeight={1.0}
+        notes="To make bolts"
+        canEdit
+      />
+    </ColorProvider>
+  </ContextProviders>
+)
+
+export const NotEditable = () => (
+  <ContextProviders>
+    <ColorProvider colorScheme={YELLOW}>
+      <ShoppingListItem
+        itemId={1}
+        description="Dwarven metal ingot"
+        quantity={5}
+        unitWeight={1.0}
+        notes="To make bolts"
+      />
+    </ColorProvider>
+  </ContextProviders>
+)
+
+export const LongValuesEditable = () => (
+  <ContextProviders>
+    <ColorProvider colorScheme={BLUE}>
+      <ShoppingListItem
+        itemId={1}
+        description="This item has a really really really really really long description for testing purposes"
+        quantity={200000000000000000}
+        unitWeight={4000000000000000.0}
+        notes="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit"
+        canEdit
+      />
+    </ColorProvider>
+  </ContextProviders>
+)
+
+export const LongValuesNotEditable = () => (
+  <ContextProviders>
+    <ColorProvider colorScheme={AQUA}>
+      <ShoppingListItem
+        itemId={1}
+        description="This item has a really really really really really long description for testing purposes"
+        quantity={200000000000000000}
+        unitWeight={4000000000000000.0}
+        notes="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit"
+      />
+    </ColorProvider>
+  </ContextProviders>
 )
 
 export const EmptyFields = () => (

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -429,7 +429,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               setFlashProps({
                 hidden: false,
                 type: 'success',
-                message: 'Success! Your shopping list item was deleted.',
+                message: 'Success! Your shopping list item has been deleted.',
               })
 
               onSuccess && onSuccess()

--- a/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
+++ b/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
@@ -850,8 +850,32 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                           role="button"
                         >
                           <span
-                            class="_descriptionContainer_fccc8d"
+                            class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                           >
+                            <span
+                              class="_editIcons_fccc8d"
+                            >
+                              <button
+                                class="_icon_fccc8d"
+                                data-testid="destroyShoppingListItem8"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="svg-inline--fa fa-xmark _fa_fccc8d"
+                                  data-icon="xmark"
+                                  data-prefix="fas"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 384 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </button>
+                            </span>
                             <h3
                               class="_description_fccc8d"
                             >
@@ -911,8 +935,32 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                           role="button"
                         >
                           <span
-                            class="_descriptionContainer_fccc8d"
+                            class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                           >
+                            <span
+                              class="_editIcons_fccc8d"
+                            >
+                              <button
+                                class="_icon_fccc8d"
+                                data-testid="destroyShoppingListItem5"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="svg-inline--fa fa-xmark _fa_fccc8d"
+                                  data-icon="xmark"
+                                  data-prefix="fas"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 384 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </button>
+                            </span>
                             <h3
                               class="_description_fccc8d"
                             >
@@ -1144,8 +1192,32 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                           role="button"
                         >
                           <span
-                            class="_descriptionContainer_fccc8d"
+                            class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                           >
+                            <span
+                              class="_editIcons_fccc8d"
+                            >
+                              <button
+                                class="_icon_fccc8d"
+                                data-testid="destroyShoppingListItem7"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="svg-inline--fa fa-xmark _fa_fccc8d"
+                                  data-icon="xmark"
+                                  data-prefix="fas"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 384 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </button>
+                            </span>
                             <h3
                               class="_description_fccc8d"
                             >
@@ -1921,8 +1993,32 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                         role="button"
                       >
                         <span
-                          class="_descriptionContainer_fccc8d"
+                          class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                         >
+                          <span
+                            class="_editIcons_fccc8d"
+                          >
+                            <button
+                              class="_icon_fccc8d"
+                              data-testid="destroyShoppingListItem8"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="svg-inline--fa fa-xmark _fa_fccc8d"
+                                data-icon="xmark"
+                                data-prefix="fas"
+                                focusable="false"
+                                role="img"
+                                viewBox="0 0 384 512"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </button>
+                          </span>
                           <h3
                             class="_description_fccc8d"
                           >
@@ -1982,8 +2078,32 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                         role="button"
                       >
                         <span
-                          class="_descriptionContainer_fccc8d"
+                          class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                         >
+                          <span
+                            class="_editIcons_fccc8d"
+                          >
+                            <button
+                              class="_icon_fccc8d"
+                              data-testid="destroyShoppingListItem5"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="svg-inline--fa fa-xmark _fa_fccc8d"
+                                data-icon="xmark"
+                                data-prefix="fas"
+                                focusable="false"
+                                role="img"
+                                viewBox="0 0 384 512"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </button>
+                          </span>
                           <h3
                             class="_description_fccc8d"
                           >
@@ -2215,8 +2335,32 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                         role="button"
                       >
                         <span
-                          class="_descriptionContainer_fccc8d"
+                          class="_descriptionContainer_fccc8d _descriptionContainerEditable_fccc8d"
                         >
+                          <span
+                            class="_editIcons_fccc8d"
+                          >
+                            <button
+                              class="_icon_fccc8d"
+                              data-testid="destroyShoppingListItem7"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="svg-inline--fa fa-xmark _fa_fccc8d"
+                                data-icon="xmark"
+                                data-prefix="fas"
+                                focusable="false"
+                                role="img"
+                                viewBox="0 0 384 512"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </button>
+                          </span>
                           <h3
                             class="_description_fccc8d"
                           >

--- a/src/support/data/contextValues.ts
+++ b/src/support/data/contextValues.ts
@@ -86,6 +86,7 @@ export const shoppingListsContextValueEmpty: ShoppingListsContextType = {
   updateShoppingList: noop,
   destroyShoppingList: noop,
   createShoppingListItem: noop,
+  destroyShoppingListItem: noop,
 }
 
 export const shoppingListsContextValue: ShoppingListsContextType = {
@@ -95,6 +96,7 @@ export const shoppingListsContextValue: ShoppingListsContextType = {
   updateShoppingList: noop,
   destroyShoppingList: noop,
   createShoppingListItem: noop,
+  destroyShoppingListItem: noop,
 }
 
 export const shoppingListsContextValueLoading: ShoppingListsContextType = {
@@ -104,6 +106,7 @@ export const shoppingListsContextValueLoading: ShoppingListsContextType = {
   updateShoppingList: noop,
   destroyShoppingList: noop,
   createShoppingListItem: noop,
+  destroyShoppingListItem: noop,
 }
 
 export const shoppingListsContextValueError: ShoppingListsContextType = {
@@ -113,4 +116,5 @@ export const shoppingListsContextValueError: ShoppingListsContextType = {
   updateShoppingList: noop,
   destroyShoppingList: noop,
   createShoppingListItem: noop,
+  destroyShoppingListItem: noop,
 }

--- a/src/support/msw/handlers.ts
+++ b/src/support/msw/handlers.ts
@@ -28,6 +28,8 @@ import {
   postShoppingListItemsSuccess,
   postShoppingListItemsUnprocessable,
   postShoppingListItemsServerError,
+  deleteShoppingListItemSuccess,
+  deleteShoppingListItemServerError,
 } from './shoppingListItems'
 
 export {
@@ -56,4 +58,6 @@ export {
   postShoppingListItemsSuccess,
   postShoppingListItemsUnprocessable,
   postShoppingListItemsServerError,
+  deleteShoppingListItemSuccess,
+  deleteShoppingListItemServerError,
 }

--- a/src/utils/api/returnValues/games.d.ts
+++ b/src/utils/api/returnValues/games.d.ts
@@ -1,5 +1,5 @@
-import { ApiResponse, SuccessStatusCode, HTTPHeaders } from '../http'
-import { ErrorObject, ResponseGame } from '../../../types/apiData'
+import { ApiResponse, type SuccessStatusCode, type HTTPHeaders } from '../http'
+import { type ErrorObject, type ResponseGame } from '../../../types/apiData'
 import { UnauthorizedResponse } from './shared'
 
 /**

--- a/src/utils/api/returnValues/shared.d.ts
+++ b/src/utils/api/returnValues/shared.d.ts
@@ -1,4 +1,4 @@
-import { ApiResponse, HTTPHeaders } from '../http'
+import { ApiResponse, type HTTPHeaders } from '../http'
 
 export class UnauthorizedResponse extends ApiResponse {
   status: 401

--- a/src/utils/api/returnValues/shoppingListItems.d.ts
+++ b/src/utils/api/returnValues/shoppingListItems.d.ts
@@ -1,5 +1,8 @@
-import { ApiResponse, HTTPHeaders } from '../http'
-import { ErrorObject, ResponseShoppingList } from '../../../types/apiData'
+import { ApiResponse, type HTTPHeaders } from '../http'
+import {
+  type ErrorObject,
+  type ResponseShoppingList,
+} from '../../../types/apiData'
 import { UnauthorizedResponse } from './shared'
 
 /**
@@ -54,3 +57,52 @@ export type PostShoppingListItemsResponse =
 export type PostShoppingListItemsReturnValue =
   | { status: 200 | 201; json: ResponseShoppingList[] }
   | { status: 405 | 422 | 500; json: ErrorObject }
+
+/**
+ *
+ * Types used for DELETE /shopping_list_items/:id endpoint
+ *
+ */
+
+class DeleteShoppingListItemSuccessResponse extends ApiResponse {
+  status: 200
+
+  constructor(
+    body,
+    options: { status: 200; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteShoppingListItemNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteShoppingListItemErrorResponse extends ApiResponse {
+  status: 405 | 500
+
+  constructor(
+    body,
+    options: { status: 405 | 500; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+export type DeleteShoppingListItemResponse =
+  | UnauthorizedResponse
+  | DeleteShoppingListItemSuccessResponse
+  | DeleteShoppingListItemNotFoundResponse
+  | DeleteShoppingListItemErrorResponse
+
+export type DeleteShoppingListItemReturnValue =
+  | { status: 200; json: ResponseShoppingList[] }
+  | { status: 405 | 500; json: ErrorObject }

--- a/src/utils/api/returnValues/shoppingLists.d.ts
+++ b/src/utils/api/returnValues/shoppingLists.d.ts
@@ -1,5 +1,8 @@
-import { ApiResponse, HTTPHeaders } from '../http'
-import { ErrorObject, ResponseShoppingList } from '../../../types/apiData'
+import { ApiResponse, type HTTPHeaders } from '../http'
+import {
+  type ErrorObject,
+  type ResponseShoppingList,
+} from '../../../types/apiData'
 import { UnauthorizedResponse } from './shared'
 
 /**

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -10,7 +10,10 @@ import {
   patchShoppingList,
   deleteShoppingList,
 } from './wrapper/shoppingListEndpoints'
-import { postShoppingListItems } from './wrapper/shoppinglistItemEndpoints'
+import {
+  postShoppingListItems,
+  deleteShoppingListItem,
+} from './wrapper/shoppinglistItemEndpoints'
 
 export {
   postGames,
@@ -22,4 +25,5 @@ export {
   patchShoppingList,
   deleteShoppingList,
   postShoppingListItems,
+  deleteShoppingListItem,
 }

--- a/src/utils/api/wrapper/shoppinglistItemEndpoints.ts
+++ b/src/utils/api/wrapper/shoppinglistItemEndpoints.ts
@@ -1,6 +1,8 @@
 import { type RequestShoppingListItem } from '../../../types/apiData'
 import { BASE_URI, combinedHeaders } from '../sharedUtils'
 import {
+  type DeleteShoppingListItemResponse,
+  type DeleteShoppingListItemReturnValue,
   type PostShoppingListItemsResponse,
   type PostShoppingListItemsReturnValue,
 } from '../returnValues/shoppingListItems'
@@ -43,6 +45,38 @@ export const postShoppingListItems = (
         throw new MethodNotAllowedError(json.errors.join(', '))
       if (returnValue.status === 422)
         throw new UnprocessableEntityError(json.errors)
+      if (returnValue.status === 500)
+        throw new InternalServerError(json.errors.join(', '))
+
+      return returnValue
+    })
+  })
+}
+
+/**
+ *
+ * DELETE /shopping_list_items/:id endpoint
+ *
+ */
+
+export const deleteShoppingListItem = (
+  itemId: number,
+  token: string
+): Promise<DeleteShoppingListItemReturnValue> | never => {
+  const uri = `${BASE_URI}/shopping_list_items/${itemId}`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, { method: 'DELETE', headers }).then((res) => {
+    const response = res as DeleteShoppingListItemResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+
+    return response.json().then((json) => {
+      const returnValue = { status: response.status, json }
+
+      if (returnValue.status === 405)
+        throw new MethodNotAllowedError(json.errors.join(', '))
       if (returnValue.status === 500)
         throw new InternalServerError(json.errors.join(', '))
 


### PR DESCRIPTION
## Context

* [**Rewrite Shopping Lists page**](https://trello.com/c/oBVGCwU1/232-rewrite-shopping-lists-page)
* [**Enable shopping list items to be destroyed from shopping lists page**](https://trello.com/c/27gRlHLQ/267-enable-shopping-list-items-to-be-destroyed-from-shopping-lists-page)

We are rewriting the shopping lists page. The next step is to enable list items on editable shopping lists to be deleted by clicking an icon.

## Changes

* Add API wrapper function to delete shopping list items at the API
* Add `destroyShoppingListItem` function to `ShoppingListsContext` to handle API responses in the UI
* Add `canEdit` prop to `ShoppingListItem` component to make list item editable or not
* Add destroy icon to `ShoppingListItem` component when editable
* Tests and stories for the above
* Update docs on `ShoppingListsContext`

## Manual Test Cases

These manual test cases assume you have the back end running locally on the `shopping-lists-page-feature-branch` branch, are signed into the front end, have at least one game with at least one regular shopping list with shopping list items, and are on the shopping lists page with that game selected.

Note that some of these tests test back-end functionality as well.

### UI Checks

1. Expand the aggregate list
2. See that the aggregate list items do not have the X icon next to the description
3. Expand the regular list(s)
4. See that the regular list items do have the X icon next to the description

### Happy Path with Cancellation

1. Expand one of the regular lists
2. Click the X icon next to one of the list item titles
3. When prompted, click cancel
4. See that no items are removed or changed
5. See a flash message that the item will not be destroyed
6. Check the back end logs to verify no DELETE request was made

### Happy Path - Just One Regular List Item

For this test, you will be deleting a list item that only exists on one regular list.

1. Expand one of the regular lists
2. Click the X icon next to the description of a list item that occurs only on that list (and the aggregate list)
3. When prompted, click OK
4. See that the list item has been removed from the list
5. See a flash message indicating the item has been successfully deleted
6. Expand the aggregate list to see that the corresponding item has been removed there as well

### Happy Path - Multiple Regular List Items

For this test, you will be deleting a list item that exists on multiple regular lists.

1. Expand one of the regular lists
2. Click the X icon next to the description of a list item that has a corresponding item on another regular list
3. When prompted, click OK
4. See that the list item has been removed from the regular list
5. See a flash message indicating the item has been successfully deleted
6. Expand the aggregate list
7. See that the quantity and any notes on the aggregate list item have been adjusted to account for the deleted item

### 404 Response

This scenario would only occur if a user had the shopping lists page open in two tabs, deleted an item in one of them, and then attempted to delete the same item in the other without refreshing. You can duplicate this scenario for this test, or you can program the API to always return a 404 error from the `ShoppingListItemsController::DestroyService#perform` method.

1. Program the API to always return a 404 error from the shopping list item deletion endpoint
2. On the front end, expand a regular shopping list
3. Click the X next to any list item description
4. See that the list item is not removed
5. See a flash message that the list item does not exist or doesn't belong to you and advising you to refresh

### 405 Response

This scenario could not occur through the UI without some significant shenanigans on the part of a (probably malicious) user. This test case is included for completeness only. It will involve programming the API's `ShoppingListItemsController::DestroyService#perform` method to always return a 405 error.

1. Program the API to always return a 405 error from the shopping list item deletion endpoint
2. On the front end, expand a regular shopping list
3. Click the X next to any list item description
4. See that the list item is not removed
5. See a flash message that you cannot manage items on an aggregate list

### 500 Response

This scenario is also not expected to occur.

1. Program the API to always return a 500 error from the shopping list item deletion endpoint
2. On the front end, expand a regular shopping list
3. Click the X next to any list item description
4. See that the list item is not removed
5. See a flash message friendly to non-technical users - it should not contain the error message sent back from the server

## Screenshots and GIFs

### 320px

<img width="321" alt="ShoppingLists-320" src="https://user-images.githubusercontent.com/5115928/229257000-05d0f68d-6269-43f9-ab4f-a408695ad637.png">

### 481px

<img width="482" alt="ShoppingLists-481" src="https://user-images.githubusercontent.com/5115928/229257010-0e079177-46d2-4f8c-89d7-bd08190942ae.png">

### 601px

<img width="602" alt="ShoppingLists-601" src="https://user-images.githubusercontent.com/5115928/229257013-3c6b274c-7acd-43c2-b19b-82b675e82b7f.png">

### 769px

<img width="770" alt="ShoppingLists-769" src="https://user-images.githubusercontent.com/5115928/229257019-3d611b7a-37fa-4461-b1f3-3fb2a72550d5.png">

### 1025px

<img width="1026" alt="ShoppingLists-1025" src="https://user-images.githubusercontent.com/5115928/229257025-3ff84e8f-dfc8-41e1-a3c7-7fc473e50efc.png">

### 1201px

<img width="1202" alt="ShoppingLists-1201" src="https://user-images.githubusercontent.com/5115928/229257030-12bf8a2c-554e-4a4e-ad5e-6eb71ba1718a.png">

### 1405px

<img width="1405" alt="ShoppingLists-1405" src="https://user-images.githubusercontent.com/5115928/229257034-2756cf09-0ba8-458a-afd3-99972dafec8d.png">

### Large Desktop

<img width="1920" alt="ShoppingLists-Full" src="https://user-images.githubusercontent.com/5115928/229257040-438eca61-8f96-4a4c-84e3-8d29c075cef5.png">