### PR TITLE
Remove invalid 'test' key from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,8 +31,4 @@ export default defineConfig({
       },
     },
   },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-  },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-/// <reference types='vitest' />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import Unfonts from 'unplugin-fonts/vite'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  }
+})


### PR DESCRIPTION
I'm opening this PR because CI wasn't running on the last one since the original PR with this change was based off a branch other than `main`.  (Original PR with context: #143)