### PR TITLE
Remove dotenv as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@typescript-eslint/parser": "^6.7.4",
     "@vitejs/plugin-react": "^3.1.0",
     "babel-loader": "^9.1.3",
-    "dotenv": "^16.0.3",
     "eslint": "^8.50.0",
     "jsdom": "^22.1.0",
     "msw": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7340,7 +7340,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0, dotenv@npm:^16.0.3":
+"dotenv@npm:^16.0.0":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
   checksum: afcf03f373d7a6d62c7e9afea6328e62851d627a4e73f2e12d0a8deae1cd375892004f3021883f8aec85932cd2834b091f568ced92b4774625b321db83b827f8
@@ -12517,7 +12517,6 @@ __metadata:
     "@vitejs/plugin-react": ^3.1.0
     babel-loader: ^9.1.3
     classnames: ^2.3.2
-    dotenv: ^16.0.3
     eslint: ^8.50.0
     firebase: ^10.4.0
     jsdom: ^22.1.0


### PR DESCRIPTION
## Context

Dependabot's PR (#114) bumping dotenv alerted me to the fact that dotenv is a dependency. We don't seem to be using it as there is no `.env` file, so we should remove it from the `package.json`.

## Changes

* Remove dotenv as a dependency

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [ ] ~~Verify TypeScript compiles~~