### PR TITLE
Ensure flash messages are shown 4 seconds then disappear

### DIFF
--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useEffect } from 'react'
+import { createContext, useState, useEffect, useRef } from 'react'
 import { ProviderProps } from '../types/contexts'
 import { type FlashProps, type ModalProps } from '../types/pageContext'
 
@@ -30,7 +30,8 @@ const PageContext = createContext<PageContextType>({
 const PageProvider = ({ children }: ProviderProps) => {
   const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
   const [modalProps, setModalProps] = useState<ModalProps>(defaultModalProps)
-  const [flashVisibleSince, setFlashVisibleSince] = useState<Date | null>(null)
+
+  const flashVisibleSince = useRef<number>(0)
 
   const value = {
     flashProps,
@@ -40,21 +41,16 @@ const PageProvider = ({ children }: ProviderProps) => {
   }
 
   useEffect(() => {
-    if (flashProps.hidden === false) {
-      setFlashVisibleSince(new Date())
+    if (flashProps.hidden === true) return
 
-      setTimeout(() => {
-        const now = new Date()
+    flashVisibleSince.current = Number(new Date())
 
-        if (
-          flashVisibleSince &&
-          Number(now) - Number(flashVisibleSince) >= 4000
-        ) {
-          setFlashVisibleSince(null)
-          setFlashProps({ ...flashProps, hidden: true })
-        }
-      }, 4000)
-    }
+    setTimeout(() => {
+      if (Number(new Date()) - flashVisibleSince.current >= 4000) {
+        setFlashProps({ ...flashProps, hidden: true })
+        flashVisibleSince.current = 0
+      }
+    }, 4000)
   }, [flashProps])
 
   return <PageContext.Provider value={value}>{children}</PageContext.Provider>

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -31,7 +31,7 @@ const PageProvider = ({ children }: ProviderProps) => {
   const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
   const [modalProps, setModalProps] = useState<ModalProps>(defaultModalProps)
 
-  const flashVisibleSince = useRef<number>(0)
+  const flashVisibleSince = useRef(0)
 
   const value = {
     flashProps,


### PR DESCRIPTION
## Context

[**Flash messages not disappearing**](https://trello.com/c/Jgu4b9J2/292-flash-message-not-disappearing)

When a user takes a certain action (creating a game, cancelling deletion of a shopping list, deleting a shopping list item, various other examples), SIM shows a flash message indicating their action was successful - or, if there was an error, what the error was. We want these messages to be visible for 4 seconds and then fade out. The only exception is if, during the four seconds, another flash message is triggered. In that case, it should replace the first message and disappear after a full four seconds - not when the original message was scheduled to disappear.

In our original approach of using a state variable for `flashVisibleSince`, we ran into a stale closure problem. We could make `flashVisibleSince` a dependency of the `useEffect` hook that hides the component, which messed things up because we could no longer tell based on the fact the hook was running whether the `flashProps` or the `flashVisibleSince` value had changed, or we could not make it a dependency, leading to other unexpected behaviour due to the stale closure.

The solution turned out to be using a ref instead of a state variable. This enabled us to circumvent the stale closure problem without triggering the `useEffect` hook to run again.

## Changes

* Use a ref instead of a state variable for the time the flash was made visible

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [x] Verify TypeScript compiles

## Manual Test Cases

You will need to test two things:

1. A flash message appears and disappears after four seconds
2. If a flash message is replaced by another flash message before disappearing, the second message is visible for 4 seconds and then disappears

For the first one, you can do any action - say, create a game - and wait for the flash message to appear. It should appear when the API call finishes. After four seconds, the message should fade out.

For the second one, try creating a game or shopping list with default attributes and immediately deleting another game or shopping list. When the first API call finishes, a flash message should be shown. It should then be replaced by the second flash message. That message should stay visible for 4 seconds and then fade out.