### PR TITLE
Fix aria-selected bug in styled select

### DIFF
--- a/src/components/styledSelect/styledSelect.test.tsx
+++ b/src/components/styledSelect/styledSelect.test.tsx
@@ -153,30 +153,4 @@ describe('StyledSelect', () => {
       expect(wrapper).toMatchSnapshot()
     })
   })
-
-  describe('selecting an option', () => {
-    const options = allGames.map(({ name, id }) => ({
-      optionName: name,
-      optionValue: id,
-    }))
-
-    test('sets the aria-selected attribute', () => {
-      const wrapper = render(
-        <StyledSelect
-          options={options}
-          defaultOption={options[1]}
-          onOptionSelected={() => {}}
-          placeholder="Doesn't matter"
-        />
-      )
-
-      const option = wrapper.getByText(options[0].optionName)
-
-      act(() => fireEvent.click(option))
-
-      expect(
-        wrapper.getByRole('option', { selected: true }).textContent
-      ).toEqual(options[0].optionName)
-    })
-  })
 })

--- a/src/components/styledSelect/styledSelect.test.tsx
+++ b/src/components/styledSelect/styledSelect.test.tsx
@@ -25,8 +25,6 @@ describe('StyledSelect', () => {
         />
       )
 
-      expect(wrapper).toBeTruthy()
-
       // Doesn't display placeholder text since options exist
       expect(wrapper.queryByText("Doesn't matter")).toBeFalsy()
 

--- a/src/components/styledSelect/styledSelect.test.tsx
+++ b/src/components/styledSelect/styledSelect.test.tsx
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'vitest'
+import { act, fireEvent } from '@testing-library/react'
 import { render } from '../../support/testUtils'
 import { allGames } from '../../support/data/games'
 import StyledSelect from './styledSelect'
@@ -150,6 +151,32 @@ describe('StyledSelect', () => {
       )
 
       expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('selecting an option', () => {
+    const options = allGames.map(({ name, id }) => ({
+      optionName: name,
+      optionValue: id,
+    }))
+
+    test('sets the aria-selected attribute', () => {
+      const wrapper = render(
+        <StyledSelect
+          options={options}
+          defaultOption={options[1]}
+          onOptionSelected={() => {}}
+          placeholder="Doesn't matter"
+        />
+      )
+
+      const option = wrapper.getByText(options[0].optionName)
+
+      act(() => fireEvent.click(option))
+
+      expect(
+        wrapper.getByRole('option', { selected: true }).textContent
+      ).toEqual(options[0].optionName)
     })
   })
 })

--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -38,9 +38,7 @@ const StyledSelect = ({
   disabled,
   className,
 }: StyledSelectProps) => {
-  const [activeOption, setActiveOption] = useState<SelectOption | null>(
-    defaultOption || null
-  )
+  const [activeOption, setActiveOption] = useState<SelectOption | null>(null)
   const [headerText, setHeaderText] = useState(defaultOption?.optionName || '')
   const [expanded, setExpanded] = useState(false)
   const componentRef = useRef<HTMLDivElement>(null)
@@ -90,6 +88,7 @@ const StyledSelect = ({
   useEffect(() => {
     if (defaultOption && !activeOption) {
       setHeaderText(defaultOption.optionName)
+      setActiveOption(defaultOption)
     }
   }, [defaultOption, activeOption])
 

--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -42,9 +42,7 @@ const StyledSelect = ({
   disabled,
   className,
 }: StyledSelectProps) => {
-  const [activeOption, setActiveOption] = useState<SelectOption | null>(
-    defaultOption || null
-  )
+  const [activeOption, setActiveOption] = useState<SelectOption | null>(null)
   const [headerText, setHeaderText] = useState(defaultOption?.optionName || '')
   const [expanded, setExpanded] = useState(false)
   const componentRef = useRef<HTMLDivElement>(null)
@@ -94,6 +92,7 @@ const StyledSelect = ({
   useEffect(() => {
     if (defaultOption && !activeOption) {
       setHeaderText(defaultOption.optionName)
+      setActiveOption(defaultOption)
     }
   }, [defaultOption, activeOption])
 

--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -30,6 +30,10 @@ const truncatedText = (text: string) => {
   return text.length > 24 ? `${text.substring(0, 23).trim()}...` : text
 }
 
+const isEqual = (option1: SelectOption, option2: SelectOption) =>
+  option1.optionName === option2.optionName &&
+  option1.optionValue === option2.optionValue
+
 const StyledSelect = ({
   options,
   placeholder,
@@ -129,8 +133,9 @@ const StyledSelect = ({
             <StyledSelectOption
               key={index}
               onSelected={selectOption}
-              ariaSelected={option === activeOption}
-              {...option}
+              ariaSelected={!!activeOption && isEqual(option, activeOption)}
+              optionName={option.optionName}
+              optionValue={option.optionValue}
             />
           )
         })}

--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -42,7 +42,9 @@ const StyledSelect = ({
   disabled,
   className,
 }: StyledSelectProps) => {
-  const [activeOption, setActiveOption] = useState<SelectOption | null>(null)
+  const [activeOption, setActiveOption] = useState<SelectOption | null>(
+    defaultOption || null
+  )
   const [headerText, setHeaderText] = useState(defaultOption?.optionName || '')
   const [expanded, setExpanded] = useState(false)
   const componentRef = useRef<HTMLDivElement>(null)
@@ -92,7 +94,6 @@ const StyledSelect = ({
   useEffect(() => {
     if (defaultOption && !activeOption) {
       setHeaderText(defaultOption.optionName)
-      setActiveOption(defaultOption)
     }
   }, [defaultOption, activeOption])
 

--- a/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
+++ b/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                   My Game 1
                 </li>
                 <li
-                  aria-selected="false"
+                  aria-selected="true"
                   class="_root_b75fe4"
                   data-option-value="51"
                   role="option"
@@ -619,7 +619,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 My Game 1
               </li>
               <li
-                aria-selected="false"
+                aria-selected="true"
                 class="_root_b75fe4"
                 data-option-value="51"
                 role="option"

--- a/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
+++ b/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                   My Game 1
                 </li>
                 <li
-                  aria-selected="true"
+                  aria-selected="false"
                   class="_root_b75fe4"
                   data-option-value="51"
                   role="option"
@@ -619,7 +619,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 My Game 1
               </li>
               <li
-                aria-selected="true"
+                aria-selected="false"
                 class="_root_b75fe4"
                 data-option-value="51"
                 role="option"


### PR DESCRIPTION
## Context

In the course of testing #35, we noticed that, although the `StyledSelect` component correctly set the `aria-selected` attribute on the initially selected option, selecting a new option resulted in all options having `aria-selected` set to `false`; the newly-selected option did not have this attribute changed to `true`.

The issue proved to be that we were using the `===` operator to test the equality of objects that would never be identical in memory. The initial option would be selected because its value _was_ identical in memory to the one compared, but subsequent selections resulted in comparisons between objects with different references.

Changing this to compare the property values of the objects instead of using `===` or `==` resulted in correct behaviour.

## Changes

* Use a comparison function instead of `===` to check equality between active select option in the `StyledSelect` component and option in the `SelectOption` child component

## Considerations

Although I wrote a regression test for this functionality, for some reason I wasn't able to make it fail. I believe the reason is that JSDOM doesn't actually capture re-renders that occur when the select box is opened or closed since showing and hiding the box is done with CSS. I believe the reason for the regression behaviour was that, while the `activeOption` state variable in the `StyledSelect` component continued to point to the same object in memory, the `option` passed into the `SelectOption` child component changed on each re-render, making it no longer comparable to the original option still stored in the state variable.

Long story short, I am not including the regression test. Although the functionality really should be tested, including a test that can't fail would only give us the illusion that the functionality is tested. 

## Manual Test Cases

1. Create a game on the games page, if you do not have one already
2. Load the shopping lists page
3. Wait for the `StyledSelect` games dropdown to load
4. Inspect the component and look at the `li` components - the `SelectOption` components - within the `ul`
5. See that the initially selected game has `aria-selected` set to `"true"`
6. See that all other options have `aria-selected` set to `"false"`
7. Select another option from the dropdown
8. See that the newly selected option has `aria-selected` set to `"true"`
9. See that all other options, including the initially-selected option, has `aria-selected` set to `"false"`.
