### PR TITLE
Attempt 3 at making black margins go away on iPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <title>Skyrim Inventory Management</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #000;
-  overflow: hidden;
+  overflow-x: hidden;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -17,6 +17,11 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
+}
+
+body {
+  overflow-x: hidden;
 }
 
 a {
@@ -24,6 +29,7 @@ a {
   color: #646cff;
   text-decoration: inherit;
 }
+
 a:hover {
   color: #535bf2;
 }

--- a/src/layouts/dashboardLayout/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout/dashboardLayout.module.css
@@ -2,6 +2,7 @@
   min-height: 100vh;
   min-width: 100vw;
   background-color: #f0f0f0;
+  object-fit: cover;
   color: #000;
 }
 

--- a/src/routing/pageRoutes.tsx
+++ b/src/routing/pageRoutes.tsx
@@ -90,7 +90,6 @@ const RouteContent = ({ title, description, jsx }: BasePage) => (
 
       <title>{title}</title>
       <meta name="description" content={description} />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </Helmet>
     {jsx}
   </>


### PR DESCRIPTION
## Context

[**Investigate black margins on Safari/iOS**](https://trello.com/c/JBUbk1wM/287-investigate-black-margins-on-safari-ios)

In #57 and #58, we tried and failed to fix the wide black side margins that are showing up in Safari on iPhone in landscape mode. This is the third attempt to make the margins go away. Based on how Safari on Mac responds, I'm a little doubtful that it will work, but I'm running out of ideas and so are ChatGPT and StackOverflow.

## Changes

* Add minimum scale to viewport meta tag
* Use `overflow-x: hidden` on both `html` and `body` elements as well as the `:root` pseudo-element
* Use `object-fit: cover` for the dashboard layout background

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~

## Manual Test Cases

Once deployed, load any dashboard page on Safari on iPhone and put the phone in landscape mode. See that the grey background and the black header bar both extend all the way to the edge of the viewport. There should be no black along the side margins of the background.

## Screenshots and GIFs

"Before" picture is available on the Trello card.