### PR TITLE
Update TypeScript from 4.9.5 to 5.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "3.0.3",
     "storybook": "^7.4.6",
     "storybook-addon-mock": "^4.3.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.2.2",
     "vite": "^4.4.11",
     "vite-plugin-fonts": "^0.7.0",
     "vitest": "^0.34.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12885,7 +12885,7 @@ __metadata:
     react-spinners: ^0.13.8
     storybook: ^7.4.6
     storybook-addon-mock: ^4.3.0
-    typescript: ^4.9.5
+    typescript: ^5.2.2
     vite: ^4.4.11
     vite-plugin-fonts: ^0.7.0
     vitest: ^0.34.6
@@ -13606,23 +13606,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^5.2.2":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
+  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context

We are helping Dependabot get ahead of updates. One of the packages to be updated is TypeScript, a critical dev dependency that has a new (to us) major version. Upgrading doesn't seem to cause any issues with TypeScript compilation - the only change that was required was the update to the `package.json` and `yarn.lock`.

## Changes

* Update TypeScript from 4.9.5 to 5.2.2

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [x] Verify TypeScript compiles