### PR TITLE
Ensure flash message stays visible at least 4 seconds

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>Skyrim Inventory Management</title>
   </head>
   <body>

--- a/src/components/styledSelect/styledSelect.stories.tsx
+++ b/src/components/styledSelect/styledSelect.stories.tsx
@@ -34,8 +34,8 @@ export const WithLongOptions = () => (
 )
 
 options.push({
-  optionName: "This Name Has 50 Characters Exactly 1234 Wwwwwwwww",
-  optionValue: 27
+  optionName: 'This Name Has 50 Characters Exactly 1234 Wwwwwwwww',
+  optionValue: 27,
 })
 
 export const WithLongDefaultOption = () => (

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -30,6 +30,7 @@ const PageContext = createContext<PageContextType>({
 const PageProvider = ({ children }: ProviderProps) => {
   const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
   const [modalProps, setModalProps] = useState<ModalProps>(defaultModalProps)
+  const [flashVisibleSince, setFlashVisibleSince] = useState<Date | null>(null)
 
   const value = {
     flashProps,
@@ -40,7 +41,16 @@ const PageProvider = ({ children }: ProviderProps) => {
 
   useEffect(() => {
     if (flashProps.hidden === false) {
-      setTimeout(() => setFlashProps({ ...flashProps, hidden: true }), 4000)
+      setFlashVisibleSince(new Date())
+
+      setTimeout(() => {
+        const now = new Date()
+
+        if (flashVisibleSince && Number(now) - Number(flashVisibleSince) >= 4000) {
+          setFlashVisibleSince(null)
+          setFlashProps({ ...flashProps, hidden: true })
+        }
+      }, 4000)
     }
   }, [flashProps])
 

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -46,7 +46,10 @@ const PageProvider = ({ children }: ProviderProps) => {
       setTimeout(() => {
         const now = new Date()
 
-        if (flashVisibleSince && Number(now) - Number(flashVisibleSince) >= 4000) {
+        if (
+          flashVisibleSince &&
+          Number(now) - Number(flashVisibleSince) >= 4000
+        ) {
           setFlashVisibleSince(null)
           setFlashProps({ ...flashProps, hidden: true })
         }


### PR DESCRIPTION
## Context

[**Ensure flash component always shows for 4 whole seconds**](https://trello.com/c/kkBvS0gK/286-ensure-flash-component-always-shows-for-4-whole-seconds)

When multiple components are using the flash message from a single `PageProvider`, we have to be careful that they don't step on each other's toes. In particular, the `PageProvider` makes sure that the flash message disappears after 4 seconds by calling `setFlashProps` and setting `hidden` to `true` in a function passed to `setTimeout`. The problem is that if, during the 4 intervening seconds, another component sets the flash message to its message, that message disappears when the first one was scheduled to. So, say that a user cancels deletion of a shopping list. The flash message, "OK, your shopping list will not be destroyed" appears. Two seconds later, they delete a list item. The API call takes 1 second to complete and then displays the flash message, "Success! Your shopping list item was deleted." Now the message is only visible for 1 second before the original flash message's timeout elapses and hides the flash. As it does this, it also resets the flash message to the original message, which can be seen as the flash fades out. Not pretty.

We wanted a way to "reset" the 4-second period each time the flash was displayed. To achieve this, we used a new state variable in the context provider, `flashVisibleSince`, which can take either a `Date` object or `null` as a value. Each time the flash is set to visible, the `flashVisibleSince` value is set in the `useEffect` hook before calling `setTimeout`. Inside the function passed to `setTimeout`, we check to ensure that the `flashVisibleSince` date is at least 4 seconds ago before hiding the flash component again.

## Changes

* Add `flashVisibleSince` state variable to ensure flash messages stay on the screen for at least 4 seconds
* A couple formatting fixes that were apparently omitted from earlier PRs

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~

## Manual Test Cases

On one of the dashboard pages, within 4 seconds of each other, take two actions that cause a flash message to be displayed. Good examples of things you can do quickly include:


- Cancelling deletion of a game, shopping list, or shopping list item
- Deleting a game, shopping list, or shopping list item
- Submitting the shopping list creation form with no title value

You should see each flash message appear as expected. The first should be replaced by the second, which should then be present for a full 4 seconds.

## Screenshots and GIFs

![Flash](https://user-images.githubusercontent.com/5115928/230720678-1a46cfae-4fbe-4ce5-9c09-141dfb59bb41.gif)
