### PR TITLE
Move bottom border of list edit form from form itself to input

### DIFF
--- a/src/components/listEditForm/listEditForm.module.css
+++ b/src/components/listEditForm/listEditForm.module.css
@@ -11,7 +11,6 @@
   font-size: 1.25rem;
   font-weight: 700;
   padding: 0;
-  padding-right: 8px;
   background-color: inherit;
   color: var(--text-color);
   border: none;

--- a/src/components/listEditForm/listEditForm.module.css
+++ b/src/components/listEditForm/listEditForm.module.css
@@ -4,7 +4,6 @@
   align-content: center;
   max-width: var(--max-width);
   background-color: var(--scheme-color);
-  border-bottom: 1px solid var(--border-color);
 }
 
 .input {
@@ -15,7 +14,8 @@
   padding-right: 8px;
   background-color: inherit;
   color: var(--text-color);
-  border-style: none;
+  border: none;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .submit {


### PR DESCRIPTION
## Context

[**Fix visual of shopping list edit form when list expanded**](https://trello.com/c/T4BOrzLG/272-fix-visual-of-shopping-list-edit-form-when-list-expanded)

The shopping list edit form (`ListEditForm` component) doesn't look good when the list is expanded on the page. The bottom border is about 1px above the top border of the contents and just doesn't look very intentional, because it is not:

<img width="295" alt="ShoppingListBefore" src="https://user-images.githubusercontent.com/5115928/230513293-bae0b4c6-80ed-4316-b59f-530ec1719a3a.png">

It doesn't look super great collapsed either, since the border just seems far away from the input contents:

<img width="293" alt="ShoppingListBeforeCollapsed" src="https://user-images.githubusercontent.com/5115928/230513317-4d515f6c-2eaf-4389-937c-94dfe36867ce.png">

## Changes

* Remove bottom border from list edit form
* Add bottom border to list edit form input

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~

## Manual Test Cases

View the shopping lists page for a game that has at least one regular shopping list. With the list expanded, click the "edit" icon to the left of the title. See the form appear. See that its bottom border looks good (although it may be hidden by the blue box the browser puts around focussed elements - at least in Chrome you can get rid of this without hiding the form by clicking inside the dev tools). Follow the same steps with the list collapsed. Do the same at all viewport sizes.

## Screenshots and GIFs

Note: No "Large Desktop" screenshot is provided because the width of shopping lists doesn't change past 1405px.

### 320px

#### Expanded

<img width="296" alt="ShoppingList-320" src="https://user-images.githubusercontent.com/5115928/230513633-6ca5e39b-360d-4595-b24d-d1cbcfc441d7.png">

#### Collapsed

<img width="293" alt="ShoppingListCollapsed-320" src="https://user-images.githubusercontent.com/5115928/230513652-20cf8d94-b99d-4646-a485-58abbdcb483f.png">

### 481px

#### Expanded

<img width="443" alt="ShoppingList-481" src="https://user-images.githubusercontent.com/5115928/230513663-225bd722-ccec-4ccb-93c5-a0511ab0baab.png">

#### Collapsed

<img width="440" alt="ShoppingListCollapsed-481" src="https://user-images.githubusercontent.com/5115928/230513681-3da8e5a1-9320-4959-9d06-cc7cb2117b8b.png">

### 601px

#### Expanded

<img width="447" alt="ShoppingList-601" src="https://user-images.githubusercontent.com/5115928/230513701-0ff09473-f0bb-4ccb-b007-460d6d7d8249.png">

#### Collapsed

<img width="438" alt="ShoppingListCollapsed-601" src="https://user-images.githubusercontent.com/5115928/230513719-7c7703c6-ae25-43a1-a8c0-b2501dbf4655.png">

### 769px

#### Expanded

<img width="493" alt="ShoppingList-769" src="https://user-images.githubusercontent.com/5115928/230513740-3a5689d9-d651-420c-abaa-db54a04f0a8a.png">

#### Collapsed

<img width="490" alt="ShoppingListCollapsed-769" src="https://user-images.githubusercontent.com/5115928/230513753-933d2611-f324-4600-934e-698958883917.png">

### 1025px

#### Expanded

<img width="562" alt="ShoppingList-1025" src="https://user-images.githubusercontent.com/5115928/230513785-e01f96b5-10c7-4338-ad24-35d8e40c5c89.png">

#### Collapsed

<img width="561" alt="ShoppingListCollapsed-1025" src="https://user-images.githubusercontent.com/5115928/230513804-a0bd5ff1-90b7-46d4-8da6-e45975b95262.png">

### 1201px

#### Expanded

<img width="548" alt="ShoppingList-1201" src="https://user-images.githubusercontent.com/5115928/230513833-4c5881f4-d015-461b-b451-8340995be212.png">

#### Collapsed

<img width="549" alt="ShoppingListCollapsed-1201" src="https://user-images.githubusercontent.com/5115928/230513868-63652f22-f6d2-4fb9-bec1-75463bc74a6b.png">

### >= 1405px

#### Expanded

<img width="572" alt="ShoppingList-1405" src="https://user-images.githubusercontent.com/5115928/230513893-a8961a49-f242-4b94-bd66-9384c848df4e.png">

#### Collapsed

<img width="568" alt="ShoppingListCollapsed-1405" src="https://user-images.githubusercontent.com/5115928/230513907-eac6ee6e-ed9f-4485-ae89-b87cc51381e2.png">
