### PR TITLE
Fix bug where aggregate list disappears on shopping list creation

### DIFF
--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.tsx
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.tsx
@@ -1,4 +1,10 @@
-import { useRef, type FormEventHandler, type CSSProperties } from 'react'
+import {
+  useState,
+  useEffect,
+  useRef,
+  type FormEventHandler,
+  type CSSProperties,
+} from 'react'
 import { type RequestShoppingList } from '../../types/apiData'
 import { DONE } from '../../utils/loadingStates'
 import { BLUE } from '../../utils/colorSchemes'
@@ -10,11 +16,12 @@ const ShoppingListCreateForm = () => {
   const { shoppingListsLoadingState, createShoppingList } =
     useShoppingListsContext()
 
+  const [disabled, setDisabled] = useState(
+    gamesLoadingState !== DONE || shoppingListsLoadingState !== DONE
+  )
+
   const formRef = useRef<HTMLFormElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-
-  const disabled =
-    gamesLoadingState !== DONE || shoppingListsLoadingState !== DONE
 
   const colorVars = {
     '--button-color': BLUE.schemeColorDark,
@@ -43,15 +50,28 @@ const ShoppingListCreateForm = () => {
     const formData = new FormData(formRef.current)
     const attributes = extractAttributes(formData)
 
-    const clearForm = () => formRef.current?.reset()
+    const clearForm = () => {
+      formRef.current?.reset()
+      setDisabled(false)
+    }
 
     const focusInput = () => {
       formRef.current?.reset()
+      setDisabled(false)
       inputRef.current?.focus()
     }
 
+    setDisabled(true)
     createShoppingList(attributes, clearForm, focusInput)
   }
+
+  useEffect(() => {
+    if (gamesLoadingState === DONE && shoppingListsLoadingState === DONE) {
+      setDisabled(false)
+    } else {
+      setDisabled(true)
+    }
+  }, [gamesLoadingState, shoppingListsLoadingState])
 
   return (
     <form

--- a/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
+++ b/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
@@ -499,6 +499,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
               <input
                 aria-label="Title"
                 class="_input_1118ad"
+                disabled=""
                 name="title"
                 pattern="\\\\s*[A-Za-z0-9 \\\\-',]*\\\\s*"
                 placeholder="Title"
@@ -507,6 +508,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
               />
               <button
                 class="_button_1118ad"
+                disabled=""
                 type="submit"
               >
                 Create
@@ -1821,6 +1823,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
             <input
               aria-label="Title"
               class="_input_1118ad"
+              disabled=""
               name="title"
               pattern="\\\\s*[A-Za-z0-9 \\\\-',]*\\\\s*"
               placeholder="Title"
@@ -1829,6 +1832,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
             />
             <button
               class="_button_1118ad"
+              disabled=""
               type="submit"
             >
               Create


### PR DESCRIPTION
## Context

[**Fix bug where aggregate list disappears on shopping list creation**](https://trello.com/c/jmd1UoK7/271-fix-bug-where-aggregate-list-disappears-on-shopping-list-creation)

There is currently a race condition triggered when a user creates two shopping lists in rapid succession without waiting for the first API call to finish. When the first call finishes, the `shoppingLists` array is updated. However, when the second API call finishes, the list created in the second API call completely replaces that/those created in the first API call in the UI. (The backend behaviour is what's expected.) The race condition stems from the `createShoppingList` function in the `ShoppingListsProvider`. If the function is called a second time before it has finished running the first time, a stale closure is effectively produced where the `shoppingLists` value used within the function is frozen when it starts running but not updated when the value changes subsequently.

## Changes

* Use a state variable instead of a simple conditional to check if the `ShoppingListCreateForm` should be disabled
* Disable the create form after it is submitted until the API call has completed it

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [x] Run formatter on final changes
- [ ] Verify TypeScript compiles

## Considerations

This is part of a bigger issue where the only tools we currently have to determine whether an API call is in progress are the `gamesLoadingState` and `shoppingListsLoadingState` variables. However, we don't want these variables set to a value other than `DONE` for most API calls, since other values trigger a loading component to be displayed instead of the shopping lists or games. There is [a card](https://trello.com/c/wy3oFvd0/301-add-state-to-pagecontext-for-when-api-calls-are-in-progress) to address these race conditions more holistically by providing an indication of when an API call is in progress without triggering loading behaviour.

## Manual Test Cases

First, you need to make sure that the existing functionality works.

1. Go to the shopping lists page
2. See that the creation form is initially disabled
3. See that the creation form is enabled when games and shopping lists have finished loading

Next, check that the functionality works as expected when the create form is submitted successfully.

1. Go to the shopping lists page
2. Create a shopping list
3. See that the creation form is disabled when the API call is made
4. See that the creation form is reenabled when the API call completes

Finally, test the error case.

1. Go to the shopping lists page
2. Create a shopping list called "All Items"
3. See that the creation form is disabled when the API call is made
4. See that the creation form is reenabled when the API call completes, even though there is a validation error
