### PR TITLE
Increase font size on game create form and remove fieldset margins

### DIFF
--- a/src/components/gameCreateForm/gameCreateForm.module.css
+++ b/src/components/gameCreateForm/gameCreateForm.module.css
@@ -21,6 +21,7 @@
   border: none;
   padding-left: 0;
   padding-right: 0;
+  margin: 0;
   max-width: 100%;
 }
 
@@ -28,6 +29,7 @@
   background-color: #fff;
   color: #000;
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  font-size: 1rem;
   padding: 8px 12px;
   border: 1px solid #5f5f5f;
   border-radius: 3px;


### PR DESCRIPTION
## Context

* [**Improve text size in game creation form**](https://trello.com/c/xoZrjGs2/282-improve-text-size-in-game-creation-form)
* [**Fix zooming issue on iPhone**](https://trello.com/c/1SlqSbG0/283-fix-zooming-issue-on-iphone)

We noticed that the text in the game creation form is tiny, looking out of balance with the rest of the page. Separately, we discovered an issue in Safari on iPhone where the browser automatically zooms in on the input when it is focussed to reveal the keyboard - apparently a well-known feature of the iPhone.

It was suggested in [this StackOverflow answer](https://stackoverflow.com/a/69125139/4056267) that increasing the font size of the input to 16px could change the zooming behaviour, which isn't present on the shopping lists page or with the game edit form. Both of these components have the font size set to 16px in their inputs.

While doing this work, we also noticed a tiny side margin to the fieldsets that was resulting in the inputs being indented - by about 2px - compared to the title or the submit button.

## Changes

* Increase game create form font size to 1rem
* Remove margins from fieldsets

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~

## Manual Test Cases

You can run the games page in production and view the page at different sizes, with the game create form expanded, to see the results of this PR, which are only small CSS changes. Testing the zooming behaviour on iPhone will not be possible prior to deployment.

## Screenshots and GIFs

### 320px

<img width="320" alt="GamesPage-320" src="https://user-images.githubusercontent.com/5115928/230391916-c6539eb6-3213-45f4-a2ac-13e2770ae821.png">

### 481px

<img width="482" alt="GamesPage-481" src="https://user-images.githubusercontent.com/5115928/230391941-edfeb743-3c4a-4d07-bd40-0927f6d034c4.png">

### 601px

<img width="601" alt="GamesPage-601" src="https://user-images.githubusercontent.com/5115928/230391967-d568790c-de3b-4e94-987b-19927cdeefb0.png">

### 769px

<img width="771" alt="GamesPage-769" src="https://user-images.githubusercontent.com/5115928/230391996-47ed2e8f-5d89-4acb-b694-d98835dfc92f.png">

### 1025px

<img width="1026" alt="GamesPage-1025" src="https://user-images.githubusercontent.com/5115928/230392046-7bed2702-f999-4137-9d11-aac3a58e9120.png">

### 1201px

<img width="1202" alt="GamesPage-1201" src="https://user-images.githubusercontent.com/5115928/230392066-7689e8ad-f7b7-447a-bd33-57d2693f5232.png">

### 1405px

<img width="1406" alt="GamesPage-1405" src="https://user-images.githubusercontent.com/5115928/230392102-3cc437cd-582f-409d-97bf-e2b009f04893.png">

### Large Desktop

<img width="1920" alt="GamesPage-Full" src="https://user-images.githubusercontent.com/5115928/230392128-142388f5-8e9d-435d-9c3b-bf70a89b4f0a.png">
