### PR TITLE
Add state to PageContext for when API calls are in progress

### DIFF
--- a/docs/contexts/page-context.md
+++ b/docs/contexts/page-context.md
@@ -46,7 +46,6 @@ The `PageProvider` exposes seven values to its consumers:
 - `addApiCall` (a function that takes a resource name (currently "games", "shoppingLists", and "shoppingListItems") and HTTP verb ("get", "patch", "post", "delete") as arguments and adds the specified API call to the `apiCallsInProgress` object)
 - `removeApiCall` (a function that takes a resource name (currently "games", "shoppingLists", and "shoppingListItems") and HTTP verb ("get", "patch", "post", "delete") as arguments and removes the specified API call, if present, from the `apiCallsInProgress` object)
 
-
 Of these, the first five are implemented as state variables within the context provider. Because of required values in the `FlashMessageProps` type, there is a default value of `flashProps` that includes an empty string as the message, a type of `'info'`, and, most importantly, `hidden: true`. Likewise, the default value of `modalProps` has `hidden` set to `true` and `children` set to an empty fragment, `<></>`.
 
 When an individual component needs to display a flash message or modal, it can access these values using the `usePageContext()` hook. To display a message, it should call `setFlashProps` with the desired type, message, and (optionally) header. The `hidden` value should also be set to `false`. To display a modal, it should call `setModalProps`, setting `hidden` to `false` and `children` to the React (TSX) element that should appear inside the modal. When hiding the modal, best practice is to set the `children` value back to an empty fragment, `<></>`.
@@ -235,9 +234,7 @@ const MyComponent = () => {
       })
   }
 
-  return(
-    <button onClick={makeApiCall}>Create Game</button>
-  )
+  return <button onClick={makeApiCall}>Create Game</button>
 }
 
 export default MyComponent
@@ -271,7 +268,9 @@ const MyComponent = () => {
   }, [apiCallsInProgress])
 
   return (
-    <button disabled={disabled} onClick={onClick}>Do the Thing!</button>
+    <button disabled={disabled} onClick={onClick}>
+      Do the Thing!
+    </button>
   )
 }
 

--- a/docs/contexts/page-context.md
+++ b/docs/contexts/page-context.md
@@ -36,18 +36,28 @@ Note that the `children` prop is not optional, but may be set to an empty fragme
 
 ## The `PageContext`
 
-The `PageProvider` exposes four values to the user:
+The `PageProvider` exposes seven values to its consumers:
 
 - `flashProps` (an object of type `FlashMessageProps`)
 - `setFlashProps` (a function taking a `FlashMessageProps` object as an argument)
 - `modalProps` (an object of type `ModalProps`)
 - `setModalProps` (a function taking a `ModalProps` object as an argument)
+- `apiCallsInProgress` (an [`ApiCalls`](/src/types/apiCalls.d.ts) object indicating which API calls are in progress)
+- `addApiCall` (a function that takes a resource name (currently "games", "shoppingLists", and "shoppingListItems") and HTTP verb ("get", "patch", "post", "delete") as arguments and adds the specified API call to the `apiCallsInProgress` object)
+- `removeApiCall` (a function that takes a resource name (currently "games", "shoppingLists", and "shoppingListItems") and HTTP verb ("get", "patch", "post", "delete") as arguments and removes the specified API call, if present, from the `apiCallsInProgress` object)
 
-All of these are implemented as state variables within the context provider. Because of required values in the `FlashMessageProps` type, there is a default value of `flashProps` that includes an empty string as the message, a type of `'info'`, and, most importantly, `hidden: true`. Likewise, the default value of `modalProps` has `hidden` set to `true` and `children` set to an empty fragment, `<></>`.
+
+Of these, the first five are implemented as state variables within the context provider. Because of required values in the `FlashMessageProps` type, there is a default value of `flashProps` that includes an empty string as the message, a type of `'info'`, and, most importantly, `hidden: true`. Likewise, the default value of `modalProps` has `hidden` set to `true` and `children` set to an empty fragment, `<></>`.
 
 When an individual component needs to display a flash message or modal, it can access these values using the `usePageContext()` hook. To display a message, it should call `setFlashProps` with the desired type, message, and (optionally) header. The `hidden` value should also be set to `false`. To display a modal, it should call `setModalProps`, setting `hidden` to `false` and `children` to the React (TSX) element that should appear inside the modal. When hiding the modal, best practice is to set the `children` value back to an empty fragment, `<></>`.
 
 With the flash message, the `PageProvider` ensures that it is hidden after a period of time, so there is no need for a user to manually dismiss it or for a component using it to ensure it disappears.
+
+### In-progress API Calls
+
+Sometimes, to avoid race conditions between API calls, it is best to disable a component when an API call is in progress. For that purpose, we can use the `apiCallsInProgress` object from the `PageProvider`. This object has a key for each resource type ("games", "shoppingLists", and "shoppingListItems"). Each key corresponds to an array of lower-case HTTP verbs indicating which API calls are in progress for that resource type. We found it advantageous to have a separate array for each resource type, since many components should be disabled when, for example, any request is made for a `shoppingList` resource, but requests made for other resources don't matter.
+
+The `apiCallsInProgress` object can be updated using the `addApiCall` and `removeApiCall` functions. Remember that, when you add an API call, it must be removed when the API call completes. This will not happen automatically.
 
 ## Examples
 
@@ -199,3 +209,81 @@ const Child = ({ gameId }: ChildProps) => {
 ```
 
 In this case, note that the component does not render the `DashboardLayout` component. Nevertheless, it will need to be rendered within a `DashboardLayout` (or at least, within the same `PageProvider` as one) in order for the modal form to appear.
+
+### Adding and Removing API Calls
+
+```tsx
+import { type MouseEventHandler } from 'react'
+import { postGames } from '../../utils/api/simApi'
+import { usePageContext } from '../../hooks/contexts'
+
+const MyComponent = () => {
+  const { addApiCall, removeApiCall } = usePageContext()
+
+  const makeApiCall: MouseEventHandler = (e) => {
+    e.preventDefault()
+
+    addApiCall('games', 'post')
+    postGames({ name: 'My Game' })
+      .then(({ status, json }) => {
+        // do something
+
+        removeApiCall('games', 'post')
+      })
+      .catch((e: Error) => {
+        removeApiCall('games', 'post')
+      })
+  }
+
+  return(
+    <button onClick={makeApiCall}>Create Game</button>
+  )
+}
+
+export default MyComponent
+```
+
+As shown, you should make sure the API call is removed from the `apiCallsInProgress` object whenever the API call is complete, even in error cases.
+
+### Checking API Call Status
+
+```tsx
+import { useState, useEffect } from 'react'
+import { usePageContext } from '../../hooks/contexts'
+
+const MyComponent = () => {
+  const { apiCallsInProgress } = usePageContext()
+
+  const [disabled, setDisabled] = useState(!!apiCallsInProgress.games.length)
+
+  const onClick: MouseEventHandler = (e) => {
+    e.preventDefault()
+
+    // do the thing
+  }
+
+  useEffect(() => {
+    if (apiCallsInProgress.games.length) {
+      setDisabled(true)
+    } else {
+      setDisabled(false)
+    }
+  }, [apiCallsInProgress])
+
+  return (
+    <button disabled={disabled} onClick={onClick}>Do the Thing!</button>
+  )
+}
+
+export default MyComponent
+```
+
+Note that you could also use more specific checks if you want the button disabled for some API calls but not others:
+
+```ts
+if ('post' in apiCallsInProgress.games) {
+  setDisabled(true)
+} else {
+  setDisabled(false)
+}
+```

--- a/src/components/shoppingListCreateForm/shoppingListCreateForm.tsx
+++ b/src/components/shoppingListCreateForm/shoppingListCreateForm.tsx
@@ -8,16 +8,23 @@ import {
 import { type RequestShoppingList } from '../../types/apiData'
 import { DONE } from '../../utils/loadingStates'
 import { BLUE } from '../../utils/colorSchemes'
-import { useGamesContext, useShoppingListsContext } from '../../hooks/contexts'
+import {
+  usePageContext,
+  useGamesContext,
+  useShoppingListsContext,
+} from '../../hooks/contexts'
 import styles from './shoppingListCreateForm.module.css'
 
 const ShoppingListCreateForm = () => {
+  const { apiCallsInProgress } = usePageContext()
   const { gamesLoadingState } = useGamesContext()
   const { shoppingListsLoadingState, createShoppingList } =
     useShoppingListsContext()
 
   const [disabled, setDisabled] = useState(
-    gamesLoadingState !== DONE || shoppingListsLoadingState !== DONE
+    gamesLoadingState !== DONE ||
+      shoppingListsLoadingState !== DONE ||
+      !!apiCallsInProgress.shoppingLists.length
   )
 
   const formRef = useRef<HTMLFormElement>(null)
@@ -52,26 +59,27 @@ const ShoppingListCreateForm = () => {
 
     const clearForm = () => {
       formRef.current?.reset()
-      setDisabled(false)
     }
 
     const focusInput = () => {
       formRef.current?.reset()
-      setDisabled(false)
       inputRef.current?.focus()
     }
 
-    setDisabled(true)
     createShoppingList(attributes, clearForm, focusInput)
   }
 
   useEffect(() => {
-    if (gamesLoadingState === DONE && shoppingListsLoadingState === DONE) {
+    if (
+      gamesLoadingState === DONE &&
+      shoppingListsLoadingState === DONE &&
+      !apiCallsInProgress.shoppingLists.length
+    ) {
       setDisabled(false)
     } else {
       setDisabled(true)
     }
-  }, [gamesLoadingState, shoppingListsLoadingState])
+  }, [gamesLoadingState, shoppingListsLoadingState, apiCallsInProgress])
 
   return (
     <form

--- a/src/components/shoppingListItem/shoppingListItem.tsx
+++ b/src/components/shoppingListItem/shoppingListItem.tsx
@@ -56,16 +56,18 @@ const ShoppingListItem = ({
   notes,
   editable = false,
 }: ShoppingListItemProps) => {
+  const { apiCallsInProgress, setFlashProps, setModalProps } = usePageContext()
+  const { destroyShoppingListItem, updateShoppingListItem } =
+    useShoppingListsContext()
+
   const [expanded, setExpanded] = useState(false)
-  const [incrementerDisabled, setIncrementerDisabled] = useState(false)
+  const [incrementerDisabled, setIncrementerDisabled] = useState(
+    !!apiCallsInProgress.shoppingListItems.length
+  )
 
   const iconsRef = useRef<HTMLSpanElement>(null)
   const incRef = useRef<HTMLButtonElement>(null)
   const decRef = useRef<HTMLButtonElement>(null)
-
-  const { setFlashProps, setModalProps } = usePageContext()
-  const { destroyShoppingListItem, updateShoppingListItem } =
-    useShoppingListsContext()
 
   const colorScheme = useColorScheme()
   const {

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -52,7 +52,8 @@ export const GamesProvider = ({ children }: ProviderProps) => {
     useGoogleLogin()
   const [gamesLoadingState, setGamesLoadingState] = useState(LOADING)
   const [games, setGames] = useState<Game[]>([])
-  const { setFlashProps, setModalProps } = usePageContext()
+  const { setFlashProps, setModalProps, addApiCall, removeApiCall } =
+    usePageContext()
   const previousTokenRef = useRef(token)
 
   /**
@@ -101,6 +102,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('games', 'post')
         postGames(body, idToken)
           .then(({ json }) => {
             if ('name' in json) {
@@ -110,6 +112,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
                 type: 'success',
                 message: 'Success! Your game has been created.',
               })
+              removeApiCall('games', 'post')
               onSuccess && onSuccess(json)
             }
           })
@@ -144,11 +147,13 @@ export const GamesProvider = ({ children }: ProviderProps) => {
    */
 
   const setGamesFromApi = (idToken: string, retries: number = 1) => {
+    addApiCall('games', 'get')
     return getGames(idToken)
       .then(({ json }) => {
         if (Array.isArray(json)) {
           setGames(json)
           setGamesLoadingState(DONE)
+          removeApiCall('games', 'get')
         }
       })
       .catch((e: ApiError) => {
@@ -157,6 +162,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
             setGamesFromApi(newToken, retries - 1)
           })
         } else {
+          removeApiCall('games', 'get')
           throw e
         }
       })
@@ -192,6 +198,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('games', 'patch')
         patchGame(gameId, attributes, idToken)
           .then(({ status, json }) => {
             if (status === 200) {
@@ -199,6 +206,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
               const index = newGames.findIndex((el) => el.id === gameId)
               newGames[index] = json
               setGames(newGames)
+              removeApiCall('games', 'patch')
               setModalProps({
                 hidden: true,
                 children: <></>,
@@ -227,6 +235,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
               })
             }
 
+            removeApiCall('games', 'patch')
             handleApiError(e)
 
             onError && onError()
@@ -253,11 +262,13 @@ export const GamesProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('games', 'delete')
         deleteGame(gameId, idToken)
           .then(({ status }) => {
             if (status === 204) {
               const newGames = games.filter(({ id }) => id !== gameId)
               setGames(newGames)
+              removeApiCall('games', 'delete')
               setFlashProps({
                 hidden: false,
                 type: 'success',
@@ -282,6 +293,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
               })
             }
 
+            removeApiCall('games', 'delete')
             handleApiError(e)
 
             onError && onError()

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -131,6 +131,7 @@ export const GamesProvider = ({ children }: ProviderProps) => {
               })
             }
 
+            removeApiCall('games', 'post')
             handleApiError(e)
             onError && onError()
           })

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -8,7 +8,7 @@ interface PageContextType {
   setFlashProps: (props: FlashProps) => void
   modalProps: ModalProps
   setModalProps: (props: ModalProps) => void
-  apiCallStatus: ApiCalls
+  apiCallsInProgress: ApiCalls
   addApiCall: (key: Resource, value: HttpVerb) => void
   removeApiCall: (key: Resource, value: HttpVerb) => void
 }
@@ -33,7 +33,7 @@ const defaultApiCallStatus = {
 const PageContext = createContext<PageContextType>({
   flashProps: defaultFlashProps,
   modalProps: defaultModalProps,
-  apiCallStatus: defaultApiCallStatus,
+  apiCallsInProgress: defaultApiCallStatus,
   setFlashProps: () => {},
   setModalProps: () => {},
   addApiCall: () => {},
@@ -43,29 +43,29 @@ const PageContext = createContext<PageContextType>({
 const PageProvider = ({ children }: ProviderProps) => {
   const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
   const [modalProps, setModalProps] = useState<ModalProps>(defaultModalProps)
-  const [apiCallStatus, setApiCallStatus] =
+  const [apiCallsInProgress, SetApiCallsInProgress] =
     useState<ApiCalls>(defaultApiCallStatus)
 
   const flashVisibleSince = useRef(0)
 
   const addApiCall = (key: Resource, value: HttpVerb) => {
-    setApiCallStatus({
-      ...apiCallStatus,
-      [key]: [...apiCallStatus[key], value],
+    SetApiCallsInProgress({
+      ...apiCallsInProgress,
+      [key]: [...apiCallsInProgress[key], value],
     })
   }
 
   const removeApiCall = (key: Resource, value: HttpVerb) => {
-    setApiCallStatus({
-      ...apiCallStatus,
-      [key]: apiCallStatus[key].filter((verb) => verb !== value),
+    SetApiCallsInProgress({
+      ...apiCallsInProgress,
+      [key]: apiCallsInProgress[key].filter((verb) => verb !== value),
     })
   }
 
   const value = {
     flashProps,
     modalProps,
-    apiCallStatus,
+    apiCallsInProgress,
     setFlashProps,
     setModalProps,
     addApiCall,

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -24,7 +24,7 @@ const defaultModalProps: ModalProps = {
   children: <></>,
 }
 
-const defaultApiCallStatus = {
+const defaultApiCallStatus: ApiCalls = {
   games: [],
   shoppingLists: [],
   shoppingListItems: [],
@@ -43,20 +43,20 @@ const PageContext = createContext<PageContextType>({
 const PageProvider = ({ children }: ProviderProps) => {
   const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
   const [modalProps, setModalProps] = useState<ModalProps>(defaultModalProps)
-  const [apiCallsInProgress, SetApiCallsInProgress] =
+  const [apiCallsInProgress, setApiCallsInProgress] =
     useState<ApiCalls>(defaultApiCallStatus)
 
   const flashVisibleSince = useRef(0)
 
   const addApiCall = (key: Resource, value: HttpVerb) => {
-    SetApiCallsInProgress({
+    setApiCallsInProgress({
       ...apiCallsInProgress,
       [key]: [...apiCallsInProgress[key], value],
     })
   }
 
   const removeApiCall = (key: Resource, value: HttpVerb) => {
-    SetApiCallsInProgress({
+    setApiCallsInProgress({
       ...apiCallsInProgress,
       [key]: apiCallsInProgress[key].filter((verb) => verb !== value),
     })

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useState, useEffect, useRef } from 'react'
+import { type ApiCalls, type Resource, type HttpVerb } from '../types/apiCalls'
 import { ProviderProps } from '../types/contexts'
 import { type FlashProps, type ModalProps } from '../types/pageContext'
 
@@ -7,6 +8,9 @@ interface PageContextType {
   setFlashProps: (props: FlashProps) => void
   modalProps: ModalProps
   setModalProps: (props: ModalProps) => void
+  apiCallStatus: ApiCalls
+  addApiCall: (key: Resource, value: HttpVerb) => void
+  removeApiCall: (key: Resource, value: HttpVerb) => void
 }
 
 const defaultFlashProps: FlashProps = {
@@ -20,24 +24,52 @@ const defaultModalProps: ModalProps = {
   children: <></>,
 }
 
+const defaultApiCallStatus = {
+  games: [],
+  shoppingLists: [],
+  shoppingListItems: [],
+}
+
 const PageContext = createContext<PageContextType>({
   flashProps: defaultFlashProps,
   modalProps: defaultModalProps,
+  apiCallStatus: defaultApiCallStatus,
   setFlashProps: () => {},
   setModalProps: () => {},
+  addApiCall: () => {},
+  removeApiCall: () => {},
 })
 
 const PageProvider = ({ children }: ProviderProps) => {
   const [flashProps, setFlashProps] = useState<FlashProps>(defaultFlashProps)
   const [modalProps, setModalProps] = useState<ModalProps>(defaultModalProps)
+  const [apiCallStatus, setApiCallStatus] =
+    useState<ApiCalls>(defaultApiCallStatus)
 
   const flashVisibleSince = useRef(0)
+
+  const addApiCall = (key: Resource, value: HttpVerb) => {
+    setApiCallStatus({
+      ...apiCallStatus,
+      [key]: [...apiCallStatus[key], value],
+    })
+  }
+
+  const removeApiCall = (key: Resource, value: HttpVerb) => {
+    setApiCallStatus({
+      ...apiCallStatus,
+      [key]: apiCallStatus[key].filter((verb) => verb !== value),
+    })
+  }
 
   const value = {
     flashProps,
     modalProps,
+    apiCallStatus,
     setFlashProps,
     setModalProps,
+    addApiCall,
+    removeApiCall,
   }
 
   useEffect(() => {

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -91,7 +91,7 @@ export const ShoppingListsContext = createContext<ShoppingListsContextType>({
 export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   const { token, authLoading, requireLogin, withTokenRefresh, signOut } =
     useGoogleLogin()
-  const { setFlashProps } = usePageContext()
+  const { setFlashProps, addApiCall, removeApiCall } = usePageContext()
   const { gamesLoadingState, games } = useGamesContext()
   const queryString = useQueryString()
   const [activeGame, setActiveGame] = useState<number | null>(null)
@@ -162,6 +162,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('shoppingLists', 'post')
         postShoppingLists(activeGame, attributes, idToken)
           .then(({ json }) => {
             if (Array.isArray(json)) {
@@ -172,6 +173,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 newShoppingLists.splice(1, 0, json[0])
                 setShoppingLists(newShoppingLists)
               }
+
+              removeApiCall('shoppingLists', 'post')
 
               setFlashProps({
                 hidden: false,
@@ -196,6 +199,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 )
               })
             } else if (e.code === 404) {
+              removeApiCall('shoppingLists', 'post')
+
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -203,6 +208,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                   "The game you've selected doesn't exist, or doesn't belong to you. Please select another game and try again.",
               })
             } else {
+              removeApiCall('shoppingLists', 'post')
               handleApiError(e)
             }
 
@@ -226,11 +232,13 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
   ) => {
     if (!activeGame || !idToken) return
 
+    addApiCall('shoppingLists', 'get')
     getShoppingLists(activeGame, idToken)
       .then(({ json }) => {
         if (Array.isArray(json)) {
           setShoppingLists(json)
           setShoppingListsLoadingState(DONE)
+          removeApiCall('shoppingLists', 'get')
         }
       })
       .catch((e: ApiError) => {
@@ -239,6 +247,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
             setShoppingListsFromApi(newToken, retries - 1)
           })
         } else if (e.code === 404) {
+          removeApiCall('shoppingLists', 'get')
+
           setFlashProps({
             hidden: false,
             type: 'error',
@@ -246,6 +256,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               "The game you've selected doesn't exist, or doesn't belong to you. Please select another game and try again.",
           })
         } else {
+          removeApiCall('shoppingLists', 'get')
           handleApiError(e)
         }
 
@@ -279,6 +290,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('shoppingLists', 'patch')
         patchShoppingList(listId, attributes, idToken)
           .then(({ status, json }) => {
             if (status === 200) {
@@ -289,10 +301,12 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               newShoppingLists[index] = json
 
               setShoppingLists(newShoppingLists)
-
+              removeApiCall('shoppingLists', 'patch')
               onSuccess && onSuccess()
             } else {
               // This won't happen but TypeScript doesn't know that
+              removeApiCall('shoppingLists', 'patch')
+
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -317,6 +331,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 )
               })
             } else if (e.code === 404) {
+              removeApiCall('shoppingLists', 'patch')
+
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -324,6 +340,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                   "The shopping list you tried to update doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
+              removeApiCall('shoppingLists', 'patch')
               handleApiError(e)
             }
 
@@ -351,12 +368,15 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('shoppingLists', 'delete')
         deleteShoppingList(listId, idToken)
           .then(({ json }) => {
             if ('errors' in json) {
               // This case should never happen because normally an ApiError
               // will be thrown for any response that includes this key, but
               // TypeScript doesn't know that.
+              removeApiCall('shoppingLists', 'delete')
+
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -377,6 +397,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               }
 
               setShoppingLists(newShoppingLists)
+              removeApiCall('shoppingLists', 'delete')
+
               setFlashProps({
                 hidden: false,
                 type: 'success',
@@ -400,6 +422,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 )
               })
             } else if (e.code === 404) {
+              removeApiCall('shoppingLists', 'delete')
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -407,6 +430,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                   "The shopping list you tried to delete doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
+              removeApiCall('shoppingLists', 'delete')
               handleApiError(e)
             }
 
@@ -435,6 +459,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('shoppingListItems', 'post')
         postShoppingListItems(listId, attributes, idToken)
           .then(({ status, json }) => {
             if (status === 200 || status === 201) {
@@ -465,6 +490,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
 
               onError && onError()
             }
+
+            removeApiCall('shoppingListItems', 'post')
           })
           .catch((e: ApiError) => {
             retries ??= 1
@@ -491,6 +518,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               handleApiError(e, 'list item')
             }
 
+            removeApiCall('shoppingListItems', 'post')
             onError && onError()
           })
       }
@@ -516,6 +544,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('shoppingListItems', 'patch')
+
         patchShoppingListItem(itemId, attributes, idToken)
           .then(({ status, json }) => {
             if (status === 200) {
@@ -544,6 +574,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
 
               onError && onError()
             }
+
+            removeApiCall('shoppingListItems', 'patch')
           })
           .catch((e: ApiError) => {
             retries ??= 1
@@ -570,6 +602,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               handleApiError(e, 'list item')
             }
 
+            removeApiCall('shoppingListItems', 'patch')
             onError && onError()
           })
       }
@@ -594,6 +627,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       idToken ??= token
 
       if (idToken) {
+        addApiCall('shoppingListItems', 'delete')
+
         deleteShoppingListItem(itemId, idToken)
           .then(({ status, json }) => {
             if (status === 200) {
@@ -623,6 +658,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
 
               onError && onError()
             }
+
+            removeApiCall('shoppingListItems', 'delete')
           })
           .catch((e: ApiError) => {
             retries ??= 1
@@ -648,6 +685,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               handleApiError(e, 'list item')
             }
 
+            removeApiCall('shoppingListItems', 'delete')
             onError && onError()
           })
       }

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -199,8 +199,6 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 )
               })
             } else if (e.code === 404) {
-              removeApiCall('shoppingLists', 'post')
-
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -208,10 +206,10 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                   "The game you've selected doesn't exist, or doesn't belong to you. Please select another game and try again.",
               })
             } else {
-              removeApiCall('shoppingLists', 'post')
               handleApiError(e)
             }
 
+            removeApiCall('shoppingLists', 'post')
             onError && onError()
           })
       }
@@ -247,8 +245,6 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
             setShoppingListsFromApi(newToken, retries - 1)
           })
         } else if (e.code === 404) {
-          removeApiCall('shoppingLists', 'get')
-
           setFlashProps({
             hidden: false,
             type: 'error',
@@ -256,10 +252,10 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               "The game you've selected doesn't exist, or doesn't belong to you. Please select another game and try again.",
           })
         } else {
-          removeApiCall('shoppingLists', 'get')
           handleApiError(e)
         }
 
+        removeApiCall('shoppingLists', 'get')
         setShoppingLists([])
         setShoppingListsLoadingState(ERROR)
       })
@@ -331,8 +327,6 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 )
               })
             } else if (e.code === 404) {
-              removeApiCall('shoppingLists', 'patch')
-
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -340,10 +334,10 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                   "The shopping list you tried to update doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
-              removeApiCall('shoppingLists', 'patch')
               handleApiError(e)
             }
 
+            removeApiCall('shoppingLists', 'patch')
             onError && onError()
           })
       }
@@ -422,7 +416,6 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 )
               })
             } else if (e.code === 404) {
-              removeApiCall('shoppingLists', 'delete')
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -430,10 +423,10 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                   "The shopping list you tried to delete doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
-              removeApiCall('shoppingLists', 'delete')
               handleApiError(e)
             }
 
+            removeApiCall('shoppingLists', 'delete')
             onError && onError()
           })
       }
@@ -642,6 +635,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               newShoppingLists[index] = json[1]
 
               setShoppingLists(newShoppingLists)
+              removeApiCall('shoppingListItems', 'delete')
+
               setFlashProps({
                 hidden: false,
                 type: 'success',
@@ -650,6 +645,8 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
 
               onSuccess && onSuccess()
             } else {
+              removeApiCall('shoppingListItems', 'delete')
+
               setFlashProps({
                 hidden: false,
                 type: 'error',
@@ -658,8 +655,6 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
 
               onError && onError()
             }
-
-            removeApiCall('shoppingListItems', 'delete')
           })
           .catch((e: ApiError) => {
             retries ??= 1

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -344,7 +344,7 @@ describe('ShoppingListsPage', () => {
           'http://localhost:5173/shopping_lists'
         )
 
-        await  wrapper.findByText(
+        await wrapper.findByText(
           /You need a game to use the shopping lists feature\./
         )
 

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -6,6 +6,7 @@ import {
   beforeEach,
   afterAll,
   afterEach,
+  vitest,
 } from 'vitest'
 import {
   waitFor,
@@ -343,11 +344,13 @@ describe('ShoppingListsPage', () => {
           'http://localhost:5173/shopping_lists'
         )
 
-        await wrapper.findByText(
+        await  wrapper.findByText(
           /You need a game to use the shopping lists feature\./
         )
 
-        expect(wrapper).toMatchSnapshot()
+        await waitFor(() => {
+          expect(wrapper).toMatchSnapshot()
+        })
       })
     })
   })

--- a/src/types/apiCalls.d.ts
+++ b/src/types/apiCalls.d.ts
@@ -1,0 +1,9 @@
+export type HttpVerb = 'get' | 'post' | 'patch' | 'delete'
+
+export type Resource = 'games' | 'shoppingLists' | 'shoppingListItems'
+
+export interface ApiCalls {
+  games: HttpVerb[]
+  shoppingLists: HttpVerb[]
+  shoppingListItems: HttpVerb[]
+}


### PR DESCRIPTION
## Context

[**Add state to PageContext for when API calls are in progress**](https://trello.com/c/wy3oFvd0/301-add-state-to-pagecontext-for-when-api-calls-are-in-progress)

We've had several bugs come up due to race conditions in API calls. We've been reluctant to use `gamesLoadingState` and `shoppingListsLoadingState` to control the `disabled` state of form components, etc. because those variables can trigger a `PulseLoader` to be shown instead of the main page content. It is becoming clear we need a way to know which API calls are in progress so we can determine disabled state for each component.

## Changes

* New types for `apiCallsInProgress` object maintained by `PageProvider`
* Add `apiCallsInProgress` state variable to `PageProvider` value
* Add `addApiCall` and `removeApiCall` functions to `PageProvider` value
* Update components (`ShoppingListCreateForm` and `ShoppingListItem`) to base disabling behaviour on API calls in progress
* Update docs

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [x] Add/update docs
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles

## Manual Test Cases

You will want to verify that the shopping list creation form on the shopping lists page is disabled when any `shoppingLists` API call is in progress. The shopping list item's increment and decrement buttons should be disabled when any `shoppingListItems` API call is in progress.
