### PR TITLE
Add styles to :after pseudo-element to fix black side margins on iPhone

### DIFF
--- a/src/layouts/dashboardLayout/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout/dashboardLayout.module.css
@@ -5,6 +5,13 @@
   color: #000;
 }
 
+.root:after {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background-color: #f0f0f0;
+}
+
 .container {
   padding: 24px 0;
   margin: 0 auto;


### PR DESCRIPTION
## Context

[**Investigate black margins on Safari/iOS**](https://trello.com/c/JBUbk1wM/287-investigate-black-margins-on-safari-ios)

In Safari on iPhone, when in landscape mode, we noticed that there are black side margins along the edge of the page. These are likely present due to black being the background colour of `body`. On dashboard pages, we would like the entire margin to be grey, `#f0f0f0`, other than next to the header bar.

## Changes

* Add `:after` pseudo element for the `.root` of the `DashboardLayout` component and style the pseudo-element

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~

## Considerations

[This StackOverflow answer](https://stackoverflow.com/a/43094794/4056267) suggested that this might be a good approach to get rid of the margins.

## Manual Test Cases

The changes themselves can't actually be tested until the app is deployed since the bug only occurs on iPhone. After deploy, load any dashboard page and put the iPhone in landscape mode. See that the grey background extends all the way to the edges. The black header bar should be unchanged and should also extend all the way to the edges.

## Screenshots and GIFs

These changes are not visible in any browser on desktop. A screenshot from iPhone illustrating the problem can be found on the Trello card.