### PR TITLE
Enable games to be created from StyledSelect

### DIFF
--- a/docs/contexts/games-context.md
+++ b/docs/contexts/games-context.md
@@ -8,7 +8,7 @@ The `GamesContext` enables us to keep track of all of a user's games as well as 
 - `updateGame`: function that takes a `gameId` and `RequestGame` object as arguments and updates the game with that game ID using those attributes at the API, updating the `games` array if successful
 - `destroyGame`: function that takes a game ID as an argument and destroys the game with that ID at the API, updating the `games` array accordingly
 
-Each of the provided function can optionally take `onSuccess` and `onError` callbacks, in that order. These callbacks are of the `CallbackFunction` type; they take no arguments and have a `void` return type. They are useful for things like hiding a form after it has been successfully submitted.
+Each of the provided function can optionally take `onSuccess` and `onError` callbacks, in that order. These callbacks are of the `CallbackFunction` type; they take no arguments and have a `void` return type. The only exception is `createGame`, which passes the newly created `ResponseGame` object to the `onSuccess` callback. These functions are useful for things like hiding a form after it has been successfully submitted.
 
 Accessing games requires a user to be authenticated, so the `GamesProvider` can only be rendered inside a [`LoginProvider`](/docs/contexts/login-context.md). Note that the `GamesProvider` itself calls the `requireLogin` function provided by the login context, so this function should not be called in any `GamesContext` consumers. The `GamesProvider` must also also nested in a [`PageProvider`](/docs/contexts/page-context.md), which allows it to control flash messages and modal forms.
 

--- a/src/components/styledSelect/__snapshots__/styledSelect.test.tsx.snap
+++ b/src/components/styledSelect/__snapshots__/styledSelect.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
           <input
             aria-label="Add or Select Option"
             class="_headerText_0a8ecf"
-            data-testid="selectedOption"
           />
           <button
             class="_trigger_0a8ecf"
@@ -90,7 +89,6 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
         <input
           aria-label="Add or Select Option"
           class="_headerText_0a8ecf"
-          data-testid="selectedOption"
         />
         <button
           class="_trigger_0a8ecf"
@@ -216,7 +214,6 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
           <input
             aria-label="Add or Select Option"
             class="_headerText_0a8ecf"
-            data-testid="selectedOption"
           />
           <button
             class="_trigger_0a8ecf"
@@ -263,7 +260,6 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
         <input
           aria-label="Add or Select Option"
           class="_headerText_0a8ecf"
-          data-testid="selectedOption"
         />
         <button
           class="_trigger_0a8ecf"
@@ -367,7 +363,6 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
           <input
             aria-label="Add or Select Option"
             class="_headerText_0a8ecf"
-            data-testid="selectedOption"
           />
           <button
             class="_trigger_0a8ecf"
@@ -436,7 +431,6 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
         <input
           aria-label="Add or Select Option"
           class="_headerText_0a8ecf"
-          data-testid="selectedOption"
         />
         <button
           class="_trigger_0a8ecf"

--- a/src/components/styledSelect/__snapshots__/styledSelect.test.tsx.snap
+++ b/src/components/styledSelect/__snapshots__/styledSelect.test.tsx.snap
@@ -18,7 +18,8 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
           class="_header_0a8ecf"
           role="combobox"
         >
-          <p
+          <input
+            aria-label="Add or Select Option"
             class="_headerText_0a8ecf"
             data-testid="selectedOption"
           />
@@ -86,7 +87,8 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
         class="_header_0a8ecf"
         role="combobox"
       >
-        <p
+        <input
+          aria-label="Add or Select Option"
           class="_headerText_0a8ecf"
           data-testid="selectedOption"
         />
@@ -211,7 +213,8 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
           class="_header_0a8ecf"
           role="combobox"
         >
-          <p
+          <input
+            aria-label="Add or Select Option"
             class="_headerText_0a8ecf"
             data-testid="selectedOption"
           />
@@ -257,7 +260,8 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
         class="_header_0a8ecf"
         role="combobox"
       >
-        <p
+        <input
+          aria-label="Add or Select Option"
           class="_headerText_0a8ecf"
           data-testid="selectedOption"
         />
@@ -360,7 +364,8 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
           class="_header_0a8ecf"
           role="combobox"
         >
-          <p
+          <input
+            aria-label="Add or Select Option"
             class="_headerText_0a8ecf"
             data-testid="selectedOption"
           />
@@ -428,7 +433,8 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
         class="_header_0a8ecf"
         role="combobox"
       >
-        <p
+        <input
+          aria-label="Add or Select Option"
           class="_headerText_0a8ecf"
           data-testid="selectedOption"
         />

--- a/src/components/styledSelect/styledSelect.module.css
+++ b/src/components/styledSelect/styledSelect.module.css
@@ -21,11 +21,15 @@
 
 .headerText {
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
+  background-color: #fff;
   font-size: 1rem;
   color: #5f5f5f;
-  margin: 8px;
+  margin: 0;
+  padding: 8px;
   height: 1rem;
   line-height: 1;
+  border: none;
+  width: 100%;
 }
 
 .trigger {

--- a/src/components/styledSelect/styledSelect.test.tsx
+++ b/src/components/styledSelect/styledSelect.test.tsx
@@ -31,7 +31,7 @@ describe('StyledSelect', () => {
       expect(wrapper.queryByText("Doesn't matter")).toBeFalsy()
 
       // Main, initially visible box is empty by default
-      expect(wrapper.getByTestId('selectedOption').textContent).toBeFalsy()
+      expect(wrapper.getByLabelText('Add or Select Option').textContent).toBeFalsy()
 
       // Initially, no option is selected
       expect(wrapper.queryByRole('option', { selected: true })).toBeFalsy()
@@ -69,7 +69,7 @@ describe('StyledSelect', () => {
             />
           )
 
-          const input = wrapper.getByTestId('selectedOption')
+          const input = wrapper.getByLabelText('Add or Select Option')
 
           act(() => fireEvent.keyDown(input, { target: { key: ' ' } }))
 
@@ -91,7 +91,7 @@ describe('StyledSelect', () => {
             />
           )
 
-          const input = wrapper.getByTestId('selectedOption')
+          const input = wrapper.getByLabelText('Add or Select Option')
 
           fireEvent.change(input, { target: { value: 'my game 2' } })
 
@@ -115,7 +115,7 @@ describe('StyledSelect', () => {
             />
           )
 
-          const input = wrapper.getByTestId('selectedOption')
+          const input = wrapper.getByLabelText('Add or Select Option')
 
           fireEvent.change(input, { target: { value: 'New Game New Name' } })
 
@@ -151,7 +151,7 @@ describe('StyledSelect', () => {
         />
       )
 
-      expect(wrapper.getByTestId('selectedOption').textContent).toEqual(
+      expect(wrapper.getByLabelText('Add or Select Option').textContent).toEqual(
         'This placeholder is way...'
       )
     })
@@ -196,7 +196,7 @@ describe('StyledSelect', () => {
       ).toEqual(options[1].optionName)
 
       // The header text should be the option name
-      expect(wrapper.getByTestId('selectedOption').textContent).toEqual(
+      expect(wrapper.getByLabelText('Add or Select Option').textContent).toEqual(
         options[1].optionName
       )
     })
@@ -213,7 +213,7 @@ describe('StyledSelect', () => {
       )
 
       // The header text should be the option name
-      expect(wrapper.getByTestId('selectedOption').textContent).toEqual(
+      expect(wrapper.getByLabelText('Add or Select Option').textContent).toEqual(
         'Game with a really real...'
       )
     })

--- a/src/components/styledSelect/styledSelect.test.tsx
+++ b/src/components/styledSelect/styledSelect.test.tsx
@@ -1,4 +1,5 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vitest } from 'vitest'
+import { act, fireEvent } from '@testing-library/react'
 import { render } from '../../support/testUtils'
 import { allGames } from '../../support/data/games'
 import StyledSelect from './styledSelect'
@@ -21,6 +22,7 @@ describe('StyledSelect', () => {
         <StyledSelect
           options={options}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="Doesn't matter"
         />
       )
@@ -45,11 +47,83 @@ describe('StyledSelect', () => {
         <StyledSelect
           options={options}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="Doesn't matter"
         />
       )
 
       expect(wrapper).toMatchSnapshot()
+    })
+
+    describe('submitting the input', () => {
+      describe('when not pressing enter', () => {
+        test("doesn't call the onSubmitInput function", () => {
+          const onSubmitInput = vitest.fn()
+
+          const wrapper = render(
+            <StyledSelect
+              options={options}
+              onOptionSelected={() => {}}
+              onSubmitInput={onSubmitInput}
+              placeholder="Doesn't matter"
+            />
+          )
+
+          const input = wrapper.getByTestId('selectedOption')
+
+          act(() => fireEvent.keyDown(input, { target: { key: ' ' } }))
+
+          expect(onSubmitInput).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the input value matches an option name', () => {
+        test.skip('selects the option', () => {
+          const onOptionSelected = vitest.fn()
+          const onSubmitInput = vitest.fn()
+
+          const wrapper = render(
+            <StyledSelect
+              options={options}
+              onOptionSelected={onOptionSelected}
+              onSubmitInput={onSubmitInput}
+              placeholder="Doesn't matter"
+            />
+          )
+
+          const input = wrapper.getByTestId('selectedOption')
+
+          fireEvent.change(input, { target: { value: 'my game 2' } })
+
+          act(() => fireEvent.keyDown(input, { target: { key: 'Enter' } }))
+
+          expect(onOptionSelected).toHaveBeenCalledWith(51)
+          expect(onSubmitInput).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when the input value does not match an option name', () => {
+        test.skip('calls the onSubmitInput function with the input value', () => {
+          const onSubmitInput = vitest.fn()
+
+          const wrapper = render(
+            <StyledSelect
+              options={options}
+              onOptionSelected={() => {}}
+              onSubmitInput={onSubmitInput}
+              placeholder="Doesn't matter"
+            />
+          )
+
+          const input = wrapper.getByTestId('selectedOption')
+
+          fireEvent.change(input, { target: { value: 'New Game New Name' } })
+
+          act(() => fireEvent.keyDown(input, { target: { key: 'Enter' } }))
+
+          expect(onSubmitInput).toHaveBeenCalledWith('New Game New Name')
+        })
+      })
     })
   })
 
@@ -59,6 +133,7 @@ describe('StyledSelect', () => {
         <StyledSelect
           options={[]}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="No options available"
         />
       )
@@ -71,6 +146,7 @@ describe('StyledSelect', () => {
         <StyledSelect
           options={[]}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="This placeholder is way too long."
         />
       )
@@ -85,6 +161,7 @@ describe('StyledSelect', () => {
         <StyledSelect
           options={[]}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="No options available"
         />
       )
@@ -105,6 +182,7 @@ describe('StyledSelect', () => {
           options={options}
           defaultOption={options[1]}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="Doesn't matter"
         />
       )
@@ -129,6 +207,7 @@ describe('StyledSelect', () => {
           options={options}
           defaultOption={options[2]}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="Doesn't matter"
         />
       )
@@ -145,6 +224,7 @@ describe('StyledSelect', () => {
           options={options}
           defaultOption={options[1]}
           onOptionSelected={() => {}}
+          onSubmitInput={() => {}}
           placeholder="Doesn't matter"
         />
       )

--- a/src/components/styledSelect/styledSelect.test.tsx
+++ b/src/components/styledSelect/styledSelect.test.tsx
@@ -31,7 +31,9 @@ describe('StyledSelect', () => {
       expect(wrapper.queryByText("Doesn't matter")).toBeFalsy()
 
       // Main, initially visible box is empty by default
-      expect(wrapper.getByLabelText('Add or Select Option').textContent).toBeFalsy()
+      expect(
+        wrapper.getByLabelText('Add or Select Option').textContent
+      ).toBeFalsy()
 
       // Initially, no option is selected
       expect(wrapper.queryByRole('option', { selected: true })).toBeFalsy()
@@ -151,9 +153,9 @@ describe('StyledSelect', () => {
         />
       )
 
-      expect(wrapper.getByLabelText('Add or Select Option').textContent).toEqual(
-        'This placeholder is way...'
-      )
+      expect(
+        wrapper.getByLabelText('Add or Select Option').textContent
+      ).toEqual('This placeholder is way...')
     })
 
     test('matches snapshot', () => {
@@ -196,9 +198,9 @@ describe('StyledSelect', () => {
       ).toEqual(options[1].optionName)
 
       // The header text should be the option name
-      expect(wrapper.getByLabelText('Add or Select Option').textContent).toEqual(
-        options[1].optionName
-      )
+      expect(
+        wrapper.getByLabelText('Add or Select Option').textContent
+      ).toEqual(options[1].optionName)
     })
 
     test.skip('truncates the title if it is too long', () => {
@@ -213,9 +215,9 @@ describe('StyledSelect', () => {
       )
 
       // The header text should be the option name
-      expect(wrapper.getByLabelText('Add or Select Option').textContent).toEqual(
-        'Game with a really real...'
-      )
+      expect(
+        wrapper.getByLabelText('Add or Select Option').textContent
+      ).toEqual('Game with a really real...')
     })
 
     test('matches snapshot', () => {

--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -107,13 +107,14 @@ const StyledSelect = ({
     )
 
     if (existingOption) {
-      setHeaderText(existingOption.optionName)
       selectOption(existingOption.optionValue)
     } else {
+      setHeaderText(inputRef.current.value)
       onSubmitInput(value)
       setIsComponentVisible(false)
-      inputRef.current?.blur()
     }
+
+    inputRef.current?.blur()
   }
 
   useEffect(() => {

--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -166,7 +166,6 @@ const StyledSelect = ({
         <input
           className={styles.headerText}
           ref={inputRef}
-          data-testid="selectedOption"
           placeholder={truncatedText(placeholder, size?.width)}
           aria-label="Add or Select Option"
           onKeyDown={onKeyDown}

--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -111,7 +111,6 @@ const StyledSelect = ({
     } else {
       setHeaderText(inputRef.current.value)
       onSubmitInput(value)
-      setIsComponentVisible(false)
     }
 
     inputRef.current?.blur()
@@ -168,7 +167,7 @@ const StyledSelect = ({
           className={styles.headerText}
           ref={inputRef}
           data-testid="selectedOption"
-          placeholder={truncatedText(placeholder)}
+          placeholder={truncatedText(placeholder, size?.width)}
           aria-label="Add or Select Option"
           onKeyDown={onKeyDown}
         />

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -1,9 +1,5 @@
 import { createContext, useCallback, useEffect, useState, useRef } from 'react'
-import {
-  type RequestGame,
-  type ResponseGame as Game,
-  ResponseGame,
-} from '../types/apiData'
+import { type RequestGame, type ResponseGame as Game } from '../types/apiData'
 import { type ProviderProps } from '../types/contexts'
 import { type CallbackFunction } from '../types/functions'
 import { useGoogleLogin, usePageContext } from '../hooks/contexts'
@@ -21,7 +17,7 @@ export interface GamesContextType {
   gamesLoadingState: LoadingState
   createGame: (
     game: RequestGame,
-    onSuccess?: (game: ResponseGame) => void,
+    onSuccess?: (game: Game) => void,
     onError?: CallbackFunction,
     idToken?: string | null,
     retries?: number
@@ -97,7 +93,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
   const createGame = useCallback(
     (
       body: RequestGame,
-      onSuccess?: (game: ResponseGame) => void,
+      onSuccess?: (game: Game) => void,
       onError?: CallbackFunction,
       idToken?: string | null,
       retries?: number

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -1,5 +1,9 @@
 import { createContext, useCallback, useEffect, useState, useRef } from 'react'
-import { type RequestGame, type ResponseGame as Game } from '../types/apiData'
+import {
+  type RequestGame,
+  type ResponseGame as Game,
+  ResponseGame,
+} from '../types/apiData'
 import { type ProviderProps } from '../types/contexts'
 import { type CallbackFunction } from '../types/functions'
 import { useGoogleLogin, usePageContext } from '../hooks/contexts'
@@ -17,7 +21,7 @@ export interface GamesContextType {
   gamesLoadingState: LoadingState
   createGame: (
     game: RequestGame,
-    onSuccess?: CallbackFunction,
+    onSuccess?: (game: ResponseGame) => void,
     onError?: CallbackFunction,
     idToken?: string | null,
     retries?: number
@@ -93,7 +97,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
   const createGame = useCallback(
     (
       body: RequestGame,
-      onSuccess?: CallbackFunction,
+      onSuccess?: (game: ResponseGame) => void,
       onError?: CallbackFunction,
       idToken?: string | null,
       retries?: number
@@ -110,7 +114,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
                 type: 'success',
                 message: 'Success! Your game has been created.',
               })
-              onSuccess && onSuccess()
+              onSuccess && onSuccess(json)
             }
           })
           .catch((e: ApiError) => {

--- a/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
+++ b/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
@@ -383,7 +383,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 <input
                   aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
-                  data-testid="selectedOption"
                 />
                 <button
                   class="_trigger_0a8ecf"
@@ -592,7 +591,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               <input
                 aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
-                data-testid="selectedOption"
               />
               <button
                 class="_trigger_0a8ecf"
@@ -858,7 +856,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 <input
                   aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
-                  data-testid="selectedOption"
                 />
                 <button
                   class="_trigger_0a8ecf"
@@ -1067,7 +1064,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               <input
                 aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
-                data-testid="selectedOption"
               />
               <button
                 class="_trigger_0a8ecf"
@@ -1338,7 +1334,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                 <input
                   aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
-                  data-testid="selectedOption"
                 />
                 <button
                   class="_trigger_0a8ecf"
@@ -1531,7 +1526,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
               <input
                 aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
-                data-testid="selectedOption"
               />
               <button
                 class="_trigger_0a8ecf"
@@ -1776,7 +1770,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                 <input
                   aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
-                  data-testid="selectedOption"
                 />
                 <button
                   class="_trigger_0a8ecf"
@@ -1964,7 +1957,6 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
               <input
                 aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
-                data-testid="selectedOption"
               />
               <button
                 class="_trigger_0a8ecf"

--- a/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
+++ b/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
@@ -380,7 +380,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 class="_header_0a8ecf"
                 role="combobox"
               >
-                <p
+                <input
+                  aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
                   data-testid="selectedOption"
                 />
@@ -588,7 +589,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               class="_header_0a8ecf"
               role="combobox"
             >
-              <p
+              <input
+                aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
                 data-testid="selectedOption"
               />
@@ -853,7 +855,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 class="_header_0a8ecf"
                 role="combobox"
               >
-                <p
+                <input
+                  aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
                   data-testid="selectedOption"
                 />
@@ -1061,7 +1064,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               class="_header_0a8ecf"
               role="combobox"
             >
-              <p
+              <input
+                aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
                 data-testid="selectedOption"
               />
@@ -1331,7 +1335,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                 class="_header_0a8ecf"
                 role="combobox"
               >
-                <p
+                <input
+                  aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
                   data-testid="selectedOption"
                 />
@@ -1523,7 +1528,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
               class="_header_0a8ecf"
               role="combobox"
             >
-              <p
+              <input
+                aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
                 data-testid="selectedOption"
               />
@@ -1767,7 +1773,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                 class="_header_0a8ecf"
                 role="combobox"
               >
-                <p
+                <input
+                  aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
                   data-testid="selectedOption"
                 />
@@ -1954,7 +1961,8 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
               class="_header_0a8ecf"
               role="combobox"
             >
-              <p
+              <input
+                aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
                 data-testid="selectedOption"
               />

--- a/src/layouts/dashboardLayout/dashboardLayout.module.css
+++ b/src/layouts/dashboardLayout/dashboardLayout.module.css
@@ -9,7 +9,6 @@
 .container {
   padding: 24px 0;
   margin: 0 16px;
-  max-width: 90%;
   padding-top: 108px;
   font-family: 'Quattrocento Sans', Arial, Helvetica, sans-serif;
 }
@@ -60,6 +59,7 @@
 @media (min-width: 601px) {
   .container {
     margin: 0 auto;
+    max-width: 90%;
   }
 
   .titleContainer {

--- a/src/layouts/dashboardLayout/dashboardLayout.tsx
+++ b/src/layouts/dashboardLayout/dashboardLayout.tsx
@@ -49,7 +49,15 @@ const DashboardLayout = ({
   }
 
   const onSubmitInput = (name: string) => {
-    createGame({ name }, ({ id }: ResponseGame) => setQueryString(id))
+    createGame(
+      { name },
+      ({ id }: ResponseGame) => setQueryString(id),
+      () =>
+        setDefaultOption({
+          optionName: games[0].name,
+          optionValue: games[0].id,
+        })
+    )
   }
 
   const hideModalIfEsc: KeyboardEventHandler = (e) => {

--- a/src/layouts/dashboardLayout/dashboardLayout.tsx
+++ b/src/layouts/dashboardLayout/dashboardLayout.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react'
 import { useNavigate } from 'react-router-dom'
 import classNames from 'classnames'
+import { ResponseGame } from '../../types/apiData'
 import { DONE } from '../../utils/loadingStates'
 import { usePageContext, useGamesContext } from '../../hooks/contexts'
 import { useQueryString } from '../../hooks/useQueryString'
@@ -29,7 +30,7 @@ const DashboardLayout = ({
   children,
 }: DashboardLayoutProps) => {
   const { flashProps, modalProps, setModalProps } = usePageContext()
-  const { games, gamesLoadingState } = useGamesContext()
+  const { games, createGame, gamesLoadingState } = useGamesContext()
 
   const queryString = useQueryString()
   const navigate = useNavigate()
@@ -39,8 +40,16 @@ const DashboardLayout = ({
   const [selectPlaceholder, setSelectPlaceholder] = useState('Games loading...')
 
   const onOptionSelected = (optionValue: number | string) => {
-    queryString.set('gameId', String(optionValue))
+    setQueryString(optionValue)
+  }
+
+  const setQueryString = (id: number | string) => {
+    queryString.set('gameId', String(id))
     navigate(`?${queryString.toString()}`)
+  }
+
+  const onSubmitInput = (name: string) => {
+    createGame({ name }, ({ id }: ResponseGame) => setQueryString(id))
   }
 
   const hideModalIfEsc: KeyboardEventHandler = (e) => {
@@ -83,6 +92,7 @@ const DashboardLayout = ({
                   options={selectOptions}
                   placeholder={selectPlaceholder}
                   onOptionSelected={onOptionSelected}
+                  onSubmitInput={onSubmitInput}
                   defaultOption={defaultOption}
                   className={styles.select}
                   disabled={gamesLoadingState !== DONE}

--- a/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
+++ b/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
@@ -32,7 +32,8 @@ exports[`ShoppingListsPage > viewing shopping lists > when loading > matches sna
                 class="_header_0a8ecf"
                 role="combobox"
               >
-                <p
+                <input
+                  aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
                   data-testid="selectedOption"
                 />
@@ -215,7 +216,8 @@ exports[`ShoppingListsPage > viewing shopping lists > when loading > matches sna
               class="_header_0a8ecf"
               role="combobox"
             >
-              <p
+              <input
+                aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
                 data-testid="selectedOption"
               />
@@ -455,7 +457,8 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                 class="_header_0a8ecf"
                 role="combobox"
               >
-                <p
+                <input
+                  aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
                   data-testid="selectedOption"
                 />
@@ -1779,7 +1782,8 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
               class="_header_0a8ecf"
               role="combobox"
             >
-              <p
+              <input
+                aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
                 data-testid="selectedOption"
               />
@@ -3160,7 +3164,8 @@ exports[`ShoppingListsPage > viewing shopping lists > when there are no games > 
                 class="_header_0a8ecf"
                 role="combobox"
               >
-                <p
+                <input
+                  aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
                   data-testid="selectedOption"
                 />
@@ -3387,7 +3392,8 @@ exports[`ShoppingListsPage > viewing shopping lists > when there are no games > 
               class="_header_0a8ecf"
               role="combobox"
             >
-              <p
+              <input
+                aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
                 data-testid="selectedOption"
               />

--- a/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
+++ b/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`ShoppingListsPage > viewing shopping lists > when loading > matches sna
                 <input
                   aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
-                  data-testid="selectedOption"
                 />
                 <button
                   class="_trigger_0a8ecf"
@@ -219,7 +218,6 @@ exports[`ShoppingListsPage > viewing shopping lists > when loading > matches sna
               <input
                 aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
-                data-testid="selectedOption"
               />
               <button
                 class="_trigger_0a8ecf"
@@ -460,7 +458,6 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                 <input
                   aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
-                  data-testid="selectedOption"
                 />
                 <button
                   class="_trigger_0a8ecf"
@@ -1785,7 +1782,6 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
               <input
                 aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
-                data-testid="selectedOption"
               />
               <button
                 class="_trigger_0a8ecf"
@@ -3167,7 +3163,6 @@ exports[`ShoppingListsPage > viewing shopping lists > when there are no games > 
                 <input
                   aria-label="Add or Select Option"
                   class="_headerText_0a8ecf"
-                  data-testid="selectedOption"
                 />
                 <button
                   class="_trigger_0a8ecf"
@@ -3395,7 +3390,6 @@ exports[`ShoppingListsPage > viewing shopping lists > when there are no games > 
               <input
                 aria-label="Add or Select Option"
                 class="_headerText_0a8ecf"
-                data-testid="selectedOption"
               />
               <button
                 class="_trigger_0a8ecf"


### PR DESCRIPTION
## Context

[**Investigate enabling games to be created from StyledSelect**](https://trello.com/c/u6lcMTot/276-investigate-enabling-games-to-be-created-from-styledselect)

In SIM, shopping lists are scoped to games. The `StyledSelect` dropdown is used to select an active game on the shopping lists page. If there are no games, a link is visible enabling a user to create a game from the shopping lists page using a modal form. However, we want users to also be able to create new games on the shopping lists page when there are existing games. We can use the `StyledSelect` component to do this.

This PR adds an input to the `StyledSelect` component that, when submitted, calls an `onSubmit` function. Then, in the `DashboardLayout` component, this made is added to create a game and set the new game as the active game in the query string.

## Changes

* Enable games to be selected by typing in the `StyledSelect` input field
* Enable games to be created by entering a nonexistent name in the `StyledSelect` input field

## Required Tasks

- [x] Add/update automated tests
- [x] Add/update Storybook stories
- [x] Add/update docs
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles

## Considerations

The ideal state would be for typing in the `StyledSelect` input to cause options to be filtered enabling users to type and then tab down or use the arrow key and enter key to select an option expediently. However, for this implementation, if a user wants to select an option by typing, they have to type the full (not truncated!) name of the option they'd like to select. If the exact name (case insensitive) is not entered, a new game will be created. 

## Manual Test Cases

### Selecting an Existing Game

1. Visit the shopping lists page, ensuring you have at least two existing games (the first will be automatically selected in the `StyledSelect`).
2. Focus the input on the `StyledSelect` and type the name of an existing, non-selected game. You can use different casing but the name must be exact for this to work. If the name is truncated, type the non-truncated name.
3. Press Enter.
4. See that the existing game has been selected in the `StyledSelect`.
5. See that the query string has been updated to include the new active game's ID.
6. See that the shopping lists for the new active game are fetched.

### Creating a New Game 1

1. Visit the shopping lists page, ensuring you have at least one existing game.
2. Focus the input on the `StyledSelect` and type the name of the game you'd like to create.
3. Press Enter.
4. See that the new game is active in the `StyledSelect`.
5. See a flash message that your game has been created.
6. See that the new game's ID is present in the query string.
7. See that the new game's (nonexistent) shopping lists are fetched.

### Creating a New Game 2

1. Visit the shopping lists page, ensuring you have at least one existing game.
2. Select a game from the dropdown such that its ID is set in the query string and its shopping lists fetched.
3. Focus the input on the `StyledSelect` and type the name of the new game you'd like to create.
4. Press Enter.
5. See that the new game is active in the `StyledSelect`.
6. See a flash message that your game has been created.
7. See that the `gameId` query parameter has been changed to the new game's ID.
8. See a flash message that your game has been created.
9. See that the new game's (nonexistent) shopping lists are fetched.

### Error Scenario

Error scenarios from the API call are unlikely to materialise for these changes. If a name is already in use for a game, then entering that name in the select box will cause that game to be selected rather than attempting to create a game with the same name. The only time a 422 error would occur would therefore be if you submitted the input twice with the same name before the API call completed.

For this reason, it might be easier to simply program the API to return a 500 error to see what happens.

1. Program the API to return a 500 error from the `GamesController::CreateService#perform` method.
2. Visit the shopping lists page.
3. Focus the input on the `StyledSelect` and type the name of the game you'd like to create.
4. Press Enter.
5. See that the previously-selected option is active in the `StyledSelect`.
6. See an opaque, user-friendly flash error message that something has gone wrong.
7. See that the `gameId` query param has not changed.