### PR TITLE
Use viewport-fit attribute in meta tag to make site cover full screen on iPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Skyrim Inventory Management</title>
   </head>
   <body>


### PR DESCRIPTION
## Context

[**Investigate black margins on Safari/iOS**](https://trello.com/c/JBUbk1wM/287-investigate-black-margins-on-safari-ios)

We've had an issue where there's a thick, black margin on either side of the screen in landscape mode on iPhone 12. After attempting to fix it in #57, #58, and #59, I was about to give up when I found [this blog post](https://stephenradford.me/removing-the-white-bars-in-safari-on-iphone-x/) by a guy who knows what the problem is and has some ideas as to how to fix it.

## Changes

* Add `viewport-fit=cover` to viewport meta tag to force background to cover full screen on iPhone in landscape mode

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~

## Considerations

The blog post points out that the black margins are present because the borders of the iPhone's screen are not straight - there is a little inset on the edge where the speaker is, and taking away the margins can result in that inset interfering with site content. If this solution ends up working, we may need to make some tweaks in another PR to ensure that site content is not getting covered by the iPhone speaker. We'll cross that bridge when we come to it though - for now, given we've got 3 failed attempts under our belt, I figured I didn't want to spend too much time going down a rabbit hole that might not even be fruitful.

## Manual Test Cases

Follow the test plan for #59.
