### PR TITLE
Fix package-ecosystem in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Context

In our `dependabot.yml` file, we currently specify `"yarn"` as the `package-ecosystem`. However, `"yarn"` is not a possible value for this field. The appropriate one for this project is `"npm"`.

## Changes

* Change `package-ecosystem` from `"yarn"` to `"npm"` in `dependabot.yml`

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [ ] ~~Verify TypeScript compiles~~