### PR TITLE
Update msw from 1.3.2 to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-loader": "^9.1.3",
     "eslint": "^8.52.0",
     "jsdom": "^22.1.0",
-    "msw": "^1.3.2",
+    "msw": "^2.0.0",
     "prettier": "3.0.3",
     "storybook": "^7.5.1",
     "storybook-addon-mock": "^4.3.0",

--- a/src/support/msw/games.ts
+++ b/src/support/msw/games.ts
@@ -1,5 +1,5 @@
-import { rest } from 'msw'
-import { type ResponseGame } from '../../types/apiData'
+import { http } from 'msw'
+import { RequestGame, type ResponseGame } from '../../types/apiData'
 import { emptyGames, allGames } from '../data/games'
 
 const BASE_URI = 'http://localhost:3000'
@@ -10,10 +10,10 @@ const BASE_URI = 'http://localhost:3000'
  *
  */
 
-export const postGamesSuccess = rest.post(
+export const postGamesSuccess = http.post(
   `${BASE_URI}/games`,
-  async (req, res, ctx) => {
-    const json = await req.json()
+  async ({ request }) => {
+    const json = await request.json() as RequestGame
 
     const body = {
       id: 102,
@@ -25,29 +25,29 @@ export const postGamesSuccess = rest.post(
       updated_at: new Date(),
     }
 
-    return res(ctx.status(201), ctx.json(body))
+    return new Response(JSON.stringify(body), { status: 201 })
   }
 )
 
-export const postGamesUnprocessable = rest.post(
+export const postGamesUnprocessable = http.post(
   `${BASE_URI}/games`,
-  (_req, res, ctx) => {
+  (_) => {
     const body = {
       errors: [
         "Name can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
       ],
     }
 
-    return res(ctx.status(422), ctx.json(body))
+    return new Response(JSON.stringify(body), { status: 422 })
   }
 )
 
-export const postGamesServerError = rest.post(
+export const postGamesServerError = http.post(
   `${BASE_URI}/games`,
-  (_req, res, ctx) => {
+  (_) => {
     const body = { errors: ['oh noes'] }
 
-    return res(ctx.status(500), ctx.json(body))
+    return new Response(JSON.stringify(body), { status: 500 })
   }
 )
 
@@ -57,24 +57,24 @@ export const postGamesServerError = rest.post(
  *
  */
 
-export const getGamesEmptySuccess = rest.get(
+export const getGamesEmptySuccess = http.get(
   `${BASE_URI}/games`,
-  (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(emptyGames))
+  (_) => {
+    return new Response(JSON.stringify(emptyGames), { status: 200 })
   }
 )
 
-export const getGamesAllSuccess = rest.get(
+export const getGamesAllSuccess = http.get(
   `${BASE_URI}/games`,
-  (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(allGames))
+  (_) => {
+    return new Response(JSON.stringify(allGames), { status: 200 })
   }
 )
 
-export const getGamesServerError = rest.get(
+export const getGamesServerError = http.get(
   `${BASE_URI}/games`,
-  (_req, res, ctx) => {
-    return res(ctx.status(500), ctx.json({ errors: ['Something went wrong'] }))
+  (_) => {
+    return new Response(JSON.stringify({ errors: ['Something went wrong'] }), { status: 500 })
   }
 )
 
@@ -99,35 +99,36 @@ const newOrExistingGame = (id: number): ResponseGame => {
   }
 }
 
-export const patchGameSuccess = rest.patch(
+export const patchGameSuccess = http.patch(
   `${BASE_URI}/games/:id`,
-  async (req, res, ctx) => {
-    const id = Number(req.params.id)
-    const body = await req.json()
-    const game = newOrExistingGame(id)
+  async ({ request, params }) => {
+    const { id } = params
+    const body = await request.json() as RequestGame
+    const game = newOrExistingGame(Number(id))
+    const respBody = JSON.stringify({ ...game, ...body })
 
-    return res(ctx.status(200), ctx.json({ ...game, ...body }))
+    return new Response(respBody, { status: 200 })
   }
 )
 
-export const patchGameUnprocessableEntity = rest.patch(
+export const patchGameUnprocessableEntity = http.patch(
   `${BASE_URI}/games/:id`,
-  (_req, res, ctx) => {
-    return res(ctx.status(422), ctx.json({ errors: ['Name must be unique'] }))
+  (_) => {
+    return new Response(JSON.stringify({ errors: ['Name must be unique'] }), { status: 422 })
   }
 )
 
-export const patchGameNotFound = rest.patch(
+export const patchGameNotFound = http.patch(
   `${BASE_URI}/games/:id`,
-  (_req, res, ctx) => {
-    return res(ctx.status(404))
+  (_) => {
+    return new Response(null, { status: 404 })
   }
 )
 
-export const patchGameServerError = rest.patch(
+export const patchGameServerError = http.patch(
   `${BASE_URI}/games/:id`,
-  (_req, res, ctx) => {
-    return res(ctx.status(500), ctx.json({ errors: ['oh noes'] }))
+  (_) => {
+    return new Response(JSON.stringify({ errors: ['oh noes'] }), { status: 500 })
   }
 )
 
@@ -137,23 +138,23 @@ export const patchGameServerError = rest.patch(
  *
  */
 
-export const deleteGameSuccess = rest.delete(
+export const deleteGameSuccess = http.delete(
   `${BASE_URI}/games/:id`,
-  (_req, res, ctx) => {
-    return res(ctx.status(204))
+  (_) => {
+    return new Response(null, { status: 204 })
   }
 )
 
-export const deleteGameNotFound = rest.delete(
+export const deleteGameNotFound = http.delete(
   `${BASE_URI}/games/:id`,
-  (_req, res, ctx) => {
-    return res(ctx.status(404))
+  (_) => {
+    return new Response(null, { status: 404 })
   }
 )
 
-export const deleteGameServerError = rest.delete(
+export const deleteGameServerError = http.delete(
   `${BASE_URI}/games/:id`,
-  (_req, res, ctx) => {
-    return res(ctx.status(500), ctx.json({ errors: ['oh noes'] }))
+  (_) => {
+    return new Response(JSON.stringify({ errors: ['oh noes'] }), { status: 500 })
   }
 )

--- a/src/support/msw/games.ts
+++ b/src/support/msw/games.ts
@@ -1,5 +1,5 @@
 import { http } from 'msw'
-import { RequestGame, type ResponseGame } from '../../types/apiData'
+import { type RequestGame, type ResponseGame } from '../../types/apiData'
 import { emptyGames, allGames } from '../data/games'
 
 const BASE_URI = 'http://localhost:3000'

--- a/src/support/msw/shoppingListItems.ts
+++ b/src/support/msw/shoppingListItems.ts
@@ -1,4 +1,4 @@
-import { rest } from 'msw'
+import { http } from 'msw'
 import { allShoppingLists, shoppingListsForGame } from '../data/shoppingLists'
 import { allShoppingListItems } from '../data/shoppingListItems'
 import { newShoppingListItem } from './helpers/data'
@@ -14,47 +14,47 @@ const listIds = allShoppingLists.map(({ id }) => id)
  */
 
 // Handles 201 and 404 responses
-export const postShoppingListItemsSuccess = rest.post(
+export const postShoppingListItemsSuccess = http.post(
   `${BASE_URI}/shopping_lists/:listId/shopping_list_items`,
-  async (req, res, ctx) => {
-    const listId: number = Number(req.params.listId)
+  async ({ request, params }) => {
+    const listId = Number(params.listId)
 
-    if (listIds.indexOf(listId) < 0) return res(ctx.status(404))
+    if (listIds.indexOf(listId) < 0) return new Response(null, { status: 404 })
 
-    const attributes = await req.json()
+    const attributes = await request.json() as RequestShoppingListItem
 
-    return res(
-      ctx.status(201),
-      ctx.json(newShoppingListItem(attributes, listId))
+    return new Response(
+      JSON.stringify(newShoppingListItem(attributes, listId)),
+      { status: 201 }
     )
   }
 )
 
 // Returns the same validation errors regardless of request body
 // submitted
-export const postShoppingListItemsUnprocessable = rest.post(
+export const postShoppingListItemsUnprocessable = http.post(
   `${BASE_URI}/shopping_lists/:listId/shopping_list_items`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(422),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: [
           'Quantity must be greater than 0',
           'Unit weight must be greater than or equal to 0',
         ],
-      })
+      }),
+      { status: 422 }
     )
   }
 )
 
-export const postShoppingListItemsServerError = rest.post(
+export const postShoppingListItemsServerError = http.post(
   `${BASE_URI}/shopping_lists/:listId/shopping_list_items`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(500),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: ['Something went horribly wrong'],
-      })
+      }),
+      { status: 500 }
     )
   }
 )
@@ -65,14 +65,14 @@ export const postShoppingListItemsServerError = rest.post(
  *
  */
 
-export const incrementShoppingListItemSuccess = rest.patch(
+export const incrementShoppingListItemSuccess = http.patch(
   `${BASE_URI}/shopping_list_items/:id`,
-  (req, res, ctx) => {
-    const itemId: number = Number(req.params.id)
+  ({ params }) => {
+    const itemId: number = Number(params.id)
     const item = allShoppingListItems.find(({ id }) => id === itemId)
     const list = allShoppingLists.find(({ id }) => id === item?.list_id)
 
-    if (!item || !list) return res(ctx.status(404))
+    if (!item || !list) return new Response(null, { status: 404 })
 
     const allItems = shoppingListsForGame(list.game_id).flatMap(
       ({ list_items }) =>
@@ -82,18 +82,18 @@ export const incrementShoppingListItemSuccess = rest.patch(
     const aggListItem = { ...allItems[0], quantity: allItems[0].quantity + 1 }
     const regItem = { ...item, quantity: item.quantity + 1 }
 
-    return res(ctx.status(200), ctx.json([aggListItem, regItem]))
+    return new Response(JSON.stringify([aggListItem, regItem]), { status: 200 })
   }
 )
 
-export const decrementShoppingListItemSuccess = rest.patch(
+export const decrementShoppingListItemSuccess = http.patch(
   `${BASE_URI}/shopping_list_items/:id`,
-  (req, res, ctx) => {
-    const itemId: number = Number(req.params.id)
+  ({ request, params }) => {
+    const itemId: number = Number(params.id)
     const item = allShoppingListItems.find(({ id }) => id === itemId)
     const list = allShoppingLists.find(({ id }) => id === item?.list_id)
 
-    if (!item || !list) return res(ctx.status(404))
+    if (!item || !list) return new Response(null, { status: 404 })
 
     const allItems = shoppingListsForGame(list.game_id).flatMap(
       ({ list_items }) =>
@@ -102,7 +102,7 @@ export const decrementShoppingListItemSuccess = rest.patch(
     const aggListItem = { ...allItems[0], quantity: allItems[0].quantity - 1 }
     const regItem = { ...item, quantity: item.quantity - 1 }
 
-    return res(ctx.status(200), ctx.json([aggListItem, regItem]))
+    return new Response(JSON.stringify([aggListItem, regItem]), { status: 200 })
   }
 )
 
@@ -117,16 +117,16 @@ export const decrementShoppingListItemSuccess = rest.patch(
 // the list item being updated has no "notes" value other than that of the
 // list item being updated - i.e., none of its other associated list items, if
 // any, have notes. If they did, that, too, would further complicate things.
-export const updateShoppingListItemSuccess = rest.patch(
+export const updateShoppingListItemSuccess = http.patch(
   `${BASE_URI}/shopping_list_items/:id`,
-  async (req, res, ctx) => {
-    const itemId: number = Number(req.params.id)
+  async ({ request, params }) => {
+    const itemId: number = Number(params.id)
     const item = allShoppingListItems.find(({ id }) => id === itemId)
     const list = allShoppingLists.find(({ id }) => id === item?.list_id)
 
-    if (!item || !list) return res(ctx.status(404))
+    if (!item || !list) return new Response(null, { status: 404 })
 
-    const json = (await req.json()) as RequestShoppingListItem
+    const json = await request.json() as RequestShoppingListItem
 
     const allItems = shoppingListsForGame(list.game_id).flatMap(
       ({ list_items }) =>
@@ -135,34 +135,34 @@ export const updateShoppingListItemSuccess = rest.patch(
     const aggListItem = { ...allItems[0], notes: json.notes }
     const regItem = { ...item, notes: json.notes }
 
-    return res(ctx.status(200), ctx.json([aggListItem, regItem]))
+    return new Response(JSON.stringify([aggListItem, regItem]), { status: 200 })
   }
 )
 
 // Returns the same validation errors regardless of request body
-export const updateShoppingListItemUnprocessable = rest.patch(
+export const updateShoppingListItemUnprocessable = http.patch(
   `${BASE_URI}/shopping_list_items/:id`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(422),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: [
           'Quantity must be greater than 0',
           'Unit weight must be greater than or equal to 0',
         ],
-      })
+      }),
+      { status: 422 }
     )
   }
 )
 
-export const updateShoppingListItemServerError = rest.patch(
+export const updateShoppingListItemServerError = http.patch(
   `${BASE_URI}/shopping_list_items/:id`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(500),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: ['Something went horribly wrong'],
-      })
+      }),
+      { status: 500 }
     )
   }
 )
@@ -178,23 +178,23 @@ export const updateShoppingListItemServerError = rest.patch(
 //       from the regular list AND the aggregate list regardless
 //       of whether there are other matching items. This function
 //       does not match the complexity of back-end behaviour.
-export const deleteShoppingListItemSuccess = rest.delete(
+export const deleteShoppingListItemSuccess = http.delete(
   `${BASE_URI}/shopping_list_items/:id`,
-  (req, res, ctx) => {
-    const itemId: number = Number(req.params.id)
+  ({ request, params }) => {
+    const itemId = Number(params.id)
     const item = allShoppingListItems.find(({ id }) => id === itemId)
 
-    if (!item) return res(ctx.status(404))
+    if (!item) return new Response(null, { status: 404 })
 
     const listId = item.list_id
     const regList = allShoppingLists.find(({ id }) => id === listId)
 
-    if (!regList) return res(ctx.status(404))
+    if (!regList) return new Response(null, { status: 404 })
 
     const aggListId = regList.aggregate_list_id
     const aggList = allShoppingLists.find(({ id }) => id === aggListId)
 
-    if (!aggList) return res(ctx.status(404))
+    if (!aggList) return new Response(null, { status: 404 })
 
     const list = { ...regList }
     const aggregate = { ...aggList }
@@ -204,16 +204,16 @@ export const deleteShoppingListItemSuccess = rest.delete(
       ({ description }) => description !== item.description
     )
 
-    return res(ctx.status(200), ctx.json([aggregate, list]))
+    return new Response(JSON.stringify([aggregate, list]), { status: 200 })
   }
 )
 
-export const deleteShoppingListItemServerError = rest.delete(
+export const deleteShoppingListItemServerError = http.delete(
   `${BASE_URI}/shopping_list_items/:id`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(500),
-      ctx.json({ errors: ['Something went horribly wrong'] })
+  (_) => {
+    return new Response(
+      JSON.stringify({ errors: ['Something went horribly wrong'] }),
+      { status: 500 }
     )
   }
 )

--- a/src/support/msw/shoppingListItems.ts
+++ b/src/support/msw/shoppingListItems.ts
@@ -2,7 +2,7 @@ import { http } from 'msw'
 import { allShoppingLists, shoppingListsForGame } from '../data/shoppingLists'
 import { allShoppingListItems } from '../data/shoppingListItems'
 import { newShoppingListItem } from './helpers/data'
-import { RequestShoppingListItem } from '../../types/apiData'
+import { type RequestShoppingListItem } from '../../types/apiData'
 
 const BASE_URI = 'http://localhost:3000'
 const listIds = allShoppingLists.map(({ id }) => id)

--- a/src/support/msw/shoppingLists.ts
+++ b/src/support/msw/shoppingLists.ts
@@ -3,7 +3,7 @@ import { allGames } from '../data/games'
 import { allShoppingLists } from '../data/shoppingLists'
 import { shoppingListsForGame } from '../data/shoppingLists'
 import { newShoppingList, newShoppingListWithAggregate } from './helpers/data'
-import { RequestShoppingList } from '../../types/apiData'
+import { type RequestShoppingList } from '../../types/apiData'
 
 const BASE_URI = 'http://localhost:3000'
 const gameIds = allGames.map(({ id }) => id)

--- a/src/support/msw/shoppingLists.ts
+++ b/src/support/msw/shoppingLists.ts
@@ -1,8 +1,9 @@
-import { rest } from 'msw'
+import { http } from 'msw'
 import { allGames } from '../data/games'
 import { allShoppingLists } from '../data/shoppingLists'
 import { shoppingListsForGame } from '../data/shoppingLists'
 import { newShoppingList, newShoppingListWithAggregate } from './helpers/data'
+import { RequestShoppingList } from '../../types/apiData'
 
 const BASE_URI = 'http://localhost:3000'
 const gameIds = allGames.map(({ id }) => id)
@@ -15,48 +16,48 @@ const listIds = allShoppingLists.map(({ id }) => id)
  */
 
 // Handles both 201 and 404 responses
-export const postShoppingListsSuccess = rest.post(
+export const postShoppingListsSuccess = http.post(
   `${BASE_URI}/games/:gameId/shopping_lists`,
-  async (req, res, ctx) => {
-    const gameId: number = Number(req.params.gameId)
+  async ({ request, params }) => {
+    const gameId = Number(params.gameId)
 
-    if (gameIds.indexOf(gameId) < 0) return res(ctx.status(404))
+    if (gameIds.indexOf(gameId) < 0) return new Response(null, { status: 404 })
 
-    const attributes = await req.json()
+    const attributes = await request.json() as RequestShoppingList
 
     const responseBody = shoppingListsForGame(gameId).length
       ? newShoppingList(attributes, gameId)
       : newShoppingListWithAggregate(attributes, gameId)
 
-    return res(ctx.status(201), ctx.json(responseBody))
+    return new Response(JSON.stringify(responseBody), { status: 201 })
   }
 )
 
 // Returns the same validation errors regardless of request body
 // submitted
-export const postShoppingListsUnprocessable = rest.post(
+export const postShoppingListsUnprocessable = http.post(
   `${BASE_URI}/games/:gameId/shopping_lists`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(422),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: [
           'Title must be unique per game',
           "Title can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
         ],
-      })
+      }),
+      { status: 422 }
     )
   }
 )
 
-export const postShoppingListsServerError = rest.post(
+export const postShoppingListsServerError = http.post(
   `${BASE_URI}/games/:gameId/shopping_lists`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(500),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: ['Something went horribly wrong'],
-      })
+      }),
+      { status: 500 }
     )
   }
 )
@@ -68,21 +69,21 @@ export const postShoppingListsServerError = rest.post(
  */
 
 // Covers both success and 404 cases
-export const getShoppingListsSuccess = rest.get(
+export const getShoppingListsSuccess = http.get(
   `${BASE_URI}/games/:gameId/shopping_lists`,
-  (req, res, ctx) => {
-    const gameId: number = Number(req.params.gameId)
+  ({ params }) => {
+    const gameId = Number(params.gameId)
 
-    if (gameIds.indexOf(gameId) < 0) return res(ctx.status(404))
+    if (gameIds.indexOf(gameId) < 0) return new Response(null, { status: 404 })
 
-    return res(ctx.status(200), ctx.json(shoppingListsForGame(gameId)))
+    return new Response(JSON.stringify(shoppingListsForGame(gameId)), { status: 200 })
   }
 )
 
-export const getShoppingListsEmptySuccess = rest.get(
+export const getShoppingListsEmptySuccess = http.get(
   `${BASE_URI}/games/:gameId/shopping_lists`,
-  (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json([]))
+  (_) => {
+    return new Response(JSON.stringify([]), { status: 200 })
   }
 )
 
@@ -93,45 +94,45 @@ export const getShoppingListsEmptySuccess = rest.get(
  */
 
 // Covers both success and 404 cases
-export const patchShoppingListSuccess = rest.patch(
+export const patchShoppingListSuccess = http.patch(
   `${BASE_URI}/shopping_lists/:id`,
-  async (req, res, ctx) => {
-    const listId: number = Number(req.params.id)
+  async ({ request, params }) => {
+    const listId = Number(params.id)
 
-    if (listIds.indexOf(listId) < 0) return res(ctx.status(404))
+    if (listIds.indexOf(listId) < 0) return new Response(null, { status: 404 })
 
     const list = allShoppingLists.find(({ id }) => id === listId)
-    const { title } = await req.json()
+    const { title } = await request.json() as RequestShoppingList
 
-    return res(ctx.status(200), ctx.json({ ...list, title }))
+    return new Response(JSON.stringify({ ...list, title }), { status: 200 })
   }
 )
 
 // Returns the same validation errors regardless of request
 // body submitted
-export const patchShoppingListUnprocessable = rest.patch(
+export const patchShoppingListUnprocessable = http.patch(
   `${BASE_URI}/shopping_lists/:id`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(422),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: [
           'Title must be unique per game',
           "Title can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
         ],
-      })
+      }),
+      { status: 422 }
     )
   }
 )
 
-export const patchShoppingListServerError = rest.patch(
+export const patchShoppingListServerError = http.patch(
   `${BASE_URI}/shopping_lists/:id`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(500),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: ['Something went horribly wrong'],
-      })
+      }),
+      { status: 500 }
     )
   }
 )
@@ -143,13 +144,13 @@ export const patchShoppingListServerError = rest.patch(
  */
 
 // Covers both success and 404 cases
-export const deleteShoppingListSuccess = rest.delete(
+export const deleteShoppingListSuccess = http.delete(
   `${BASE_URI}/shopping_lists/:listId`,
-  (req, res, ctx) => {
-    const listId = Number(req.params.listId)
+  ({ params }) => {
+    const listId = Number(params.listId)
     const list = allShoppingLists.find(({ id }) => id === listId)
 
-    if (!list) return res(ctx.status(404))
+    if (!list) return new Response(null, { status: 404 })
 
     const lists = shoppingListsForGame(list.game_id)
 
@@ -165,18 +166,18 @@ export const deleteShoppingListSuccess = rest.delete(
       }
     }
 
-    return res(ctx.status(200), ctx.json(json))
+    return new Response(JSON.stringify(json), { status: 200 })
   }
 )
 
-export const deleteShoppingListServerError = rest.delete(
+export const deleteShoppingListServerError = http.delete(
   `${BASE_URI}/shopping_lists/:listId`,
-  (_req, res, ctx) => {
-    return res(
-      ctx.status(500),
-      ctx.json({
+  (_) => {
+    return new Response(
+      JSON.stringify({
         errors: ['Something went horribly wrong'],
-      })
+      }),
+      { status: 500 }
     )
   }
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,6 +1479,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bundled-es-modules/cookie@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@bundled-es-modules/cookie@npm:2.0.0"
+  dependencies:
+    cookie: ^0.5.0
+  checksum: 53114eabbedda20ba6c63f45dcea35c568616d22adf5d1882cef9761f65ae636bf47e0c66325572cc8e3a335e0257caf5f76ff1287990d9e9265be7bc9767a87
+  languageName: node
+  linkType: hard
+
+"@bundled-es-modules/js-levenshtein@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@bundled-es-modules/js-levenshtein@npm:2.0.1"
+  dependencies:
+    js-levenshtein: ^1.1.6
+  checksum: 13d0cbd2b00e563e09a797559dcff8c7e208c1f71e1787535a3d248f7e3d33ef3f0809b9f498d41788ab5fd399882dcca79917d70d97921b7dde94a282c1b7d8
+  languageName: node
+  linkType: hard
+
+"@bundled-es-modules/statuses@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@bundled-es-modules/statuses@npm:1.0.1"
+  dependencies:
+    statuses: ^2.0.1
+  checksum: bcaa7de192e73056950b5fd20e75140d8d09074b1adc4437924b2051bb02b4dbf568c96e67d53b220fb7d735c3446e2ba746599cb1793ab2d23dd2ef230a8622
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -2682,29 +2709,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mswjs/cookies@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "@mswjs/cookies@npm:0.2.2"
-  dependencies:
-    "@types/set-cookie-parser": ^2.4.0
-    set-cookie-parser: ^2.4.6
-  checksum: 23b1ef56d57efcc1b44600076f531a1fb703855af342a31e01bad4adaf0dab51f6d3b5595a95a7988c3f612ba075835f9a06c52833205284d101eb9a51dd72b0
+"@mswjs/cookies@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@mswjs/cookies@npm:1.0.0"
+  checksum: 5ae38a399162fb96b367b9d0da24c1cf64dea9f5a0a07255a14c4b047da788049268059b0350a0b7788f37a32834c9fbef2fc5f60755d0d98bcf95bcb6ffe92e
   languageName: node
   linkType: hard
 
-"@mswjs/interceptors@npm:^0.17.10":
-  version: 0.17.10
-  resolution: "@mswjs/interceptors@npm:0.17.10"
+"@mswjs/interceptors@npm:^0.25.1":
+  version: 0.25.7
+  resolution: "@mswjs/interceptors@npm:0.25.7"
   dependencies:
-    "@open-draft/until": ^1.0.3
-    "@types/debug": ^4.1.7
-    "@xmldom/xmldom": ^0.8.3
-    debug: ^4.3.3
-    headers-polyfill: 3.2.5
+    "@open-draft/deferred-promise": ^2.2.0
+    "@open-draft/logger": ^0.3.0
+    "@open-draft/until": ^2.0.0
+    is-node-process: ^1.2.0
     outvariant: ^1.2.1
-    strict-event-emitter: ^0.2.4
-    web-encoding: ^1.1.5
-  checksum: 0e6d32f399144b5cefe6fd7620f2776c83adc9bbbbccf2eb4ea347332be059f585136c44168c09b544c41cd3d686f88e43432e10192227a24fbb0c98a2f52dc8
+    strict-event-emitter: ^0.5.1
+  checksum: d9dc1bf11e088b52ba01a4fbcedb3bf7451592bd0255e3591a6478f5465caf0fbd9264c7a32b0aad5bbd31baa2c9eabd6a36b5deace23a82061e34c884eb5fcb
   languageName: node
   linkType: hard
 
@@ -2755,10 +2777,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@open-draft/until@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@open-draft/until@npm:1.0.3"
-  checksum: 323e92ebef0150ed0f8caedc7d219b68cdc50784fa4eba0377eef93533d3f46514eb2400ced83dda8c51bddc3d2c7b8e9cf95e5ec85ab7f62dfc015d174f62f2
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 7f29d39725bb8ab5b62f89d88a4202ce2439ac740860979f9e3d0015dfe4bc3daddcfa5727fa4eed482fdbee770aa591b1136b98b0a0f0569a65294f35bdf56a
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: ^1.2.0
+    outvariant: ^1.4.0
+  checksum: 7adfe3d0ed8ca32333ce2a77f9a93d561ebc89c989eaa9722f1dc8a2d2854f5de1bef6fa6894cdf58e16fa4dd9cfa99444ea1f5cac6eb1518e9247911ed042d5
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0, @open-draft/until@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 140ea3b16f4a3a6a729c1256050e20a93d408d7aa1e125648ce2665b3c526ed452510c6e4a6f4b15d95fb5e41203fb51510eb8fbc8812d5e5a91880293d66471
   languageName: node
   linkType: hard
 
@@ -4667,7 +4706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.7":
+"@types/debug@npm:^4.0.0":
   version: 4.1.7
   resolution: "@types/debug@npm:4.1.7"
   dependencies:
@@ -5042,12 +5081,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/set-cookie-parser@npm:^2.4.0":
-  version: 2.4.2
-  resolution: "@types/set-cookie-parser@npm:2.4.2"
-  dependencies:
-    "@types/node": "*"
-  checksum: c31bf04eb9620829dc3c91bced74ac934ad039d20d20893fb5acac0f08769cbd4eef3bf7502a0289c7be59c3e9cfa456147b4e88bff47dd1b9efb4995ba5d5a3
+"@types/statuses@npm:^2.0.1":
+  version: 2.0.3
+  resolution: "@types/statuses@npm:2.0.3"
+  checksum: ff47ea1177c9ed37d733e8d089663fc45f006a4eea319e4cd558a49feb17159e32ab53013fbb6f32bf30f869f652eb88d00d42cb819d88009fb7ce0afe48d73c
   languageName: node
   linkType: hard
 
@@ -5243,13 +5280,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.3":
-  version: 0.8.6
-  resolution: "@xmldom/xmldom@npm:0.8.6"
-  checksum: f17ac6d99a971a6aeb831fcfc5cfa86f367664e45815046548814b2deb17ccc421fef4e0d5ba29e66179d112b552f6caa5680064f8e7bd8a389b788a60404c8e
-  languageName: node
-  linkType: hard
-
 "@yarnpkg/esbuild-plugin-pnp@npm:^3.0.0-rc.10":
   version: 3.0.0-rc.15
   resolution: "@yarnpkg/esbuild-plugin-pnp@npm:3.0.0-rc.15"
@@ -5278,13 +5308,6 @@ __metadata:
     "@types/emscripten": ^1.39.6
     tslib: ^1.13.0
   checksum: 533a4883f69bb013f955d80dc19719881697e6849ea5f0cbe6d87ef1d582b05cbae8a453802f92ad0c852f976296cac3ff7834be79a7e415b65cdf213e448110
-  languageName: node
-  linkType: hard
-
-"@zxing/text-encoding@npm:0.9.0":
-  version: 0.9.0
-  resolution: "@zxing/text-encoding@npm:0.9.0"
-  checksum: c23b12aee7639382e4949961304a1294776afaffa40f579e09ffecd0e5e68cf26ef3edd75009de46da8a536e571448755ca68b3e2ea707d53793c0edb2e2c34a
   languageName: node
   linkType: hard
 
@@ -6307,17 +6330,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.5.0":
+"cookie@npm:0.5.0, cookie@npm:^0.5.0":
   version: 0.5.0
   resolution: "cookie@npm:0.5.0"
   checksum: 1f4bd2ca5765f8c9689a7e8954183f5332139eb72b6ff783d8947032ec1fdf43109852c178e21a953a30c0dd42257828185be01b49d1eb1a67fd054ca588a180
-  languageName: node
-  linkType: hard
-
-"cookie@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "cookie@npm:0.4.2"
-  checksum: a00833c998bedf8e787b4c342defe5fa419abd96b32f4464f718b91022586b8f1bafbddd499288e75c037642493c83083da426c6a9080d309e3bd90fd11baa9b
   languageName: node
   linkType: hard
 
@@ -7162,13 +7178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
-  languageName: node
-  linkType: hard
-
 "execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -7559,6 +7568,16 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
+  languageName: node
+  linkType: hard
+
+"formdata-node@npm:4.4.1":
+  version: 4.4.1
+  resolution: "formdata-node@npm:4.4.1"
+  dependencies:
+    node-domexception: 1.0.0
+    web-streams-polyfill: 4.0.0-beta.3
+  checksum: d91d4f667cfed74827fc281594102c0dabddd03c9f8b426fc97123eedbf73f5060ee43205d89284d6854e2fc5827e030cd352ef68b93beda8decc2d72128c576
   languageName: node
   linkType: hard
 
@@ -7980,10 +7999,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"headers-polyfill@npm:3.2.5":
-  version: 3.2.5
-  resolution: "headers-polyfill@npm:3.2.5"
-  checksum: a3c4bdd661584fd39e40c0f91412abc514616edfbd20d29a75567e591f90ef5c445c8e209b7f3c2b2375d27e95e4690f33417368a168d4832484a93861ab6a3c
+"headers-polyfill@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "headers-polyfill@npm:4.0.2"
+  checksum: a95280ed58df429fc86c4f49b21596be3ea3f5f3d790e7d75238668df9b90b292f15a968c7c19ae1db88c0ae036dd1bf363a71b8e771199d82848e2d8b3c6c2e
   languageName: node
   linkType: hard
 
@@ -9992,37 +10011,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "msw@npm:1.3.2"
+"msw@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "msw@npm:2.0.0"
   dependencies:
-    "@mswjs/cookies": ^0.2.2
-    "@mswjs/interceptors": ^0.17.10
-    "@open-draft/until": ^1.0.3
+    "@bundled-es-modules/cookie": ^2.0.0
+    "@bundled-es-modules/js-levenshtein": ^2.0.1
+    "@bundled-es-modules/statuses": ^1.0.1
+    "@mswjs/cookies": ^1.0.0
+    "@mswjs/interceptors": ^0.25.1
+    "@open-draft/until": ^2.1.0
     "@types/cookie": ^0.4.1
     "@types/js-levenshtein": ^1.1.1
-    chalk: ^4.1.1
+    "@types/statuses": ^2.0.1
+    chalk: ^4.1.2
     chokidar: ^3.4.2
-    cookie: ^0.4.2
+    formdata-node: 4.4.1
     graphql: ^16.8.1
-    headers-polyfill: 3.2.5
+    headers-polyfill: ^4.0.1
     inquirer: ^8.2.0
     is-node-process: ^1.2.0
     js-levenshtein: ^1.1.6
     node-fetch: ^2.6.7
     outvariant: ^1.4.0
     path-to-regexp: ^6.2.0
-    strict-event-emitter: ^0.4.3
+    strict-event-emitter: ^0.5.0
     type-fest: ^2.19.0
     yargs: ^17.3.1
   peerDependencies:
-    typescript: ">= 4.4.x <= 5.2.x"
+    typescript: ">= 4.7.x <= 5.2.x"
   peerDependenciesMeta:
     typescript:
       optional: true
   bin:
     msw: cli/index.js
-  checksum: c2d4f7747f5806f0fd8d8cc3ca250ee1c2a7a6cd608de43f95bd072ba1fb13cdce0b52932ce9bf8f4a21b194d2815db535501e224ec8f7052593447fe1c0cb70
+  checksum: b8de495c829f097ae59e74254bce5ab21742a1c4f8e034bb882f75d5f242e329db436ae10bbaa87497fc62003221860ddd115478a30034a349b44d4b36021d08
   languageName: node
   linkType: hard
 
@@ -10069,6 +10092,13 @@ __metadata:
   dependencies:
     minimatch: ^3.0.2
   checksum: 29de9560e52cdac8d3f794d38d782f6799e13d4d11aaf96d3da8c28458e1c5e33bb5f8edfb42dc34172ec5516c50c5b8850c9e1526542616757a969267263328
+  languageName: node
+  linkType: hard
+
+"node-domexception@npm:1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: ee1d37dd2a4eb26a8a92cd6b64dfc29caec72bff5e1ed9aba80c294f57a31ba4895a60fd48347cf17dd6e766da0ae87d75657dfd1f384ebfa60462c2283f5c7f
   languageName: node
   linkType: hard
 
@@ -11636,13 +11666,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-cookie-parser@npm:^2.4.6":
-  version: 2.5.1
-  resolution: "set-cookie-parser@npm:2.5.1"
-  checksum: b99c37f976e68ae6eb7c758bf2bbce1e60bb54e3eccedaa25f2da45b77b9cab58d90674cf9edd7aead6fbeac6308f2eb48713320a47ca120d0e838d0194513b6
-  languageName: node
-  linkType: hard
-
 "setprototypeof@npm:1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
@@ -11762,7 +11785,7 @@ __metadata:
     eslint: ^8.52.0
     firebase: ^10.5.0
     jsdom: ^22.1.0
-    msw: ^1.3.2
+    msw: ^2.0.0
     prettier: 3.0.3
     react: ^18.2.0
     react-animate-height: ^3.2.2
@@ -11903,7 +11926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:2.0.1":
+"statuses@npm:2.0.1, statuses@npm:^2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
@@ -11981,19 +12004,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strict-event-emitter@npm:^0.2.4":
-  version: 0.2.8
-  resolution: "strict-event-emitter@npm:0.2.8"
-  dependencies:
-    events: ^3.3.0
-  checksum: 6ac06fe72a6ee6ae64d20f1dd42838ea67342f1b5f32b03b3050d73ee6ecee44b4d5c4ed2965a7154b47991e215f373d4e789e2b2be2769cd80e356126c2ca53
-  languageName: node
-  linkType: hard
-
-"strict-event-emitter@npm:^0.4.3":
-  version: 0.4.6
-  resolution: "strict-event-emitter@npm:0.4.6"
-  checksum: 4f4f2909613e7811de789991c06bfb770d6d6987e2ec5c66fa7485d0f07cc4e7e32eba0dcf26cee6d86af6c92946d7f4acdfaff57d0c4114df2cfa1bf0e3c091
+"strict-event-emitter@npm:^0.5.0, strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 350480431bc1c28fdb601ef4976c2f8155fc364b4740f9692dd03e5bdd48aafc99a5e021fe655fbd986d0b803e9f3fc5c4b018b35cb838c4690d60f2a26f1cf3
   languageName: node
   linkType: hard
 
@@ -12783,7 +12797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util@npm:^0.12.0, util@npm:^0.12.3, util@npm:^0.12.4":
+"util@npm:^0.12.0, util@npm:^0.12.4":
   version: 0.12.5
   resolution: "util@npm:0.12.5"
   dependencies:
@@ -13058,16 +13072,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-encoding@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "web-encoding@npm:1.1.5"
-  dependencies:
-    "@zxing/text-encoding": 0.9.0
-    util: ^0.12.3
-  dependenciesMeta:
-    "@zxing/text-encoding":
-      optional: true
-  checksum: 2234a2b122f41006ce07859b3c0bf2e18f46144fda2907d5db0b571b76aa5c26977c646100ad9c00d2f8a4f6f2b848bc02147845d8c447ab365ec4eff376338d
+"web-streams-polyfill@npm:4.0.0-beta.3":
+  version: 4.0.0-beta.3
+  resolution: "web-streams-polyfill@npm:4.0.0-beta.3"
+  checksum: dfec1fbf52b9140e4183a941e380487b6c3d5d3838dd1259be81506c1c9f2abfcf5aeb670aeeecfd9dff4271a6d8fef931b193c7bedfb42542a3b05ff36c0d16
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context

[**Update msw to 2.x**](https://trello.com/c/8D2tNI1Z/339-update-msw-to-version-2x)

In #159 Dependabot attempted to bump the [msw package](https://www.npmjs.com/package/msw) from 1.3.2 to 2.0.0. However, the API of the library has changed significantly in the new major version, leading to test failures on Dependabot's PR. This PR updates msw and fixes the test failures in line with the [migration guide](https://mswjs.io/docs/migrations/1.x-to-2.x).

## Changes

* Update msw from 1.3.2 to 2.0.0
* Fix test failures by updating msw API in helper functions

## Required Tasks

- [x] Add/update automated tests
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [x] Verify TypeScript compiles
