### PR TITLE
Handle case where user submits edit form without changing any attributes

### DIFF
--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.test.tsx
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.test.tsx
@@ -137,5 +137,31 @@ describe('ShoppingListItemEditForm', () => {
         expect(updateShoppingListItem).not.toHaveBeenCalled()
       })
     })
+
+    describe('with identical attributes', () => {
+      test("doesn't update the item", () => {
+        const updateShoppingListItem = vitest.fn()
+        contextValue = { ...shoppingListsContextValue, updateShoppingListItem }
+
+        const wrapper = renderWithContexts(
+          <ShoppingListItemEditForm
+            itemId={6}
+            description="Health potion ingredients"
+            listTitle="Alchemy Ingredients"
+            buttonColor={BLUE}
+            quantity={2}
+            unitWeight={3}
+            notes={null}
+          />
+        )
+
+        const form = wrapper.getByTestId('editShoppingListItem6Form')
+
+        // Submit the form without updating any fields
+        act(() => fireEvent.submit(form))
+
+        expect(updateShoppingListItem).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
@@ -78,7 +78,11 @@ const ShoppingListItemEditForm = ({
     const formData = new FormData(formRef.current)
     const attributes = extractAttributes(formData)
 
-    if (attributes) updateShoppingListItem(itemId, attributes, onSuccess)
+    if (attributes) {
+      updateShoppingListItem(itemId, attributes, onSuccess)
+    } else {
+      setModalProps({ hidden: true, children: <></> })
+    }
   }
 
   useEffect(() => {

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
@@ -40,7 +40,7 @@ const ShoppingListItemEditForm = ({
     '--button-border-color': buttonColor.borderColor,
   } as CSSProperties
 
-  const extractAttributes = (formData: FormData): ListItem => {
+  const extractAttributes = (formData: FormData): ListItem | null => {
     const values = Object.fromEntries(Array.from(formData.entries())) as Record<
       string,
       string
@@ -55,6 +55,8 @@ const ShoppingListItemEditForm = ({
       attributes.quantity = newQty
     if (newWeight !== unitWeight) attributes.unit_weight = newWeight
     if (newNotes !== notes) attributes.notes = newNotes
+
+    if (!Object.keys(attributes).length) return null
 
     return attributes
   }
@@ -76,7 +78,7 @@ const ShoppingListItemEditForm = ({
     const formData = new FormData(formRef.current)
     const attributes = extractAttributes(formData)
 
-    updateShoppingListItem(itemId, attributes, onSuccess)
+    if (attributes) updateShoppingListItem(itemId, attributes, onSuccess)
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Context

While manually testing #35, we found an edge case where the API would return a 400 error if a user submitted the shopping list item edit form without updating any of the item's attributes. The issue is that the request body only includes changed attributes, and when there are none the required param `:shopping_list_item` is not present in the params received by the Rails controller.

## Changes

* Ensure that no API call is made to update a shopping list item if the attributes haven't been changed
* Add test

## Manual Test Cases

1. On the shopping lists page, click the edit link next to any regular shopping list item
2. Submit the form without changing anything
3. See that the form modal is hidden
4. See that no request has been made to the API