### PR TITLE
Fix black margins in Safari on iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #000;
+  overflow: hidden;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/src/layouts/dashboardLayout/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout/dashboardLayout.module.css
@@ -5,13 +5,6 @@
   color: #000;
 }
 
-.root:after {
-  position: absolute;
-  left: 0;
-  right: 0;
-  background-color: #f0f0f0;
-}
-
 .container {
   padding: 24px 0;
   margin: 0 auto;

--- a/src/routing/pageRoutes.tsx
+++ b/src/routing/pageRoutes.tsx
@@ -90,6 +90,7 @@ const RouteContent = ({ title, description, jsx }: BasePage) => (
 
       <title>{title}</title>
       <meta name="description" content={description} />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </Helmet>
     {jsx}
   </>


### PR DESCRIPTION
## Context

[**Investigate black margins on Safari/iOS**](https://trello.com/c/JBUbk1wM/287-investigate-black-margins-on-safari-ios)

When viewed in Safari on iPhone in landscape mode, pages using the `DashboardLayout` have a wide black margin on both sides, instead of the grey background covering the full screen. We tried to fix this in #57 by introducing an `:after` pseudo-element on the `DashboardLayout` and setting its background colour, but this didn't change anything. For the next pass, we are trying `overflow: hidden` on the `:root` pseudo-element for the entire app.

Additionally, in the course of doing this work, I noticed that the viewport `meta` tag was missing, so I've added it to all pages.

## Changes

* Add `viewport` meta tag
* Set `overflow` to `hidden` on the `:root` pseudo-element for the document
* Remove code added in #57 since that didn't end up working

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~

## Manual Test Cases

These changes can't truly be tested until post-deploy. Once they are deployed, view any of the dashboard pages in Safari on iPhone with the phone turned to landscape mode. The grey background should cover the entire screen (except for the black header). Both the background and the header should extend to the very edges of the viewport.

You can see the effect of these changes locally by pulling left or right on the screen (2 fingers on a trackpad will do the trick). Prior to these changes, pulling left or right would reveal a black edge and the screen contents would move as if scrolling. With these changes, pulling left or right should have no effect.

You can also check the presence of the `meta` tag in your dev environment. If you inspect the page, inside the `<head>`, there should be a meta tag, `<meta name="viewport" content="width=device-width, initial-scale=1.0" />`.