### PR TITLE
Prevent users' resources being accessed after they log out

### DIFF
--- a/docs/contexts/login-context.md
+++ b/docs/contexts/login-context.md
@@ -8,6 +8,7 @@ The `LoginProvider`'s value makes the following values available:
 - `token`: string
 - `authLoading`: boolean
 - `requireLogin`: function
+- `signOut`: function
 - `withTokenRefresh`: function
   - Takes a single argument: a function taking the new ID token as a parameter
 
@@ -132,3 +133,7 @@ In this example, the login context identifies the signed-in user, if any, and pr
 ## Types
 
 The `LoginProvider` takes no props other than `children`, which can be React (TSX) elements or string types.
+
+## signOut vs. signOutWithGoogle
+
+The [firebase.ts](/src/firebase.ts) file exports a function called `signOutWithGoogle`. This should not be used to sign out users. Instead, the `LoginProvider`'s `signOut` function should be used. The `signOutWithGoogle` function signs out the user but doesn't nullify the user's token in memory, meaning that it could still be used for other back-end requests after that user has logged out, even if another user has subsequently logged in, as long as the token hasn't expired and the second user doesn't refresh the page.

--- a/docs/contexts/page-context.md
+++ b/docs/contexts/page-context.md
@@ -81,7 +81,6 @@ export default Parent
  */
 
 import { useState, useEffect } from 'react'
-import { signOutWithGoogle } from '../../firebase'
 import { type ResponseGame as Game } from '../../types/apiData'
 import { type ApiError } from '../../types/errors'
 import { useGoogleLogin, usePageContext } from '../../hooks/contexts'
@@ -90,7 +89,7 @@ import DashboardLayout from '../../layouts/dashboardLayout/dashboardLayout'
 import styles from './child.module.css'
 
 const Child = () => {
-  const { user, token, authLoading } = useGoogleLogin()
+  const { user, token, authLoading, signOut } = useGoogleLogin()
   const { setFlashProps } = usePageContext()
   const [games, setGames] = useState<Game[]>([])
 
@@ -103,7 +102,7 @@ const Child = () => {
           setGames(json)
         })
         .catch((e: ApiError) => {
-          if (e.status === 401) signOutWithGoogle()
+          if (e.status === 401) signOut()
 
           setFlashProps({
             type: 'error',

--- a/src/components/dashboardHeader/__snapshots__/dashboardHeader.test.tsx.snap
+++ b/src/components/dashboardHeader/__snapshots__/dashboardHeader.test.tsx.snap
@@ -85,7 +85,9 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -194,7 +196,9 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
           <menu
             class="_dropdown_d263fb"
           >
-            <div>
+            <div
+              role="button"
+            >
               <svg
                 aria-hidden="true"
                 class="svg-inline--fa fa-right-from-bracket "

--- a/src/components/userInfo/__snapshots__/userInfo.test.tsx.snap
+++ b/src/components/userInfo/__snapshots__/userInfo.test.tsx.snap
@@ -55,7 +55,9 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
         <menu
           class="_dropdown_d263fb"
         >
-          <div>
+          <div
+            role="button"
+          >
             <svg
               aria-hidden="true"
               class="svg-inline--fa fa-right-from-bracket "
@@ -132,7 +134,9 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
       <menu
         class="_dropdown_d263fb"
       >
-        <div>
+        <div
+          role="button"
+        >
           <svg
             aria-hidden="true"
             class="svg-inline--fa fa-right-from-bracket "

--- a/src/components/userInfo/userInfo.tsx
+++ b/src/components/userInfo/userInfo.tsx
@@ -2,14 +2,13 @@ import { type MouseEventHandler, useState } from 'react'
 import classnames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBars, faRightFromBracket } from '@fortawesome/free-solid-svg-icons'
-import { signOutWithGoogle } from '../../firebase'
 import { useGoogleLogin } from '../../hooks/contexts'
 import anonymousAvatar from './anonymousAvatar.jpg'
 import styles from './userInfo.module.css'
 
 const UserInfo = () => {
   const [dropdownVisible, setDropdownVisible] = useState(false)
-  const { user } = useGoogleLogin()
+  const { user, signOut } = useGoogleLogin()
 
   const toggleDropdown: MouseEventHandler = (): void => {
     setDropdownVisible(!dropdownVisible)
@@ -40,7 +39,7 @@ const UserInfo = () => {
             [styles.active]: dropdownVisible,
           })}
         >
-          <div onClick={signOutWithGoogle}>
+          <div onClick={signOut}>
             <FontAwesomeIcon icon={faRightFromBracket} />
             <p className={styles.signOutText}>Sign Out</p>
           </div>

--- a/src/components/userInfo/userInfo.tsx
+++ b/src/components/userInfo/userInfo.tsx
@@ -39,7 +39,7 @@ const UserInfo = () => {
             [styles.active]: dropdownVisible,
           })}
         >
-          <div onClick={signOut}>
+          <div role="button" onClick={signOut}>
             <FontAwesomeIcon icon={faRightFromBracket} />
             <p className={styles.signOutText}>Sign Out</p>
           </div>

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -1,5 +1,4 @@
 import { createContext, useCallback, useEffect, useState, useRef } from 'react'
-import { signOutWithGoogle } from '../firebase'
 import { type RequestGame, type ResponseGame as Game } from '../types/apiData'
 import { type ProviderProps } from '../types/contexts'
 import { type CallbackFunction } from '../types/functions'
@@ -49,7 +48,7 @@ export const GamesContext = createContext<GamesContextType>({
 })
 
 export const GamesProvider = ({ children }: ProviderProps) => {
-  const { token, authLoading, requireLogin, withTokenRefresh } =
+  const { token, authLoading, requireLogin, withTokenRefresh, signOut } =
     useGoogleLogin()
   const [gamesLoadingState, setGamesLoadingState] = useState(LOADING)
   const [games, setGames] = useState<Game[]>([])
@@ -65,7 +64,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
   const handleApiError = (e: ApiError) => {
     if (import.meta.env.DEV) console.error(e.message)
 
-    if (e.code === 401) signOutWithGoogle()
+    if (e.code === 401) signOut()
 
     if (Array.isArray(e.message)) {
       setFlashProps({

--- a/src/contexts/loginContext.tsx
+++ b/src/contexts/loginContext.tsx
@@ -10,6 +10,7 @@ export interface LoginContextType {
   authLoading: boolean
   token: string | null
   requireLogin: () => void
+  signOut: () => void
   withTokenRefresh: (fn: (idToken: string) => void) => void
   user?: User | null
 }
@@ -18,8 +19,9 @@ export const LoginContext = createContext<LoginContextType>({
   user: null,
   token: null,
   authLoading: true,
+  signOut: () => {}, // noop
   requireLogin: () => {}, // noop
-  withTokenRefresh: () => {},
+  withTokenRefresh: () => {}, // noop
 })
 
 export const LoginProvider = ({ children }: ProviderProps) => {
@@ -46,16 +48,21 @@ export const LoginProvider = ({ children }: ProviderProps) => {
     }
   }
 
+  const signOut = () => {
+    signOutWithGoogle().then(() => setToken(null))
+  }
+
   const value = {
     user,
     token,
     requireLogin,
     withTokenRefresh,
+    signOut,
     authLoading,
   }
 
   useEffect(() => {
-    if (authError) signOutWithGoogle()
+    if (authError) signOut()
 
     refreshToken()
   }, [user, authError])

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -1,5 +1,4 @@
 import { createContext, useEffect, useState, useRef, useCallback } from 'react'
-import { signOutWithGoogle } from '../firebase'
 import { type CallbackFunction } from '../types/functions'
 import {
   type RequestShoppingListItem,
@@ -90,7 +89,7 @@ export const ShoppingListsContext = createContext<ShoppingListsContextType>({
 })
 
 export const ShoppingListsProvider = ({ children }: ProviderProps) => {
-  const { token, authLoading, requireLogin, withTokenRefresh } =
+  const { token, authLoading, requireLogin, withTokenRefresh, signOut } =
     useGoogleLogin()
   const { setFlashProps } = usePageContext()
   const { gamesLoadingState, games } = useGamesContext()
@@ -111,7 +110,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
     if (import.meta.env.DEV) console.error(e.message)
 
     if (e.code === 401) {
-      signOutWithGoogle()
+      signOut()
     } else if (e.code === 422) {
       setFlashProps({
         hidden: false,

--- a/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
+++ b/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
@@ -105,7 +105,9 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -251,7 +253,9 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -514,7 +518,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -720,7 +726,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -983,7 +991,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -1189,7 +1199,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -1436,7 +1448,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -1626,7 +1640,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -1868,7 +1884,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -2053,7 +2071,9 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -2244,7 +2264,9 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -2378,7 +2400,9 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "

--- a/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
+++ b/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
@@ -155,7 +155,9 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -351,7 +353,9 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "

--- a/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
+++ b/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
@@ -407,7 +407,9 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -568,7 +570,9 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -786,7 +790,9 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -947,7 +953,9 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -1165,7 +1173,9 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -1326,7 +1336,9 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "

--- a/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
+++ b/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
@@ -1702,7 +1702,9 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -3022,7 +3024,9 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "
@@ -3304,7 +3308,9 @@ exports[`ShoppingListsPage > viewing shopping lists > when there are no games > 
               <menu
                 class="_dropdown_d263fb"
               >
-                <div>
+                <div
+                  role="button"
+                >
                   <svg
                     aria-hidden="true"
                     class="svg-inline--fa fa-right-from-bracket "
@@ -3529,7 +3535,9 @@ exports[`ShoppingListsPage > viewing shopping lists > when there are no games > 
             <menu
               class="_dropdown_d263fb"
             >
-              <div>
+              <div
+                role="button"
+              >
                 <svg
                   aria-hidden="true"
                   class="svg-inline--fa fa-right-from-bracket "

--- a/src/support/data/contextValues.ts
+++ b/src/support/data/contextValues.ts
@@ -18,6 +18,7 @@ export const loginContextValue: LoginContextType = {
   user: testUser,
   token: 'xxxxxxx',
   requireLogin: noop,
+  signOut: noop,
   withTokenRefresh: (fn) => fn('xxxxxxx'),
   authLoading: false,
 }
@@ -26,6 +27,7 @@ export const loadingLoginContextValue: LoginContextType = {
   user: null,
   token: null,
   requireLogin: noop,
+  signOut: noop,
   withTokenRefresh: noop,
   authLoading: true,
 }
@@ -34,6 +36,7 @@ export const unauthenticatedLoginContextValue: LoginContextType = {
   user: null,
   token: null,
   requireLogin: noop,
+  signOut: noop,
   withTokenRefresh: noop,
   authLoading: false,
 }


### PR DESCRIPTION
## Context

[**Leaky sign-in state giving users access to other users' resources**](https://trello.com/c/og8GrMGx/300-leaky-sign-in-state-giving-users-access-to-other-users-resources)

We discovered an issue where, if a user signed out and another user immediately signed in without refreshing the page, the first user's token would be used to fetch resources, causing the response to include the first user's, and only the first user's, resources. It turns out Google tokens, oddly, remain valid after sign-out. Thus, since the `LoginProvider` doesn't nullify the token when a user logs out, that token stays in memory until the page is refreshed or the token expires. That is the case even if a new user logs in, due to the fact that the login page doesn't directly set the token on the login provider when the user signs in.

## Changes

* Create `signOut` function in `LoginProvider` that signs out the user and nullifies their token
* Update docs

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [x] Add/update docs
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles

## Considerations

I considered having the front end use a `signIn` function from the `LoginProvider` to set the token when the user signs in. However, this would've interfered with the `useAuthState` hook from `react-firebase-hooks/auth`, which we need since users don't always start on the login page (i.e., after logging in, a user may step away for X amount of time, come back and navigate directly to their shopping lists page or whatever). 

## Manual Test Cases

### Repro Steps

1. Sign in as a user with games and visit the games page
2. See that your games are visible
3. Sign out
4. Sign in again as a different user with visibly different games
5. Visit the games page
6. See that the first user's games are visible
7. Refresh the page
8. See that the second user's games are now visible

### Test Case

Follow the repro steps, but observe that now each user only gets to see their own games.