### PR TITLE
Prevent deploys to Firebase if tests fail on main

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -3,14 +3,17 @@
 
 name: Deploy to Firebase Hosting on merge
 'on':
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [ "Skyrim Inventory Management Frontend CI" ]
+    branches: [ main ]
+    types:
+      - completed
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create production build
         run: yarn && yarn build
       - uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION
## Context

[**Prevent deploys to Firebase if tests fail on main**](https://trello.com/c/KM65iAgf/330-prevent-deploys-to-firebase-if-tests-fail-on-main)

We currently have GitHub Actions configured to run tests and deploy to Firebase on merge to `main`. However, these two workflows run independently of each other so the app could be deployed despite test failure. In fact, it could even be deployed before tests finish running. We would like deployment to Firebase to be contingent on tests passing on `main`.

## Changes

* Make Firebase deploy workflow dependent on success of test workflow

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [ ] ~~Verify TypeScript compiles~~

## Considerations

It won't really be possible to test this until it is merged to main. 🤠 