### PR TITLE
Trim form values that are strings prior to API call

### DIFF
--- a/src/components/gameCreateForm/gameCreateForm.test.tsx
+++ b/src/components/gameCreateForm/gameCreateForm.test.tsx
@@ -71,8 +71,6 @@ describe('<GameCreateForm />', () => {
           const createGame = vitest
             .fn()
             .mockImplementation((_game: RequestGame) => {})
-          const destroyGame = () => {}
-          const updateGame = () => {}
 
           const wrapper = renderAuthenticated(
             <PageProvider>
@@ -92,6 +90,39 @@ describe('<GameCreateForm />', () => {
             fireEvent.change(nameInput, { target: { value: 'Skyrim' } })
             fireEvent.change(descInput, {
               target: { value: 'Custom description' },
+            })
+            fireEvent.submit(form)
+          })
+
+          expect(createGame).toHaveBeenCalledWith(
+            { name: 'Skyrim', description: 'Custom description' },
+            expect.any(Function)
+          )
+        })
+
+        test('trims strings', () => {
+          const createGame = vitest
+            .fn()
+            .mockImplementation((_game: RequestGame) => {})
+
+          const wrapper = renderAuthenticated(
+            <PageProvider>
+              <GamesContext.Provider
+                value={{ ...gamesContextValue, createGame }}
+              >
+                <GameCreateForm />
+              </GamesContext.Provider>
+            </PageProvider>
+          )
+
+          const nameInput = wrapper.getByTestId('createNameField')
+          const descInput = wrapper.getByTestId('createDescriptionField')
+          const form = wrapper.getByTestId('gameCreateFormForm')
+
+          act(() => {
+            fireEvent.change(nameInput, { target: { value: '   Skyrim  ' } })
+            fireEvent.change(descInput, {
+              target: { value: ' Custom description   ' },
             })
             fireEvent.submit(form)
           })

--- a/src/components/gameCreateForm/gameCreateForm.tsx
+++ b/src/components/gameCreateForm/gameCreateForm.tsx
@@ -37,8 +37,8 @@ const GameCreateForm = ({ disabled }: GameCreateFormProps) => {
       string
     >
     return {
-      name: values.name || null,
-      description: values.description || null,
+      name: values.name?.trim() || null,
+      description: values.description?.trim() || null,
     }
   }
 

--- a/src/components/gameEditForm/gameEditForm.test.tsx
+++ b/src/components/gameEditForm/gameEditForm.test.tsx
@@ -57,11 +57,7 @@ describe('GameEditForm', () => {
       const game = games[0]
       const contextValue = {
         ...gamesContextValue,
-        updateGame: vitest
-          .fn()
-          .mockImplementation(
-            (_gameId: number, _attributes: RequestGame) => {}
-          ),
+        updateGame: vitest.fn(),
       }
 
       const wrapper = renderAuthenticated(
@@ -100,11 +96,7 @@ describe('GameEditForm', () => {
       const game = games[0]
       const contextValue = {
         ...gamesContextValue,
-        updateGame: vitest
-          .fn()
-          .mockImplementation(
-            (_gameId: number, _attributes: RequestGame) => {}
-          ),
+        updateGame: vitest.fn(),
       }
 
       const wrapper = renderAuthenticated(
@@ -145,11 +137,7 @@ describe('GameEditForm', () => {
       const game = games[0]
       const contextValue = {
         ...gamesContextValue,
-        updateGame: vitest
-          .fn()
-          .mockImplementation(
-            (_gameId: number, _attributes: RequestGame) => {}
-          ),
+        updateGame: vitest.fn(),
       }
 
       const wrapper = renderAuthenticated(

--- a/src/components/gameEditForm/gameEditForm.test.tsx
+++ b/src/components/gameEditForm/gameEditForm.test.tsx
@@ -1,6 +1,5 @@
 import { describe, test, expect, vitest } from 'vitest'
 import { act, fireEvent } from '@testing-library/react'
-import { RequestGame } from '../../types/apiData'
 import { renderAuthenticated } from '../../support/testUtils'
 import { allGames as games } from '../../support/data/games'
 import { gamesContextValue } from '../../support/data/contextValues'
@@ -84,7 +83,7 @@ describe('GameEditForm', () => {
       fireEvent.change(nameInput, { target: { value: 'Something new' } })
       fireEvent.change(descInput, { target: { value: 'New description' } })
 
-      act(() => button.click())
+      act(() => fireEvent.click(button))
 
       expect(contextValue.updateGame).toHaveBeenCalledWith(game.id, {
         name: 'Something new',
@@ -125,7 +124,7 @@ describe('GameEditForm', () => {
         target: { value: '  New description    ' },
       })
 
-      act(() => button.click())
+      act(() => fireEvent.click(button))
 
       expect(contextValue.updateGame).toHaveBeenCalledWith(game.id, {
         name: 'Something new',
@@ -157,7 +156,7 @@ describe('GameEditForm', () => {
         'submitGameEditForm'
       ) as HTMLButtonElement
 
-      act(() => button.click())
+      act(() => fireEvent.click(button))
 
       expect(contextValue.updateGame).not.toHaveBeenCalled()
     })

--- a/src/components/gameEditForm/gameEditForm.test.tsx
+++ b/src/components/gameEditForm/gameEditForm.test.tsx
@@ -95,5 +95,83 @@ describe('GameEditForm', () => {
         description: 'New description',
       })
     })
+
+    test('trims strings', () => {
+      const game = games[0]
+      const contextValue = {
+        ...gamesContextValue,
+        updateGame: vitest
+          .fn()
+          .mockImplementation(
+            (_gameId: number, _attributes: RequestGame) => {}
+          ),
+      }
+
+      const wrapper = renderAuthenticated(
+        <PageProvider>
+          <GamesContext.Provider value={contextValue}>
+            <GameEditForm
+              gameId={game.id}
+              name={game.name}
+              description={game.description}
+              buttonColor={GREEN}
+            />
+          </GamesContext.Provider>
+        </PageProvider>
+      )
+
+      const nameInput = wrapper.getByTestId('editNameField') as HTMLInputElement
+      const descInput = wrapper.getByTestId(
+        'editDescriptionField'
+      ) as HTMLInputElement
+      const button = wrapper.getByTestId(
+        'submitGameEditForm'
+      ) as HTMLButtonElement
+
+      fireEvent.change(nameInput, { target: { value: ' Something new ' } })
+      fireEvent.change(descInput, {
+        target: { value: '  New description    ' },
+      })
+
+      act(() => button.click())
+
+      expect(contextValue.updateGame).toHaveBeenCalledWith(game.id, {
+        name: 'Something new',
+        description: 'New description',
+      })
+    })
+
+    test("doesn't update if attributes aren't changed", () => {
+      const game = games[0]
+      const contextValue = {
+        ...gamesContextValue,
+        updateGame: vitest
+          .fn()
+          .mockImplementation(
+            (_gameId: number, _attributes: RequestGame) => {}
+          ),
+      }
+
+      const wrapper = renderAuthenticated(
+        <PageProvider>
+          <GamesContext.Provider value={contextValue}>
+            <GameEditForm
+              gameId={game.id}
+              name={game.name}
+              description={game.description}
+              buttonColor={GREEN}
+            />
+          </GamesContext.Provider>
+        </PageProvider>
+      )
+
+      const button = wrapper.getByTestId(
+        'submitGameEditForm'
+      ) as HTMLButtonElement
+
+      act(() => button.click())
+
+      expect(contextValue.updateGame).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/components/gameEditForm/gameEditForm.tsx
+++ b/src/components/gameEditForm/gameEditForm.tsx
@@ -5,7 +5,7 @@ import {
   type FormEventHandler,
 } from 'react'
 import { RequestGame as Game } from '../../types/apiData'
-import { useGamesContext } from '../../hooks/contexts'
+import { usePageContext, useGamesContext } from '../../hooks/contexts'
 import colorSchemes, { ColorScheme } from '../../utils/colorSchemes'
 import styles from './gameEditForm.module.css'
 
@@ -22,6 +22,7 @@ const GameEditForm = ({
   description,
   buttonColor,
 }: GameEditFormProps) => {
+  const { setModalProps } = usePageContext()
   const { updateGame } = useGamesContext()
   const formRef = useRef<HTMLFormElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -63,7 +64,11 @@ const GameEditForm = ({
     const formData = new FormData(formRef.current)
     const game = extractAttributes(formData)
 
-    if (game) updateGame(gameId, game)
+    if (game) {
+      updateGame(gameId, game)
+    } else {
+      setModalProps({ hidden: true, children: <></> })
+    }
   }
 
   useEffect(() => {

--- a/src/components/gameEditForm/gameEditForm.tsx
+++ b/src/components/gameEditForm/gameEditForm.tsx
@@ -38,17 +38,19 @@ const GameEditForm = ({
     '--button-border-color': colorRef.current.borderColor,
   } as CSSProperties
 
-  const extractAttributes = (formData: FormData): Game => {
+  const extractAttributes = (formData: FormData): Game | null => {
     const values = Object.fromEntries(Array.from(formData.entries())) as Record<
       string,
       string
     >
     const attributes: Game = {}
-    const newName = values.name || null
-    const newDescription = values.description || null
+    const newName = values.name?.trim() || null
+    const newDescription = values.description?.trim() || null
 
     if (newName !== name) attributes.name = newName
     if (newDescription !== description) attributes.description = newDescription
+
+    if (!Object.keys(attributes).length) return null
 
     return attributes
   }
@@ -61,7 +63,7 @@ const GameEditForm = ({
     const formData = new FormData(formRef.current)
     const game = extractAttributes(formData)
 
-    updateGame(gameId, game)
+    if (game) updateGame(gameId, game)
   }
 
   useEffect(() => {

--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -114,12 +114,18 @@ const ShoppingList = ({
     }
   }
 
-  const extractAttributes = (formData: FormData): RequestShoppingList => {
-    const attributes = ({ title } = Object.fromEntries(
+  const extractAttributes = (
+    formData: FormData
+  ): RequestShoppingList | null => {
+    const attributes = Object.fromEntries(
       Array.from(formData.entries())
-    ) as Record<string, string>)
+    ) as Record<string, string>
 
-    return attributes
+    attributes.title = attributes.title?.trim()
+
+    if (attributes.title === title) return null
+
+    return { title: attributes.title }
   }
 
   const submitAndHideForm: FormEventHandler = (e) => {
@@ -132,7 +138,8 @@ const ShoppingList = ({
 
     const onSuccess = () => setIsComponentVisible(false)
 
-    updateShoppingList(listId, attributes, onSuccess)
+    console.log('attributes: ', attributes)
+    if (attributes) updateShoppingList(listId, attributes, onSuccess)
   }
 
   useEffect(() => {

--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -138,7 +138,6 @@ const ShoppingList = ({
 
     const onSuccess = () => setIsComponentVisible(false)
 
-    console.log('attributes: ', attributes)
     if (attributes) updateShoppingList(listId, attributes, onSuccess)
   }
 

--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -138,7 +138,11 @@ const ShoppingList = ({
 
     const onSuccess = () => setIsComponentVisible(false)
 
-    if (attributes) updateShoppingList(listId, attributes, onSuccess)
+    if (attributes) {
+      updateShoppingList(listId, attributes, onSuccess)
+    } else {
+      setIsComponentVisible(false)
+    }
   }
 
   useEffect(() => {

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.test.tsx
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.test.tsx
@@ -173,7 +173,7 @@ describe('ShoppingListCreateForm', () => {
 
   describe('submitting the form', () => {
     describe('when the form is enabled', () => {
-      test('calls the createShoppingList function', () => {
+      test('trims the title and calls the createShoppingList function', () => {
         const createShoppingList = vitest.fn()
         const contextValue = {
           ...shoppingListsContextValue,
@@ -193,10 +193,9 @@ describe('ShoppingListCreateForm', () => {
         const input = wrapper.getByPlaceholderText('Title')
         const button = wrapper.getByText('Create')
 
-        act(() => {
-          fireEvent.change(input, { target: { value: 'New Shopping List' } })
-          fireEvent.click(button)
-        })
+        fireEvent.change(input, { target: { value: '   New Shopping List  ' } })
+
+        act(() => fireEvent.click(button))
 
         expect(createShoppingList).toHaveBeenCalledWith(
           { title: 'New Shopping List' },

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.tsx
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.tsx
@@ -30,7 +30,7 @@ const ShoppingListCreateForm = () => {
     >
     const attributes: RequestShoppingList = {}
 
-    if (values.title) attributes.title = values.title
+    if (values.title) attributes.title = values.title.trim()
 
     return attributes
   }

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.test.tsx
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.test.tsx
@@ -72,11 +72,10 @@ describe('ShoppingListItemCreateForm', () => {
       const quantityField = wrapper.getByLabelText('Quantity')
       const form = wrapper.getByLabelText('Shopping list item creation form')
 
-      act(() => {
-        fireEvent.change(descField, { target: { value: 'Iron ingot' } })
-        fireEvent.change(quantityField, { target: { value: '2' } })
-        fireEvent.submit(form)
-      })
+      fireEvent.change(descField, { target: { value: '  Iron ingot    ' } })
+      fireEvent.change(quantityField, { target: { value: '2' } })
+
+      act(() => fireEvent.submit(form))
 
       expect(createShoppingListItem).toHaveBeenCalledWith(
         4,

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.tsx
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.tsx
@@ -49,13 +49,13 @@ const ShoppingListItemCreateForm = ({ listId }: CreateFormProps) => {
     ) as Record<string, string>
 
     const returnValue: RequestShoppingListItem = {
-      description: attributes.description,
+      description: attributes.description?.trim(),
       quantity: Number(attributes.quantity),
     }
 
     if (attributes.unit_weight)
       returnValue.unit_weight = Number(attributes.unit_weight)
-    if (attributes.notes) returnValue.notes = attributes.notes
+    if (attributes.notes) returnValue.notes = attributes.notes.trim()
 
     return returnValue
   }

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.test.tsx
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.test.tsx
@@ -93,17 +93,18 @@ describe('ShoppingListItemEditForm', () => {
 
         const qtyInput = wrapper.getByLabelText('Quantity')
         const weightInput = wrapper.getByLabelText('Unit Weight')
+        const notesInput = wrapper.getByLabelText('Notes')
         const form = wrapper.getByTestId('editShoppingListItem6Form')
 
-        act(() => {
-          fireEvent.change(qtyInput, { target: { value: '4' } })
-          fireEvent.change(weightInput, { target: { value: '0.1' } })
-          fireEvent.submit(form)
-        })
+        fireEvent.change(qtyInput, { target: { value: '4' } })
+        fireEvent.change(weightInput, { target: { value: '0.1' } })
+        fireEvent.change(notesInput, { target: { value: '  New notes    ' } })
+
+        act(() => fireEvent.submit(form))
 
         expect(updateShoppingListItem).toHaveBeenCalledWith(
           6,
-          { quantity: 4, unit_weight: 0.1 },
+          { quantity: 4, unit_weight: 0.1, notes: 'New notes' },
           expect.any(Function)
         )
       })

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
@@ -54,7 +54,7 @@ const ShoppingListItemEditForm = ({
     if (typeof newQty === 'number' && newQty !== quantity)
       attributes.quantity = newQty
     if (newWeight !== unitWeight) attributes.unit_weight = newWeight
-    if (newNotes !== notes) attributes.notes = newNotes
+    if (newNotes !== notes) attributes.notes = newNotes?.trim()
 
     if (!Object.keys(attributes).length) return null
 

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
@@ -49,12 +49,12 @@ const ShoppingListItemEditForm = ({
 
     const newQty = values.quantity ? Number(values.quantity) : null
     const newWeight = values.unit_weight ? Number(values.unit_weight) : null
-    const newNotes = values.notes || null
+    const newNotes = values.notes?.trim() || null
 
     if (typeof newQty === 'number' && newQty !== quantity)
       attributes.quantity = newQty
     if (newWeight !== unitWeight) attributes.unit_weight = newWeight
-    if (newNotes !== notes) attributes.notes = newNotes?.trim()
+    if (newNotes !== notes) attributes.notes = newNotes
 
     if (!Object.keys(attributes).length) return null
 

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -812,7 +812,7 @@ describe('ShoppingListsPage', () => {
       beforeEach(() => mockServer.resetHandlers())
       afterAll(() => mockServer.close())
 
-      test('updates the title', async () => {
+      test('trims and updates the title', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
             <GamesProvider>
@@ -832,7 +832,7 @@ describe('ShoppingListsPage', () => {
         const editForm = wrapper.getByLabelText('List title edit form')
 
         fireEvent.change(titleInput, {
-          target: { value: 'Alchemy Ingredients' },
+          target: { value: ' Alchemy Ingredients  ' },
         })
 
         act(() => fireEvent.submit(editForm))


### PR DESCRIPTION
## Context

[**Trim strings entered into forms before making API calls**](https://trello.com/c/DkWS2EUH/280-trim-strings-entered-into-forms-before-making-api-calls)

Currently, the front end takes form input as-is, converting numeric inputs to numbers but passing strings directly through to the API without trimming leading or trailing whitespace. This is, in general, not as it should be, but it was proving a real pain with shopping list items, which are supposed to be combined on creation with other items having the same description. They were not being combined in the case where one of the descriptions had leading or trailing whitespace that made them not equal.

## Changes

* Update all form components to trim string values before sending to the server
* Update tests to cover this edge case

## Required Tasks

- [x] Add/update automated tests
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] Verify TypeScript compiles

## Manual Test Cases

You will need to use each form updated in this PR, entering strings with leading and trailing whitespace and verifying that the resources are created or updated with trimmed strings. You can also try trailing whitespace with numeric values (if the device you are testing on permits it).