### PR TITLE
Fix bug decrementing shopping list items to 0

### DIFF
--- a/src/components/shoppingListItem/shoppingListItem.test.tsx
+++ b/src/components/shoppingListItem/shoppingListItem.test.tsx
@@ -436,7 +436,11 @@ describe('ShoppingListItem', () => {
         act(() => fireEvent.click(decrementIcon))
 
         expect(window.confirm).toHaveBeenCalledOnce()
-        expect(destroyShoppingListItem).toHaveBeenCalledWith(33)
+        expect(destroyShoppingListItem).toHaveBeenCalledWith(
+          33,
+          null,
+          expect.any(Function)
+        )
       })
     })
   })

--- a/src/components/shoppingListItem/shoppingListItem.tsx
+++ b/src/components/shoppingListItem/shoppingListItem.tsx
@@ -162,7 +162,9 @@ const ShoppingListItem = ({
 
       if (confirmed) {
         setIncrementerDisabled(true)
-        destroyShoppingListItem(itemId)
+        destroyShoppingListItem(itemId, null, () =>
+          setIncrementerDisabled(false)
+        )
       } else {
         setFlashProps({
           hidden: false,

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -33,36 +33,36 @@ export interface ShoppingListsContextType {
   shoppingListsLoadingState: LoadingState
   createShoppingList: (
     attributes: RequestShoppingList,
-    onSuccess?: CallbackFunction,
-    onError?: CallbackFunction
+    onSuccess?: CallbackFunction | null,
+    onError?: CallbackFunction | null
   ) => void
   updateShoppingList: (
     listId: number,
     attributes: RequestShoppingList,
-    onSuccess?: CallbackFunction,
-    onError?: CallbackFunction
+    onSuccess?: CallbackFunction | null,
+    onError?: CallbackFunction | null
   ) => void
   destroyShoppingList: (
     listId: number,
-    onSuccess?: CallbackFunction,
-    onError?: CallbackFunction
+    onSuccess?: CallbackFunction | null,
+    onError?: CallbackFunction | null
   ) => void
   createShoppingListItem: (
     listId: number,
     attributes: RequestShoppingListItem,
-    onSuccess?: CallbackFunction,
-    onError?: CallbackFunction
+    onSuccess?: CallbackFunction | null,
+    onError?: CallbackFunction | null
   ) => void
   updateShoppingListItem: (
     itemId: number,
     attributes: RequestShoppingListItem,
-    onSuccess?: CallbackFunction,
-    onError?: CallbackFunction
+    onSuccess?: CallbackFunction | null,
+    onError?: CallbackFunction | null
   ) => void
   destroyShoppingListItem: (
     itemId: number,
-    onSuccess?: CallbackFunction,
-    onError?: CallbackFunction
+    onSuccess?: CallbackFunction | null,
+    onError?: CallbackFunction | null
   ) => void
 }
 
@@ -130,8 +130,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   const createShoppingList = useCallback(
     (
       attributes: RequestShoppingList,
-      onSuccess?: CallbackFunction,
-      onError?: CallbackFunction
+      onSuccess?: CallbackFunction | null,
+      onError?: CallbackFunction | null
     ) => {
       if (!activeGame) {
         setFlashProps({
@@ -229,8 +229,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
     (
       listId: number,
       attributes: RequestShoppingList,
-      onSuccess?: CallbackFunction,
-      onError?: CallbackFunction
+      onSuccess?: CallbackFunction | null,
+      onError?: CallbackFunction | null
     ) => {
       if (user && token) {
         patchShoppingList(listId, attributes, token)
@@ -284,8 +284,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   const destroyShoppingList = useCallback(
     (
       listId: number,
-      onSuccess?: CallbackFunction,
-      onError?: CallbackFunction
+      onSuccess?: CallbackFunction | null,
+      onError?: CallbackFunction | null
     ) => {
       if (user && token) {
         deleteShoppingList(listId, token)
@@ -352,8 +352,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
     (
       listId: number,
       attributes: RequestShoppingListItem,
-      onSuccess?: CallbackFunction,
-      onError?: CallbackFunction
+      onSuccess?: CallbackFunction | null,
+      onError?: CallbackFunction | null
     ) => {
       if (user && token) {
         postShoppingListItems(listId, attributes, token)
@@ -416,8 +416,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
     (
       itemId: number,
       attributes: RequestShoppingListItem,
-      onSuccess?: CallbackFunction,
-      onError?: CallbackFunction
+      onSuccess?: CallbackFunction | null,
+      onError?: CallbackFunction | null
     ) => {
       if (user && token) {
         patchShoppingListItem(itemId, attributes, token)
@@ -477,8 +477,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   const destroyShoppingListItem = useCallback(
     (
       itemId: number,
-      onSuccess?: CallbackFunction,
-      onError?: CallbackFunction
+      onSuccess?: CallbackFunction | null,
+      onError?: CallbackFunction | null
     ) => {
       if (user && token) {
         deleteShoppingListItem(itemId, token)


### PR DESCRIPTION
## Context

In the course of testing #35, we realised there was a bug with decrementing a shopping list item to 0. Before the API call to delete the item is made, the increment & decrement icons are disabled. However, since no callback is passed into `destroyShoppingListItem`, they are not reenabled when the API call finishes if there is an error - the code doesn't account for the fact that deletion might not "just work".

## Changes

* Enable callback functions to be `null` in `ShoppingListsContext`
* Pass in `onError` callback function to reenable increment/decrement icons if shopping list item deletion fails

## Considerations

I chose to change the possible type of the callback function instead of passing in `undefined` because passing in `undefined` just seemed sloppy/a hack. Since other functions in the `ShoppingListsContext` have similar signatures, I changed this for them, too, even though it isn't explicitly needed at this point.

## Manual Test Cases

These test cases assume you are on the shopping lists page and have at least one regular shopping list item with a quantity of 1.

1. Program the API to always return an error (doesn't matter which)
2. Expand the shopping list with the item you would like to decrement/delete
3. Click the decrement icon next to the quantity value
4. When prompted, confirm deletion of the item
5. See that the increment & decrement icons are disabled for that item
6. See a flash error message reflecting the error returned by the back end
7. See that the icons have been reenabled
