### PR TITLE
Remove link to running legacy front end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Skyrim Inventory Management Frontend
 
-This is the rewritten frontend to Skyrim Inventory Management. The original frontend, which now runs on https://sim-legacy.danascheider.com, can be found at https://github.com/danascheider/sim_legacy_frontend. This rewrite has just begun and the README will be expanded with additional information as the app grows.
+This is the rewritten frontend to Skyrim Inventory Management. The original frontend, which has been decommissioned, can be found at https://github.com/danascheider/sim_legacy_frontend. This rewrite has just begun and the README will be expanded with additional information as the app grows.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Skyrim Inventory Management Frontend
 
-This is the rewritten frontend to Skyrim Inventory Management. The original frontend, which has been decommissioned, can be found at https://github.com/danascheider/sim_legacy_frontend. This rewrite has just begun and the README will be expanded with additional information as the app grows.
+This is the rewritten frontend to Skyrim Inventory Management. The original frontend, which has been decommissioned, can be found at https://github.com/danascheider/sim_legacy_frontend.
 
 ## Table of Contents
 
+- [Production Site](#production-site)
 - [Overview](#overview)
 - [Developer Information](#developer-information)
   - [Running Locally](#running-locally)
@@ -19,6 +20,10 @@ This is the rewritten frontend to Skyrim Inventory Management. The original fron
   - [GitHub Actions](#github-actions)
     - [Tests](#tests)
     - [Deploys](#deploys)
+
+## Production Site
+
+https://sim.danascheider.com
 
 ## Overview
 


### PR DESCRIPTION
## Context

[**Decommission old front end**](https://trello.com/c/bdgz4P5j/295-decommission-old-front-end)

The time has come to take the legacy front end offline. The rewritten front end is what we've got now. I've nuked the Heroku dyno and gotten rid of DNS records and SSL certs, so the last step is to remove any links to `https://sim-legacy.danascheider.com`.

There are no code changes in this PR.

## Changes

* Remove link to legacy front end from README (keeping link to repo)

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Verify TypeScript compiles~~