### PR TITLE
Refresh token and retry when API returns a 401 response - take 2

### DIFF
--- a/docs/adrs/0009-standard-dom-breakpoints.md
+++ b/docs/adrs/0009-standard-dom-breakpoints.md
@@ -47,5 +47,3 @@ Our minimum officially supported viewport width is 320px, and our maximum is 140
 - 1024px and 1025px
 - 1200px and 1201px
 - 1404px and 1405px
-
-

--- a/docs/contexts/login-context.md
+++ b/docs/contexts/login-context.md
@@ -8,6 +8,68 @@ The `LoginProvider`'s value makes the following values available:
 - `token`: string
 - `authLoading`: boolean
 - `requireLogin`: function
+- `withTokenRefresh`: function
+  - Takes a single argument: a function taking the new ID token as a parameter
+
+## Refreshing Tokens on Failed API Call
+
+### Potential Issues
+
+Each time the front end makes an API call to the back end, it includes the access token provided by Google. The token is then validated on the back end using the front end's credentials. This can pose a problem if the token expires between the time the user refreshes the page and the time the back end validates the token with Google, resulting in a user being logged out and having to log in again even if their token could've been refreshed. Refreshing tokens on the back end is infeasible, since it would entail one of two things:
+
+1. Sending the refresh token to the back end over the network
+2. Authenticating the back end separately with Google, giving it its own tokens, and authenticating the front end with `devise_token_auth` or the like
+
+Of these options, the first is unacceptable for security reasons - sending the long-lived refresh token over the network would open SIM up to man-in-the-middle attacks, which are less likely since we are using HTTPS, but still possible. The second option is infeasible because it would involve an overhaul of our entire auth architecture and could entail months of work given how difficult it has been to work with Google Identity prior to the introduction of Firebase on the front end. Additionally, it would further complicate our auth system, making security vulnerabilities more likely.
+
+### Required Solutions
+
+In order to solve the issue of unnecessary logouts, the front end needs to refresh tokens and retry API calls that have returned a 401 response. Ideally, this would be taken care of within the API wrapper itself, however, it is not for the reasons described below. Consequently, when writing functions that call the API, developers should be sure to handle 401 responses from the API by retrying once using the `withTokenRefresh` function from the `LoginProvider`. A second 401 response should result in logout and redirection to the home/login page.
+
+Why not rewrite the API wrapper as a context provider? There are a few reasons. Firstly, we need to be mindful of adding too many context providers, since it's easy for React components to become very deeply nested in context providers. These providers can also potentially interfere with one another, leading to subtle bugs that can be difficult to troubleshoot. Secondly, the API provider would be extremely bloated. There are already numerous functions corresponding to different endpoints (11 at this writing, before implementing the inventory lists feature). The current API wrapper is made more manageable by breaking it up into multiple files from which it imports and then exports these functions, but in a context provider that wouldn't be possible since all the functions would rely on the `LoginProvider`'s `withTokenRefresh` function. This would result in a provider that could easily balloon into thousands of lines of code. For that reason, it makes more sense to keep token refresh functionality in the existing, resource-specific context providers.
+
+The existing pattern for retries is to create functions taking an `idToken` and `retries` as arguments that call themselves recursively from a catch function appended to a promise returned by the API wrapper function, as follows:
+
+```ts
+import { type ApiError } from '../../types/errors'
+import { getResource } from '../../utils/simApi'
+import { useGoogleLogin } from '../../hooks/contexts'
+
+// Define context here
+
+const MyProvider = ({ children }: MyProviderProps) => {
+  const { token, withTokenRefresh } = useGoogleLogin()
+
+  // Note that the type of the idToken is `string | null`, because
+  // the `token` might be `null`.
+  const fetchResource = (
+    idToken?: string | null = token,
+    retries?: number = 1
+  ) => {
+    if (idToken) {
+      getResource(idToken)
+        .then(({ json }) => {
+          /* do something */
+        })
+        .catch((e: ApiError) => {
+          if (e.code === 401 && retries > 0) {
+            return withTokenRefresh((newToken) => {
+              fetchResource(newToken, retries - 1)
+            })
+          } else {
+            /* handle error */
+          }
+        })
+    }
+  }
+
+  return (
+    <MyContext.Provider value={{ fetchResource }}>
+      {children}
+    </MyContext.Provider>
+  )
+}
+```
 
 ## Example
 

--- a/docs/contexts/login-context.md
+++ b/docs/contexts/login-context.md
@@ -1,75 +1,13 @@
 # Login Context
 
-The `LoginContext` keeps track of the logged in user and manages their tokens.
+The `LoginContext` keeps track of the logged in user, manages their tokens, signs out in the event of authentication errors, and provides a `requireLogin` function that can be used in the `useEffect` hook of any component using the context to sign out and redirect to the homepage if login is unsuccessful or no user is logged in.
 
 The `LoginProvider`'s value makes the following values available:
 
 - `user`: User (type defined in Firebase)
 - `token`: string
 - `authLoading`: boolean
-- `withTokenRefresh`: function
-  - Takes a single argument: a function taking the new ID token as a parameter
-
-## Refreshing Tokens on Failed API Call
-
-### Potential Issues
-
-Each time the front end makes an API call to the back end, it includes the access token provided by Google. The token is then validated on the back end using the front end's credentials. This can pose a problem if the token expires between the time the user refreshes the page and the time the back end validates the token with Google, resulting in a user being logged out and having to log in again even if their token could've been refreshed. Refreshing tokens on the back end is infeasible, since it would entail one of two things:
-
-1. Sending the refresh token to the back end over the network
-2. Authenticating the back end separately with Google, giving it its own tokens, and authenticating the front end with `devise_token_auth` or the like
-
-Of these options, the first is unacceptable for security reasons - sending the long-lived refresh token over the network would open SIM up to man-in-the-middle attacks, which are less likely since we are using HTTPS, but still possible. The second option is infeasible because it would involve an overhaul of our entire auth architecture and could entail months of work given how difficult it has been to work with Google Identity prior to the introduction of Firebase on the front end. Additionally, it would further complicate our auth system, making security vulnerabilities more likely.
-
-### Required Solutions
-
-In order to solve the issue of unnecessary logouts, the front end needs to refresh tokens and retry API calls that have returned a 401 response. Ideally, this would be taken care of within the API wrapper itself, however, it is not for the reasons described below. Consequently, when writing functions that call the API, developers should be sure to handle 401 responses from the API by retrying once using the `withTokenRefresh` function from the `LoginProvider`. A second 401 response should result in logout and redirection to the home/login page.
-
-Why not rewrite the API wrapper as a context provider? There are a few reasons. Firstly, we need to be mindful of adding too many context providers, since it's easy for React components to become very deeply nested in context providers. These providers can also potentially interfere with one another, leading to subtle bugs that can be difficult to troubleshoot. Secondly, the API provider would be extremely bloated. There are already numerous functions corresponding to different endpoints (11 at this writing, before implementing the inventory lists feature). The current API wrapper is made more manageable by breaking it up into multiple files from which it imports and then exports these functions, but in a context provider that wouldn't be possible since all the functions would rely on the `LoginProvider`'s `withTokenRefresh` function. This would result in a provider that could easily balloon into thousands of lines of code. For that reason, it makes more sense to keep token refresh functionality in the existing, resource-specific context providers.
-
-The existing pattern for retries is to create functions taking an `idToken` and `retries` as arguments that call themselves recursively from a `catch` function appended to a promise returned by the API wrapper function, as follows:
-
-```tsx
-import { type ApiError } from '../../types/errors'
-import { getResource } from '../../utils/simApi'
-import { useGoogleLogin } from '../../hooks/contexts'
-
-// Define context here
-
-const MyProvider = ({ children }: MyProviderProps) => {
-  const { token, withTokenRefresh } = useGoogleLogin()
-
-  // Note that the type of the idToken is `string | null`, because
-  // the `token` might be `null`.
-  const fetchResource = (
-    idToken?: string | null = token,
-    retries?: number = 1
-  ) => {
-    if (idToken) {
-      getResource(idToken)
-        .then(({ json }) => {
-          /* do something */
-        })
-        .catch((e: ApiError) => {
-          if (e.code === 401 && retries > 0) {
-            return withTokenRefresh((newToken) => {
-              fetchResource(newToken, retries - 1)
-            })
-          } else {
-            /* handle error */
-          }
-        })
-    }
-  }
-
-    return (
-      <MyContext.Provider value={{ fetchResource }}>
-        {children}
-      </MyContext.Provider>
-    )
-  }
-}
-```
+- `requireLogin`: function
 
 ## Example
 

--- a/docs/contexts/login-context.md
+++ b/docs/contexts/login-context.md
@@ -1,13 +1,75 @@
 # Login Context
 
-The `LoginContext` keeps track of the logged in user, manages their tokens, signs out in the event of authentication errors, and provides a `requireLogin` function that can be used in the `useEffect` hook of any component using the context to sign out and redirect to the homepage if login is unsuccessful or no user is logged in.
+The `LoginContext` keeps track of the logged in user and manages their tokens.
 
 The `LoginProvider`'s value makes the following values available:
 
 - `user`: User (type defined in Firebase)
 - `token`: string
 - `authLoading`: boolean
-- `requireLogin`: function
+- `withTokenRefresh`: function
+  - Takes a single argument: a function taking the new ID token as a parameter
+
+## Refreshing Tokens on Failed API Call
+
+### Potential Issues
+
+Each time the front end makes an API call to the back end, it includes the access token provided by Google. The token is then validated on the back end using the front end's credentials. This can pose a problem if the token expires between the time the user refreshes the page and the time the back end validates the token with Google, resulting in a user being logged out and having to log in again even if their token could've been refreshed. Refreshing tokens on the back end is infeasible, since it would entail one of two things:
+
+1. Sending the refresh token to the back end over the network
+2. Authenticating the back end separately with Google, giving it its own tokens, and authenticating the front end with `devise_token_auth` or the like
+
+Of these options, the first is unacceptable for security reasons - sending the long-lived refresh token over the network would open SIM up to man-in-the-middle attacks, which are less likely since we are using HTTPS, but still possible. The second option is infeasible because it would involve an overhaul of our entire auth architecture and could entail months of work given how difficult it has been to work with Google Identity prior to the introduction of Firebase on the front end. Additionally, it would further complicate our auth system, making security vulnerabilities more likely.
+
+### Required Solutions
+
+In order to solve the issue of unnecessary logouts, the front end needs to refresh tokens and retry API calls that have returned a 401 response. Ideally, this would be taken care of within the API wrapper itself, however, it is not for the reasons described below. Consequently, when writing functions that call the API, developers should be sure to handle 401 responses from the API by retrying once using the `withTokenRefresh` function from the `LoginProvider`. A second 401 response should result in logout and redirection to the home/login page.
+
+Why not rewrite the API wrapper as a context provider? There are a few reasons. Firstly, we need to be mindful of adding too many context providers, since it's easy for React components to become very deeply nested in context providers. These providers can also potentially interfere with one another, leading to subtle bugs that can be difficult to troubleshoot. Secondly, the API provider would be extremely bloated. There are already numerous functions corresponding to different endpoints (11 at this writing, before implementing the inventory lists feature). The current API wrapper is made more manageable by breaking it up into multiple files from which it imports and then exports these functions, but in a context provider that wouldn't be possible since all the functions would rely on the `LoginProvider`'s `withTokenRefresh` function. This would result in a provider that could easily balloon into thousands of lines of code. For that reason, it makes more sense to keep token refresh functionality in the existing, resource-specific context providers.
+
+The existing pattern for retries is to create functions taking an `idToken` and `retries` as arguments that call themselves recursively from a `catch` function appended to a promise returned by the API wrapper function, as follows:
+
+```tsx
+import { type ApiError } from '../../types/errors'
+import { getResource } from '../../utils/simApi'
+import { useGoogleLogin } from '../../hooks/contexts'
+
+// Define context here
+
+const MyProvider = ({ children }: MyProviderProps) => {
+  const { token, withTokenRefresh } = useGoogleLogin()
+
+  // Note that the type of the idToken is `string | null`, because
+  // the `token` might be `null`.
+  const fetchResource = (
+    idToken?: string | null = token,
+    retries?: number = 1
+  ) => {
+    if (idToken) {
+      getResource(idToken)
+        .then(({ json }) => {
+          /* do something */
+        })
+        .catch((e: ApiError) => {
+          if (e.code === 401 && retries > 0) {
+            return withTokenRefresh((newToken) => {
+              fetchResource(newToken, retries - 1)
+            })
+          } else {
+            /* handle error */
+          }
+        })
+    }
+  }
+
+    return (
+      <MyContext.Provider value={{ fetchResource }}>
+        {children}
+      </MyContext.Provider>
+    )
+  }
+}
+```
 
 ## Example
 

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -49,8 +49,7 @@ export const GamesContext = createContext<GamesContextType>({
 })
 
 export const GamesProvider = ({ children }: ProviderProps) => {
-  const { user, token, authLoading, requireLogin, withTokenRefresh } =
-    useGoogleLogin()
+  const { token, authLoading, withTokenRefresh } = useGoogleLogin()
   const [gamesLoadingState, setGamesLoadingState] = useState(LOADING)
   const [games, setGames] = useState<Game[]>([])
   const { setFlashProps, setModalProps } = usePageContext()
@@ -298,10 +297,6 @@ export const GamesProvider = ({ children }: ProviderProps) => {
     updateGame,
     destroyGame,
   }
-
-  useEffect(() => {
-    requireLogin()
-  }, [requireLogin])
 
   useEffect(() => {
     if (authLoading) return

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useEffect, useState } from 'react'
+import { createContext, useCallback, useEffect, useState, useRef } from 'react'
 import { signOutWithGoogle } from '../firebase'
 import { type RequestGame, type ResponseGame as Game } from '../types/apiData'
 import { type ProviderProps } from '../types/contexts'
@@ -49,11 +49,12 @@ export const GamesContext = createContext<GamesContextType>({
 })
 
 export const GamesProvider = ({ children }: ProviderProps) => {
-  const { user, token, authLoading, requireLogin, withTokenRefresh } =
+  const { token, authLoading, requireLogin, withTokenRefresh } =
     useGoogleLogin()
   const [gamesLoadingState, setGamesLoadingState] = useState(LOADING)
   const [games, setGames] = useState<Game[]>([])
   const { setFlashProps, setModalProps } = usePageContext()
+  const previousTokenRef = useRef(token)
 
   /**
    *
@@ -304,10 +305,14 @@ export const GamesProvider = ({ children }: ProviderProps) => {
   }, [requireLogin])
 
   useEffect(() => {
-    if (authLoading) return
+    if (
+      authLoading ||
+      (token && previousTokenRef.current && previousTokenRef.current !== token)
+    )
+      return
 
     fetchGames()
-  }, [authLoading])
+  }, [authLoading, token])
 
   return <GamesContext.Provider value={value}>{children}</GamesContext.Provider>
 }

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -305,13 +305,18 @@ export const GamesProvider = ({ children }: ProviderProps) => {
   }, [requireLogin])
 
   useEffect(() => {
-    if (
-      authLoading ||
-      (token && previousTokenRef.current && previousTokenRef.current !== token)
-    )
-      return
+    if (authLoading) return
 
-    fetchGames()
+    // Only fetch games if token is present and
+    // (a) the token just changed from null to a string value or
+    // (b) the token is already set and it is the initial render
+    if (
+      token &&
+      (!previousTokenRef.current || previousTokenRef.current === token)
+    )
+      fetchGames()
+
+    previousTokenRef.current = token
   }, [authLoading, token])
 
   return <GamesContext.Provider value={value}>{children}</GamesContext.Provider>

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -233,7 +233,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
           })
       }
     },
-    [user, token, games]
+    [token, games]
   )
 
   /**
@@ -288,7 +288,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
           })
       }
     },
-    [user, token, games]
+    [token, games]
   )
 
   const value = {
@@ -307,7 +307,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
     if (authLoading) return
 
     fetchGames()
-  }, [authLoading, fetchGames])
+  }, [authLoading])
 
   return <GamesContext.Provider value={value}>{children}</GamesContext.Provider>
 }

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -49,7 +49,8 @@ export const GamesContext = createContext<GamesContextType>({
 })
 
 export const GamesProvider = ({ children }: ProviderProps) => {
-  const { token, authLoading, withTokenRefresh } = useGoogleLogin()
+  const { user, token, authLoading, requireLogin, withTokenRefresh } =
+    useGoogleLogin()
   const [gamesLoadingState, setGamesLoadingState] = useState(LOADING)
   const [games, setGames] = useState<Game[]>([])
   const { setFlashProps, setModalProps } = usePageContext()
@@ -297,6 +298,10 @@ export const GamesProvider = ({ children }: ProviderProps) => {
     updateGame,
     destroyGame,
   }
+
+  useEffect(() => {
+    requireLogin()
+  }, [requireLogin])
 
   useEffect(() => {
     if (authLoading) return

--- a/src/contexts/loginContext.tsx
+++ b/src/contexts/loginContext.tsx
@@ -1,12 +1,15 @@
 import { createContext, useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { type User } from 'firebase/auth'
 import { useAuthState } from 'react-firebase-hooks/auth'
 import { auth, signOutWithGoogle } from '../firebase'
 import { ProviderProps } from '../types/contexts'
+import paths from '../routing/paths'
 
 export interface LoginContextType {
   authLoading: boolean
   token: string | null
+  requireLogin: () => void
   withTokenRefresh: (fn: (idToken: string) => void) => void
   user?: User | null
 }
@@ -15,12 +18,20 @@ export const LoginContext = createContext<LoginContextType>({
   user: null,
   token: null,
   authLoading: true,
+  requireLogin: () => {}, // noop
   withTokenRefresh: () => {},
 })
 
 export const LoginProvider = ({ children }: ProviderProps) => {
   const [user, authLoading, authError] = useAuthState(auth)
   const [token, setToken] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const requireLogin = useCallback(() => {
+    if (!user && !authLoading) {
+      navigate(paths.home)
+    }
+  }, [user, authLoading])
 
   const refreshToken = useCallback(() => {
     if (user) user.getIdToken(true).then((idToken) => setToken(idToken))
@@ -38,6 +49,7 @@ export const LoginProvider = ({ children }: ProviderProps) => {
   const value = {
     user,
     token,
+    requireLogin,
     withTokenRefresh,
     authLoading,
   }

--- a/src/contexts/loginContext.tsx
+++ b/src/contexts/loginContext.tsx
@@ -1,15 +1,12 @@
 import { createContext, useState, useEffect, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { type User } from 'firebase/auth'
 import { useAuthState } from 'react-firebase-hooks/auth'
 import { auth, signOutWithGoogle } from '../firebase'
 import { ProviderProps } from '../types/contexts'
-import paths from '../routing/paths'
 
 export interface LoginContextType {
   authLoading: boolean
   token: string | null
-  requireLogin: () => void
   withTokenRefresh: (fn: (idToken: string) => void) => void
   user?: User | null
 }
@@ -18,20 +15,12 @@ export const LoginContext = createContext<LoginContextType>({
   user: null,
   token: null,
   authLoading: true,
-  requireLogin: () => {}, // noop
   withTokenRefresh: () => {},
 })
 
 export const LoginProvider = ({ children }: ProviderProps) => {
   const [user, authLoading, authError] = useAuthState(auth)
   const [token, setToken] = useState<string | null>(null)
-  const navigate = useNavigate()
-
-  const requireLogin = useCallback(() => {
-    if (!user && !authLoading) {
-      navigate(paths.home)
-    }
-  }, [user, authLoading])
 
   const refreshToken = useCallback(() => {
     if (user) user.getIdToken(true).then((idToken) => setToken(idToken))
@@ -49,7 +38,6 @@ export const LoginProvider = ({ children }: ProviderProps) => {
   const value = {
     user,
     token,
-    requireLogin,
     withTokenRefresh,
     authLoading,
   }

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -691,13 +691,18 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   }, [queryString, gamesLoadingState, games])
 
   useEffect(() => {
-    if (
-      authLoading ||
-      (token && previousTokenRef.current && previousTokenRef.current !== token)
-    )
-      return
+    if (authLoading) return
 
-    fetchShoppingLists()
+    // Only fetch shopping lists if token is present and
+    // (a) the token just changed from null to a string value or
+    // (b) the token is already set and it is the initial render
+    if (
+      token &&
+      (!previousTokenRef.current || previousTokenRef.current === token)
+    )
+      fetchShoppingLists()
+
+    previousTokenRef.current = token
   }, [authLoading, activeGame, token])
 
   useEffect(() => {

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -90,7 +90,7 @@ export const ShoppingListsContext = createContext<ShoppingListsContextType>({
 })
 
 export const ShoppingListsProvider = ({ children }: ProviderProps) => {
-  const { user, token, authLoading, requireLogin, withTokenRefresh } =
+  const { token, authLoading, requireLogin, withTokenRefresh } =
     useGoogleLogin()
   const { setFlashProps } = usePageContext()
   const { gamesLoadingState, games } = useGamesContext()
@@ -211,7 +211,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
           })
       }
     },
-    [user, token, activeGame, shoppingLists]
+    [token, activeGame, shoppingLists]
   )
 
   /**

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState, useCallback } from 'react'
+import { createContext, useEffect, useState, useRef, useCallback } from 'react'
 import { signOutWithGoogle } from '../firebase'
 import { type CallbackFunction } from '../types/functions'
 import {
@@ -99,6 +99,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   const [shoppingListsLoadingState, setShoppingListsLoadingState] =
     useState(LOADING)
   const [shoppingLists, setShoppingLists] = useState<ResponseShoppingList[]>([])
+  const previousTokenRef = useRef(token)
 
   /**
    *
@@ -690,10 +691,14 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   }, [queryString, gamesLoadingState, games])
 
   useEffect(() => {
-    if (authLoading) return
+    if (
+      authLoading ||
+      (token && previousTokenRef.current && previousTokenRef.current !== token)
+    )
+      return
 
     fetchShoppingLists()
-  }, [authLoading, activeGame])
+  }, [authLoading, activeGame, token])
 
   useEffect(() => {
     requireLogin()

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -652,7 +652,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
           })
       }
     },
-    [user, token, shoppingLists]
+    [token, shoppingLists]
   )
 
   /**
@@ -693,7 +693,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
     if (authLoading) return
 
     fetchShoppingLists()
-  }, [authLoading, fetchShoppingLists])
+  }, [authLoading, activeGame])
 
   useEffect(() => {
     requireLogin()

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -594,7 +594,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
-        deleteShoppingListItem(itemId, token)
+        deleteShoppingListItem(itemId, idToken)
           .then(({ status, json }) => {
             if (status === 200) {
               const newShoppingLists = [...shoppingLists]
@@ -625,6 +625,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
             }
           })
           .catch((e: ApiError) => {
+            retries ??= 1
+
             if (e.code === 401 && retries > 0) {
               return withTokenRefresh((newToken) => {
                 destroyShoppingListItem(

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -90,8 +90,7 @@ export const ShoppingListsContext = createContext<ShoppingListsContextType>({
 })
 
 export const ShoppingListsProvider = ({ children }: ProviderProps) => {
-  const { user, token, authLoading, requireLogin, withTokenRefresh } =
-    useGoogleLogin()
+  const { token, authLoading, withTokenRefresh } = useGoogleLogin()
   const { setFlashProps } = usePageContext()
   const { gamesLoadingState, games } = useGamesContext()
   const queryString = useQueryString()
@@ -210,7 +209,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
           })
       }
     },
-    [user, token, activeGame, shoppingLists]
+    [token, activeGame, shoppingLists]
   )
 
   /**
@@ -694,10 +693,6 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
 
     fetchShoppingLists()
   }, [authLoading, activeGame])
-
-  useEffect(() => {
-    requireLogin()
-  }, [requireLogin])
 
   return (
     <ShoppingListsContext.Provider value={value}>

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -90,7 +90,8 @@ export const ShoppingListsContext = createContext<ShoppingListsContextType>({
 })
 
 export const ShoppingListsProvider = ({ children }: ProviderProps) => {
-  const { token, authLoading, withTokenRefresh } = useGoogleLogin()
+  const { user, token, authLoading, requireLogin, withTokenRefresh } =
+    useGoogleLogin()
   const { setFlashProps } = usePageContext()
   const { gamesLoadingState, games } = useGamesContext()
   const queryString = useQueryString()
@@ -209,7 +210,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
           })
       }
     },
-    [token, activeGame, shoppingLists]
+    [user, token, activeGame, shoppingLists]
   )
 
   /**
@@ -693,6 +694,10 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
 
     fetchShoppingLists()
   }, [authLoading, activeGame])
+
+  useEffect(() => {
+    requireLogin()
+  }, [requireLogin])
 
   return (
     <ShoppingListsContext.Provider value={value}>

--- a/src/pages/dashboardPage/dashboardPage.tsx
+++ b/src/pages/dashboardPage/dashboardPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, CSSProperties } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { PulseLoader } from 'react-spinners'
 import { type RelativePath } from '../../types/navigation'
 import { YELLOW, PINK, BLUE, GREEN, AQUA } from '../../utils/colorSchemes'
@@ -49,12 +48,11 @@ const loaderStyles: CSSProperties = {
 }
 
 const DashboardPage = () => {
-  const { token, authLoading } = useGoogleLogin()
-  const navigate = useNavigate()
+  const { authLoading, requireLogin } = useGoogleLogin()
 
   useEffect(() => {
-    if (!token && !authLoading) navigate(paths.home)
-  }, [token, authLoading])
+    requireLogin()
+  }, [requireLogin])
 
   return (
     <DashboardLayout>

--- a/src/pages/dashboardPage/dashboardPage.tsx
+++ b/src/pages/dashboardPage/dashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { PulseLoader } from 'react-spinners'
 import { type RelativePath } from '../../types/navigation'
 import { YELLOW, PINK, BLUE, GREEN, AQUA } from '../../utils/colorSchemes'
@@ -48,11 +49,12 @@ const loaderStyles: CSSProperties = {
 }
 
 const DashboardPage = () => {
-  const { authLoading, requireLogin } = useGoogleLogin()
+  const { token, authLoading } = useGoogleLogin()
+  const navigate = useNavigate()
 
   useEffect(() => {
-    requireLogin()
-  }, [requireLogin])
+    if (!token && !authLoading) navigate(paths.home)
+  }, [token, authLoading])
 
   return (
     <DashboardLayout>

--- a/src/support/data/contextValues.ts
+++ b/src/support/data/contextValues.ts
@@ -17,7 +17,6 @@ const noop = () => {}
 export const loginContextValue: LoginContextType = {
   user: testUser,
   token: 'xxxxxxx',
-  requireLogin: noop,
   withTokenRefresh: (fn) => fn('xxxxxxx'),
   authLoading: false,
 }
@@ -25,7 +24,6 @@ export const loginContextValue: LoginContextType = {
 export const loadingLoginContextValue: LoginContextType = {
   user: null,
   token: null,
-  requireLogin: noop,
   withTokenRefresh: noop,
   authLoading: true,
 }
@@ -33,7 +31,6 @@ export const loadingLoginContextValue: LoginContextType = {
 export const unauthenticatedLoginContextValue: LoginContextType = {
   user: null,
   token: null,
-  requireLogin: noop,
   withTokenRefresh: noop,
   authLoading: false,
 }

--- a/src/support/data/contextValues.ts
+++ b/src/support/data/contextValues.ts
@@ -18,6 +18,7 @@ export const loginContextValue: LoginContextType = {
   user: testUser,
   token: 'xxxxxxx',
   requireLogin: noop,
+  withTokenRefresh: (fn) => fn('xxxxxxx'),
   authLoading: false,
 }
 
@@ -25,6 +26,7 @@ export const loadingLoginContextValue: LoginContextType = {
   user: null,
   token: null,
   requireLogin: noop,
+  withTokenRefresh: noop,
   authLoading: true,
 }
 
@@ -32,6 +34,7 @@ export const unauthenticatedLoginContextValue: LoginContextType = {
   user: null,
   token: null,
   requireLogin: noop,
+  withTokenRefresh: noop,
   authLoading: false,
 }
 

--- a/src/support/data/contextValues.ts
+++ b/src/support/data/contextValues.ts
@@ -17,6 +17,7 @@ const noop = () => {}
 export const loginContextValue: LoginContextType = {
   user: testUser,
   token: 'xxxxxxx',
+  requireLogin: noop,
   withTokenRefresh: (fn) => fn('xxxxxxx'),
   authLoading: false,
 }
@@ -24,6 +25,7 @@ export const loginContextValue: LoginContextType = {
 export const loadingLoginContextValue: LoginContextType = {
   user: null,
   token: null,
+  requireLogin: noop,
   withTokenRefresh: noop,
   authLoading: true,
 }
@@ -31,6 +33,7 @@ export const loadingLoginContextValue: LoginContextType = {
 export const unauthenticatedLoginContextValue: LoginContextType = {
   user: null,
   token: null,
+  requireLogin: noop,
   withTokenRefresh: noop,
   authLoading: false,
 }


### PR DESCRIPTION
## Context

[**Enable the back end to refresh tokens**](https://trello.com/c/V087rV56/290-enable-the-back-end-to-refresh-tokens)

In #68, we attempted to catch 401 responses from the API and retry the requests after refreshing the Google access token. Unfortunately, this approach did not work during manual testing. This PR is take 2.

## Changes

* Ensure Google access tokens are refreshed and API calls retried if the API returns a 401 response
* Remove `requireLogin` function from `LoginProvider` and remove from `useEffect` hooks in `ShoppingListsProvider` and `GamesProvider`
* Run formatter (hence random changed ADR)

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] Verify TypeScript compiles

## Considerations

There's much about this approach I'm not happy with, starting with the two additional positional args every function that makes an API call now has to take (`idToken` and `retries`). I wanted to give these args default values to make them a little less onerous, but that would involve putting them before the optional args (mostly `onSuccess` and `onError` callbacks), forcing a value to be included every time the functions were called with optional args. I wanted these values to be "behind the scenes" and not that visible to any old context consumer.

## Manual Test Cases

Manually testing this PR will be a slow process since we'll have to manually test each function after waiting for the access token to expire. It is also completely essential since automated testing was impractical. The following functions will need to be tested, after waiting for the token to expire and without refreshing the page:

- [x] Create a game from the games page
- [x] Update a game on the games page
- [x] Destroy a game on the games page
- [x] Fetch shopping lists for another game on the shopping lists page (just change game in dropdown)
- [x] Create a shopping list on the shopping lists page
- [x] Update the title of a shopping list on the shopping lists page
- [x] Destroy a shopping list on the shopping lists page
- [x] Create a shopping list item on the shopping lists page
- [x] Update a shopping list item on the shopping lists page
- [x] Destroy a shopping list item on the shopping lists page

Remember that updating code refreshes the page, so we can't make code changes while waiting. Additionally, fetching games also now has the same retry behaviour, however, it is difficult to effect a fetch of games without refreshing the page.

To verify the functionality is working, after performing each action, look at the back end logs to ensure two requests have been made. The first should've resulted in a 401 response, and the second should be successful.
