### PR TITLE
Refresh token and retry when API returns a 401 response

### DIFF
--- a/docs/adrs/0009-standard-dom-breakpoints.md
+++ b/docs/adrs/0009-standard-dom-breakpoints.md
@@ -47,5 +47,3 @@ Our minimum officially supported viewport width is 320px, and our maximum is 140
 - 1024px and 1025px
 - 1200px and 1201px
 - 1404px and 1405px
-
-

--- a/src/support/data/contextValues.ts
+++ b/src/support/data/contextValues.ts
@@ -18,6 +18,9 @@ export const loginContextValue: LoginContextType = {
   user: testUser,
   token: 'xxxxxxx',
   requireLogin: noop,
+  withTokenRefresh: (fn) => {
+    fn('xxxxxxx')
+  },
   authLoading: false,
 }
 
@@ -25,6 +28,7 @@ export const loadingLoginContextValue: LoginContextType = {
   user: null,
   token: null,
   requireLogin: noop,
+  withTokenRefresh: noop,
   authLoading: true,
 }
 
@@ -32,6 +36,7 @@ export const unauthenticatedLoginContextValue: LoginContextType = {
   user: null,
   token: null,
   requireLogin: noop,
+  withTokenRefresh: noop,
   authLoading: false,
 }
 


### PR DESCRIPTION
## Context

[**Enable the back end to refresh tokens**](https://trello.com/c/V087rV56/290-enable-the-back-end-to-refresh-tokens)

Sometimes, the Google auth access token expires between the time the front end refreshes it and the time the back end receives it. This has been resulting in some odd behaviour, such as multiple consecutive logouts when trying to load the shopping list page. (To be honest, I'm not sure why it's always the shopping list page that causes these.)

Although the attached Trello card suggests this is back end work, we've decided to try a front end solution to this problem instead (see "Considerations", below).

## Changes

* Add `withTokenRefresh` function to `LoginProvider` value
* Update test data to include this function
* Use `withTokenRefresh` for all API calls

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [x] Verify TypeScript compiles

## Considerations

We were going to enable the back end to refresh tokens using a service account, but an investigation into that approach determined that it would involve substantial work. The back end would need to separately authenticate with Google and then authenticate the front end using its own token system. In other words, we would need to entirely revamp our auth architecture, which I was reluctant to do given we just got off the ground with this one.

Fortunately, there was a feasible alternative. When the back end returns a 401 error, the front end can refresh the token and retry the request. While this might be slightly less optimal from a performance perspective than the back end refreshing tokens on its own, it's certainly preferable from the standpoint of likely development investment. Implementing anything to do with Google auth has been an absolute quagmire, and setting up the kind of auth architecture we'd need to separately authenticate the back end could take months of dev effort, conservatively speaking. It would also substantially complicate session management.

## Manual Test Cases

This PR will be a challenge to manually test. Testing it would involve waiting for a Google access token to expire, making a request, and verifying that the request is retried after returning a 401. (In dev environments, there will be console logging indicating a request is being retried.) However, the more salient point is that what we are really looking for is evidence that this change has solved the problem we were having, i.e., multiple consecutive logouts/login prompts when a token expires. This problem came up just frequently enough to be annoying - a time or two per day during active use/testing - but not enough for it to be decisively obvious when it is solved.

My suggested solution is not to merge this PR immediately. Instead, we should base the next PR branch off this one and implicitly test this PR while doing manual tests for a more predictable feature or bugfix. We are testing both whether these changes solve the problem we're having and whether they break anything that is currently working. Specifically, we should be looking out for:

- Unexpected logouts
- Missing or extra API calls
- Unsuccessful logout attempts (i.e., user clicks sign out but is kept signed in)
- Excessive retries (a failed API call should be retried only once)
- Retries for errors other than authentication issues (only 401 errors should result in a retry)