### PR TITLE
Use GitHub Actions v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 19
+        node-version: "19.8.1"
     - name: Install Node Modules
       run: yarn
     - name: lint


### PR DESCRIPTION
## Context

We have some [tests failing on `main`](https://github.com/danascheider/skyrim_inventory_management_frontend/actions/runs/6345379352/job/17237377962) that are not failing on my local. I believe the problem may be that Github Actions v2 uses Node 16 where we are using Node 19.8.1 locally and in production.

## Changes

* Use GitHub Actions v3
* Specify Node 19.8.1

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [ ] ~~Verify TypeScript compiles~~