### PR TITLE
Maintain shopping list component height when edit form displayed

### DIFF
--- a/src/components/shoppingList/shoppingList.module.css
+++ b/src/components/shoppingList/shoppingList.module.css
@@ -40,9 +40,9 @@
 }
 
 .form {
-  height: 26px;
+  height: 25px;
   margin-left: 8px;
-  padding: 7px 0;
+  padding: 8px 0;
   max-width: var(--max-title-width);
 }
 


### PR DESCRIPTION
## Context

[**Make sure showing/hiding edit form doesn't change height of shopping list component**](https://trello.com/c/7oikgYeK/285-make-sure-showing-hiding-edit-form-doesnt-change-height-of-shopping-list-component)

Currently, there is a slight visual bug where showing or hiding the shopping list edit form slightly changes the height of the shopping list component when the title of the shopping list fits on a single line. The change was only a pixel or two, enough to be noticeable but not enough to look intentional. This PR adds some small CSS fixes that ensure that, when a shopping list's title fits on a single line, the component height doesn't change when the edit form is shown or hidden.

## Changes

* Correct height and padding values of the `ListEditForm` for a shopping list

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [ ] ~~Verify TypeScript compiles~~

## Considerations

These changes have been tested in Brave, Chrome, and Safari.

## Manual Test Cases

1. Go to the shopping lists page
2. Select a game that has at least one editable shopping list
3. Click the edit icon next to that shopping list's title
4. See that the form is displayed
5. See that the height of the shopping list component stays the same
6. See that the title text doesn't shift up or down

## Screenshots and GIFs

### Single-Line Title Doesn't Change

![SingleLine](https://user-images.githubusercontent.com/5115928/235270882-bbc142a3-b781-40fc-a01c-341d58bd4021.gif)

### Multi-Line Title Still Changes

![MultiLine](https://user-images.githubusercontent.com/5115928/235270899-3f7f2284-d474-4aee-86a8-68cfe4a9e026.gif)
