### PR TITLE
Remove invalid 'test' key from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,8 +31,4 @@ export default defineConfig({
       },
     },
   },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-  },
 })


### PR DESCRIPTION
## Context

We have been getting errors from TS about an invalid key, `test`, in the Vite config. This PR removes the key.

## Changes

* Remove invalid key `test` from Vite config

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [x] Verify TypeScript compiles

## Considerations

Removal of this key and value from the config file does not seem to impact test runs at all.