### PR TITLE
Update UI to use wishlist nomenclature

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ Summary of the changes made, preferably as a bulleted list
 
 - [ ] Add/update automated tests
 - [ ] Add/update Storybook stories
+- [ ] Comprehensively test final changes in local environment
 - [ ] Add/update docs
 - [ ] Run formatter on final changes
 - [ ] Verify TypeScript compiles

--- a/docs/contexts/shopping-lists-context.md
+++ b/docs/contexts/shopping-lists-context.md
@@ -1,34 +1,34 @@
 # Shopping Lists Context
 
-The `ShoppingListsContext` keeps track of the active game and its shopping lists. The `ShoppingListsProvider` makes the following values available to consumers:
+The `ShoppingListsContext` keeps track of the active game and its wish lists. (Note that the naming scheme "shopping list" is being replaced with "wish list" but has not yet been replaced in the front end code or API endpoints/request bodies.) The `ShoppingListsProvider` makes the following values available to consumers:
 
-- `shoppingLists`: array of [`ResponseShoppingList`](/src/types/apiData.d.ts), the shopping lists returned from the API for the current active game
-- `shoppingListsLoadingStatus`: string of either `'LOADING'`, `'ERROR'`, or `'DONE'`, indicating whether shopping lists have loaded successfully from the API initialised as `'LOADING'`
-- `createShoppingList`: a function that creates a shopping list for the current active game at the API, taking the following arguments:
-  - `attributes`: an object containing an optional `title` key with a string value, the attributes of the shopping list to create
+- `shoppingLists`: array of [`ResponseShoppingList`](/src/types/apiData.d.ts), the wish lists returned from the API for the current active game
+- `shoppingListsLoadingStatus`: string of either `'LOADING'`, `'ERROR'`, or `'DONE'`, indicating whether wish lists have loaded successfully from the API initialised as `'LOADING'`
+- `createShoppingList`: a function that creates a wish list for the current active game at the API, taking the following arguments:
+  - `attributes`: an object containing an optional `title` key with a string value, the attributes of the wish list to create
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
-- `updateShoppingList`: a function that creates a shopping list for the current active game at the API, taking the following arguments:
-  - `listId`: the ID of the shopping list to be updated
-  - `attributes`: an object containing an optional `title` key with a string value, the attributes of the shopping list to create
+- `updateShoppingList`: a function that creates a wish list for the current active game at the API, taking the following arguments:
+  - `listId`: the ID of the wish list to be updated
+  - `attributes`: an object containing an optional `title` key with a string value, the attributes of the wish list to create
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
-- `destroyShoppingList`: a function that destroys the selected shopping list at the API, taking the following arguments:
-  - `listId`: the `id` of the shopping list to be destroyed
+- `destroyShoppingList`: a function that destroys the selected wish list at the API, taking the following arguments:
+  - `listId`: the `id` of the wish list to be destroyed
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
-- `createShoppingListItem`: a function that creates a shopping list item on the selected shopping list at the API, taking the following arguments:
-  - `listId`: the `id` of the list on which to create the shopping list item
+- `createShoppingListItem`: a function that creates a wish list item on the selected wish list at the API, taking the following arguments:
+  - `listId`: the `id` of the list on which to create the wish list item
   - `attributes`: the attributes of the item to be created (required attributes are `description` (string) and `quantity` (number))
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
-- `updateShoppingListItem`: a function that updates a shopping list item at the API, taking the following arguments:
-  - `itemId`: the `id` of the shopping list item to be updated
+- `updateShoppingListItem`: a function that updates a wish list item at the API, taking the following arguments:
+  - `itemId`: the `id` of the wish list item to be updated
   - `attributes`: the attributes of the item to be updated (`description` is not allowed as a value)
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
-- `destroyShoppingListItem`: a function that destroys the selected shopping list at the API, taking the following arguments:
-  - `itemId`: the `id` of the shopping list item to be destroyed
+- `destroyShoppingListItem`: a function that destroys the selected wish list at the API, taking the following arguments:
+  - `itemId`: the `id` of the wish list item to be destroyed
   - `onSuccess` (optional): a callback called on a successful response; no arguments are passed in and its return value, if any, is not used
   - `onError` (optional): a callback called on an unsuccessful response; no arguments are passed in and its return value, if any, is not used
 

--- a/src/components/shoppingList/__snapshots__/shoppingList.test.tsx.snap
+++ b/src/components/shoppingList/__snapshots__/shoppingList.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`ShoppingList > displaying a list > when the list is not editable > matc
                     style="display: none;"
                   >
                     <form
-                      aria-label="Shopping list item creation form"
+                      aria-label="Wish list item creation form"
                       class="_form_003550"
                     >
                       <label
@@ -273,7 +273,7 @@ exports[`ShoppingList > displaying a list > when the list is not editable > matc
                   style="display: none;"
                 >
                   <form
-                    aria-label="Shopping list item creation form"
+                    aria-label="Wish list item creation form"
                     class="_form_003550"
                   >
                     <label
@@ -501,7 +501,7 @@ exports[`ShoppingList > displaying a list > when there are list items > matches 
                     style="display: none;"
                   >
                     <form
-                      aria-label="Shopping list item creation form"
+                      aria-label="Wish list item creation form"
                       class="_form_003550"
                     >
                       <label
@@ -968,7 +968,7 @@ exports[`ShoppingList > displaying a list > when there are list items > matches 
                   style="display: none;"
                 >
                   <form
-                    aria-label="Shopping list item creation form"
+                    aria-label="Wish list item creation form"
                     class="_form_003550"
                   >
                     <label
@@ -1492,7 +1492,7 @@ exports[`ShoppingList > displaying a list > when there are no list items > match
                     style="display: none;"
                   >
                     <form
-                      aria-label="Shopping list item creation form"
+                      aria-label="Wish list item creation form"
                       class="_form_003550"
                     >
                       <label
@@ -1663,7 +1663,7 @@ exports[`ShoppingList > displaying a list > when there are no list items > match
                   style="display: none;"
                 >
                   <form
-                    aria-label="Shopping list item creation form"
+                    aria-label="Wish list item creation form"
                     class="_form_003550"
                   >
                     <label
@@ -1924,7 +1924,7 @@ exports[`ShoppingList > displaying the edit form > matches snapshot 1`] = `
                     style="display: none;"
                   >
                     <form
-                      aria-label="Shopping list item creation form"
+                      aria-label="Wish list item creation form"
                       class="_form_003550"
                     >
                       <label
@@ -2128,7 +2128,7 @@ exports[`ShoppingList > displaying the edit form > matches snapshot 1`] = `
                   style="display: none;"
                 >
                   <form
-                    aria-label="Shopping list item creation form"
+                    aria-label="Wish list item creation form"
                     class="_form_003550"
                   >
                     <label

--- a/src/components/shoppingList/shoppingList.tsx
+++ b/src/components/shoppingList/shoppingList.tsx
@@ -109,7 +109,7 @@ const ShoppingList = ({
       setFlashProps({
         hidden: false,
         type: 'info',
-        message: 'OK, your shopping list will not be destroyed.',
+        message: 'OK, your wish list will not be destroyed.',
       })
     }
   }
@@ -200,13 +200,13 @@ const ShoppingList = ({
       >
         <div className={styles.details}>
           {editable && <ShoppingListItemCreateForm listId={listId} />}
-          {/* We only want to display the "This shopping list has no list items"
+          {/* We only want to display the "This wish list has no list items"
           message if there is no list item creation form */}
           {children || editable ? (
             children
           ) : (
             <p className={styles.emptyList}>
-              This shopping list has no list items.
+              This wish list has no list items.
             </p>
           )}
         </div>

--- a/src/components/shoppingListGrouping/__snapshots__/shoppingListGrouping.test.tsx.snap
+++ b/src/components/shoppingListGrouping/__snapshots__/shoppingListGrouping.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ShoppingListGrouping > when there are no shopping lists > matches snaps
       <p
         class="_noLists_92c834"
       >
-        This game has no shopping lists.
+        This game has no wish lists.
       </p>
     </div>
   </body>,
@@ -16,7 +16,7 @@ exports[`ShoppingListGrouping > when there are no shopping lists > matches snaps
     <p
       class="_noLists_92c834"
     >
-      This game has no shopping lists.
+      This game has no wish lists.
     </p>
   </div>,
   "debug": [Function],
@@ -325,7 +325,7 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                         style="display: none;"
                       >
                         <form
-                          aria-label="Shopping list item creation form"
+                          aria-label="Wish list item creation form"
                           class="_form_003550"
                         >
                           <label
@@ -793,7 +793,7 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                         style="display: none;"
                       >
                         <form
-                          aria-label="Shopping list item creation form"
+                          aria-label="Wish list item creation form"
                           class="_form_003550"
                         >
                           <label
@@ -1113,7 +1113,7 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                         style="display: none;"
                       >
                         <form
-                          aria-label="Shopping list item creation form"
+                          aria-label="Wish list item creation form"
                           class="_form_003550"
                         >
                           <label
@@ -1436,7 +1436,7 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                       style="display: none;"
                     >
                       <form
-                        aria-label="Shopping list item creation form"
+                        aria-label="Wish list item creation form"
                         class="_form_003550"
                       >
                         <label
@@ -1904,7 +1904,7 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                       style="display: none;"
                     >
                       <form
-                        aria-label="Shopping list item creation form"
+                        aria-label="Wish list item creation form"
                         class="_form_003550"
                       >
                         <label
@@ -2224,7 +2224,7 @@ exports[`ShoppingListGrouping > when there are shopping lists > matches snapshot
                       style="display: none;"
                     >
                       <form
-                        aria-label="Shopping list item creation form"
+                        aria-label="Wish list item creation form"
                         class="_form_003550"
                       >
                         <label

--- a/src/components/shoppingListGrouping/shoppingListGrouping.test.tsx
+++ b/src/components/shoppingListGrouping/shoppingListGrouping.test.tsx
@@ -142,7 +142,7 @@ describe('ShoppingListGrouping', () => {
         </PageProvider>
       )
 
-      expect(wrapper.getByText('This game has no shopping lists.')).toBeTruthy()
+      expect(wrapper.getByText('This game has no wish lists.')).toBeTruthy()
     })
 
     test('matches snapshot', () => {

--- a/src/components/shoppingListGrouping/shoppingListGrouping.tsx
+++ b/src/components/shoppingListGrouping/shoppingListGrouping.tsx
@@ -36,7 +36,7 @@ const ShoppingListGrouping = () => {
   if (gamesLoadingState === DONE && !games.length)
     return (
       <p className={styles.noLists}>
-        You need a game to use the shopping lists feature.{' '}
+        You need a game to use the wish lists feature.{' '}
         <button className={styles.link} onClick={showGameForm}>
           Create a game
         </button>{' '}
@@ -45,7 +45,7 @@ const ShoppingListGrouping = () => {
     )
 
   if (!shoppingLists.length)
-    return <p className={styles.noLists}>This game has no shopping lists.</p>
+    return <p className={styles.noLists}>This game has no wish lists.</p>
 
   return (
     <div className={styles.root}>

--- a/src/components/shoppingListItem/shoppingListItem.tsx
+++ b/src/components/shoppingListItem/shoppingListItem.tsx
@@ -125,7 +125,7 @@ const ShoppingListItem = ({
     e.preventDefault()
 
     const confirmed = window.confirm(
-      'Destroy shopping list item? Your aggregate list will be updated to reflect the change. This action cannot be undone.'
+      'Destroy wish list item? Your aggregate list will be updated to reflect the change. This action cannot be undone.'
     )
 
     if (confirmed) {
@@ -134,7 +134,7 @@ const ShoppingListItem = ({
       setFlashProps({
         hidden: false,
         type: 'info',
-        message: 'OK, your shopping list item will not be deleted.',
+        message: 'OK, your wish list item will not be deleted.',
       })
     }
   }
@@ -159,7 +159,7 @@ const ShoppingListItem = ({
 
     if (quantity === 1) {
       const confirmed = window.confirm(
-        "You can't reduce shopping list item quantity below 1. Would you like to delete this item? This cannot be undone."
+        "You can't reduce wish list item quantity below 1. Would you like to delete this item? This cannot be undone."
       )
 
       if (confirmed) {
@@ -171,7 +171,7 @@ const ShoppingListItem = ({
         setFlashProps({
           hidden: false,
           type: 'info',
-          message: 'OK, your shopping list item will not be deleted.',
+          message: 'OK, your wish list item will not be deleted.',
         })
       }
     } else {

--- a/src/components/shoppingListItemCreateForm/__snapshots__/shoppingListItemCreateForm.test.tsx.snap
+++ b/src/components/shoppingListItemCreateForm/__snapshots__/shoppingListItemCreateForm.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ShoppingListItemCreateForm > matches snapshot 1`] = `
             style="display: none;"
           >
             <form
-              aria-label="Shopping list item creation form"
+              aria-label="Wish list item creation form"
               class="_form_003550"
             >
               <label
@@ -125,7 +125,7 @@ exports[`ShoppingListItemCreateForm > matches snapshot 1`] = `
           style="display: none;"
         >
           <form
-            aria-label="Shopping list item creation form"
+            aria-label="Wish list item creation form"
             class="_form_003550"
           >
             <label

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.test.tsx
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.test.tsx
@@ -70,7 +70,7 @@ describe('ShoppingListItemCreateForm', () => {
 
       const descField = wrapper.getByLabelText('Description')
       const quantityField = wrapper.getByLabelText('Quantity')
-      const form = wrapper.getByLabelText('Shopping list item creation form')
+      const form = wrapper.getByLabelText('Wish list item creation form')
 
       fireEvent.change(descField, { target: { value: '  Iron ingot    ' } })
       fireEvent.change(quantityField, { target: { value: '2' } })

--- a/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.tsx
+++ b/src/components/shoppingListItemCreateForm/shoppingListItemCreateForm.tsx
@@ -106,7 +106,7 @@ const ShoppingListItemCreateForm = ({ listId }: CreateFormProps) => {
           className={styles.form}
           ref={formRef}
           onSubmit={createItem}
-          aria-label="Shopping list item creation form"
+          aria-label="Wish list item creation form"
         >
           <label className={styles.label}>
             Description

--- a/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
+++ b/src/components/shoppingListItemEditForm/shoppingListItemEditForm.tsx
@@ -69,7 +69,7 @@ const ShoppingListItemEditForm = ({
       setFlashProps({
         hidden: false,
         type: 'success',
-        message: 'Success! Your shopping list item has been updated.',
+        message: 'Success! Your wish list item has been updated.',
       })
     }
 

--- a/src/contexts/shoppingListsContext.tsx
+++ b/src/contexts/shoppingListsContext.tsx
@@ -115,7 +115,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
       setFlashProps({
         hidden: false,
         type: 'error',
-        header: `${e.message.length} error(s) prevented your shopping ${
+        header: `${e.message.length} error(s) prevented your wish ${
           resource || 'list'
         } from being saved:`,
         message: e.message,
@@ -153,7 +153,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
           hidden: false,
           type: 'warning',
           message:
-            'You must select a game from the dropdown before creating a shopping list.',
+            'You must select a game from the dropdown before creating a wish list.',
         })
 
         return
@@ -179,7 +179,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               setFlashProps({
                 hidden: false,
                 type: 'success',
-                message: 'Success! Your shopping list has been created.',
+                message: 'Success! Your wish list has been created.',
               })
 
               onSuccess && onSuccess()
@@ -331,7 +331,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 hidden: false,
                 type: 'error',
                 message:
-                  "The shopping list you tried to update doesn't exist, or doesn't belong to you. Please refresh and try again.",
+                  "The wish list you tried to update doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
               handleApiError(e)
@@ -396,7 +396,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               setFlashProps({
                 hidden: false,
                 type: 'success',
-                message: 'Success! Your shopping list has been deleted.',
+                message: 'Success! Your wish list has been deleted.',
               })
 
               onSuccess && onSuccess()
@@ -420,7 +420,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 hidden: false,
                 type: 'error',
                 message:
-                  "The shopping list you tried to delete doesn't exist, or doesn't belong to you. Please refresh and try again.",
+                  "The wish list you tried to delete doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
               handleApiError(e)
@@ -470,7 +470,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               setFlashProps({
                 hidden: false,
                 type: 'success',
-                message: 'Success! Your shopping list item has been created.',
+                message: 'Success! Your wish list item has been created.',
               })
 
               onSuccess && onSuccess()
@@ -505,7 +505,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 hidden: false,
                 type: 'error',
                 message:
-                  "The shopping list you tried to add an item to doesn't exist, or doesn't belong to you. Please refresh and try again.",
+                  "The wish list you tried to add an item to doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
               handleApiError(e, 'list item')
@@ -589,7 +589,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
                 hidden: false,
                 type: 'error',
                 message:
-                  "You have attempted to update a shopping list item that doesn't exist, or doesn't belong to you. Please refresh and try again.",
+                  "You have attempted to update a wish list item that doesn't exist, or doesn't belong to you. Please refresh and try again.",
               })
             } else {
               handleApiError(e, 'list item')
@@ -640,7 +640,7 @@ export const ShoppingListsProvider = ({ children }: ProviderProps) => {
               setFlashProps({
                 hidden: false,
                 type: 'success',
-                message: 'Success! Your shopping list item has been deleted.',
+                message: 'Success! Your wish list item has been deleted.',
               })
 
               onSuccess && onSuccess()

--- a/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
+++ b/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                   href="/shopping_lists"
                   style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
                 >
-                  Your Shopping Lists
+                  Your Wish Lists
                 </a>
               </div>
               <div
@@ -234,7 +234,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                 href="/shopping_lists"
                 style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
               >
-                Your Shopping Lists
+                Your Wish Lists
               </a>
             </div>
             <div

--- a/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
+++ b/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               >
                 <a
                   class="_root_396ea1"
-                  href="/shopping_lists"
+                  href="/wish_lists"
                   style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
                 >
                   Your Wish Lists
@@ -231,7 +231,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
             >
               <a
                 class="_root_396ea1"
-                href="/shopping_lists"
+                href="/wish_lists"
                 style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
               >
                 Your Wish Lists

--- a/src/pages/dashboardPage/dashboardPage.test.tsx
+++ b/src/pages/dashboardPage/dashboardPage.test.tsx
@@ -47,7 +47,7 @@ describe('<DashboardPage />', () => {
     )
 
     expect(wrapper.getByText('Your Games')).toBeTruthy()
-    expect(wrapper.getByText('Your Shopping Lists')).toBeTruthy()
+    expect(wrapper.getByText('Your Wish Lists')).toBeTruthy()
     expect(wrapper.getByText('Your Inventory')).toBeTruthy()
     expect(wrapper.getByText('Nav Link 4')).toBeTruthy()
     expect(wrapper.getByText('Nav Link 5')).toBeTruthy()

--- a/src/pages/dashboardPage/dashboardPage.tsx
+++ b/src/pages/dashboardPage/dashboardPage.tsx
@@ -20,8 +20,8 @@ const navigationCards = [
   {
     colorScheme: PINK,
     href: paths.dashboard.shoppingLists,
-    children: 'Your Shopping Lists',
-    key: 'shopping-lists',
+    children: 'Your Wish Lists',
+    key: 'wish-lists',
   },
   {
     colorScheme: BLUE,

--- a/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
+++ b/src/pages/shoppingListsPage/__snapshots__/shoppingListsPage.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when loading > matches sna
             <h2
               class="_title_03d657"
             >
-              Your Shopping Lists
+              Your Wish Lists
             </h2>
             <div
               class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
@@ -200,7 +200,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when loading > matches sna
           <h2
             class="_title_03d657"
           >
-            Your Shopping Lists
+            Your Wish Lists
           </h2>
           <div
             class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
@@ -440,7 +440,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
             <h2
               class="_title_03d657"
             >
-              Your Shopping Lists
+              Your Wish Lists
             </h2>
             <div
               class="_root_0a8ecf _select_03d657"
@@ -762,7 +762,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                             style="display: none;"
                           >
                             <form
-                              aria-label="Shopping list item creation form"
+                              aria-label="Wish list item creation form"
                               class="_form_003550"
                             >
                               <label
@@ -1230,7 +1230,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                             style="display: none;"
                           >
                             <form
-                              aria-label="Shopping list item creation form"
+                              aria-label="Wish list item creation form"
                               class="_form_003550"
                             >
                               <label
@@ -1550,7 +1550,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                             style="display: none;"
                           >
                             <form
-                              aria-label="Shopping list item creation form"
+                              aria-label="Wish list item creation form"
                               class="_form_003550"
                             >
                               <label
@@ -1764,7 +1764,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
           <h2
             class="_title_03d657"
           >
-            Your Shopping Lists
+            Your Wish Lists
           </h2>
           <div
             class="_root_0a8ecf _select_03d657"
@@ -2086,7 +2086,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                           style="display: none;"
                         >
                           <form
-                            aria-label="Shopping list item creation form"
+                            aria-label="Wish list item creation form"
                             class="_form_003550"
                           >
                             <label
@@ -2554,7 +2554,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                           style="display: none;"
                         >
                           <form
-                            aria-label="Shopping list item creation form"
+                            aria-label="Wish list item creation form"
                             class="_form_003550"
                           >
                             <label
@@ -2874,7 +2874,7 @@ exports[`ShoppingListsPage > viewing shopping lists > when the game is set in th
                           style="display: none;"
                         >
                           <form
-                            aria-label="Shopping list item creation form"
+                            aria-label="Wish list item creation form"
                             class="_form_003550"
                           >
                             <label

--- a/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.test.tsx
@@ -52,14 +52,14 @@ import ShoppingListsPage from './shoppingListsPage'
 /**
  *
  * Not able to be tested:
- * - 404 responses when creating a shopping list
+ * - 404 responses when creating a wish list
  *   - This would be a difficult state to arrive at. You would have to have multiple tabs open
- *     and delete a game from the games page in one tab and then create a shopping list in
+ *     and delete a game from the games page in one tab and then create a wish list in
  *     another tab while it is set to that game without refreshing. In the test environment, these
  *     conditions are hard to create since there would first be a 404 error when fetching the
- *     shopping lists in the first place.
- * - 404 response when editing/destroying a shopping list or managing its items
- * - 405 response when editing/destroying a shopping list or managing its items
+ *     wish lists in the first place.
+ * - 404 response when editing/destroying a wish list or managing its items
+ * - 405 response when editing/destroying a wish list or managing its items
  *   - This response from the API occurs when the client makes a PUT, PATCH, or DELETE request
  *     on an aggregate list. In the UI, aggregate lists are always uneditable and won't have a
  *     way to update them or manage items, so the only way to get this response would be to
@@ -68,7 +68,6 @@ import ShoppingListsPage from './shoppingListsPage'
  * - Flash warning being shown and no request made if, somehow, the user submits the create form
  *   before an active game has been set
  * - New list items get added to the correct list
- * -
  *
  */
 
@@ -178,7 +177,7 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => {
             expect(
-              wrapper.getByText('This game has no shopping lists.')
+              wrapper.getByText('This game has no wish lists.')
             ).toBeTruthy()
           })
         })
@@ -303,7 +302,7 @@ describe('ShoppingListsPage', () => {
           expect(wrapper.queryByTestId('pulseLoader')).toBeFalsy()
           expect(
             wrapper.getByText(
-              /You need a game to use the shopping lists feature\./
+              /You need a game to use the wish lists feature\./
             )
           ).toBeTruthy()
           expect(wrapper.getByText('Create a game')).toBeTruthy()
@@ -325,7 +324,7 @@ describe('ShoppingListsPage', () => {
         await waitFor(() => {
           expect(
             wrapper.getByText(
-              /You need a game to use the shopping lists feature\./
+              /You need a game to use the wish lists feature\./
             )
           ).toBeTruthy()
           expect(wrapper.getByText('Create a game')).toBeTruthy()
@@ -399,11 +398,11 @@ describe('ShoppingListsPage', () => {
           // expect(wrapper.getByText(/New Name/)).toBeTruthy()
           expect(
             wrapper.queryByText(
-              /You need a game to use the shopping lists feature\./
+              /You need a game to use the wish lists feature\./
             )
           ).toBeFalsy()
           expect(
-            wrapper.getByText('This game has no shopping lists.')
+            wrapper.getByText('This game has no wish lists.')
           ).toBeTruthy()
           expect(
             wrapper.getByText('Success! Your game has been created.')
@@ -572,7 +571,7 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => {
             expect(
-              wrapper.getByText('Success! Your shopping list has been created.')
+              wrapper.getByText('Success! Your wish list has been created.')
             ).toBeTruthy()
             expect(wrapper.getByText('Smithing Materials')).toBeTruthy()
           })
@@ -602,10 +601,10 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => {
             expect(
-              wrapper.getByText('Success! Your shopping list has been created.')
+              wrapper.getByText('Success! Your wish list has been created.')
             ).toBeTruthy()
             expect(wrapper.getByText('All Items')).toBeTruthy()
-            expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
+            expect(wrapper.getByText('My Wish List 1')).toBeTruthy()
           })
         })
       })
@@ -636,12 +635,12 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => {
             expect(
-              wrapper.getByText('Success! Your shopping list has been created.')
+              wrapper.getByText('Success! Your wish list has been created.')
             ).toBeTruthy()
             expect(wrapper.getByText('All Items')).toBeTruthy()
             expect(wrapper.getByText('Smithing Materials')).toBeTruthy()
             expect(
-              wrapper.queryByText('This game has no shopping lists.')
+              wrapper.queryByText('This game has no wish lists.')
             ).toBeFalsy()
           })
         })
@@ -684,7 +683,7 @@ describe('ShoppingListsPage', () => {
         await waitFor(() => {
           expect(
             wrapper.getByText(
-              '2 error(s) prevented your shopping list from being saved:'
+              '2 error(s) prevented your wish list from being saved:'
             )
           ).toBeTruthy()
           expect(
@@ -788,14 +787,14 @@ describe('ShoppingListsPage', () => {
             })
 
             expect(window.confirm).toHaveBeenCalledWith(
-              'Are you sure you want to delete the list "My Shopping List 1"? You will also lose any list items on the list. This action cannot be undone.'
+              'Are you sure you want to delete the list "My Wish List 1"? You will also lose any list items on the list. This action cannot be undone.'
             )
 
             await waitFor(() => {
               expect(wrapper.queryByText('All Items')).toBeFalsy()
-              expect(wrapper.queryByText('My Shopping List 1')).toBeFalsy()
+              expect(wrapper.queryByText('My Wish List 1')).toBeFalsy()
               expect(
-                wrapper.getByText('This game has no shopping lists.')
+                wrapper.getByText('This game has no wish lists.')
               ).toBeTruthy()
             })
           })
@@ -823,13 +822,13 @@ describe('ShoppingListsPage', () => {
             })
 
             expect(window.confirm).toHaveBeenCalledWith(
-              'Are you sure you want to delete the list "My Shopping List 1"? You will also lose any list items on the list. This action cannot be undone.'
+              'Are you sure you want to delete the list "My Wish List 1"? You will also lose any list items on the list. This action cannot be undone.'
             )
 
             await waitFor(() => {
               expect(
                 wrapper.getByText(
-                  'Success! Your shopping list has been deleted.'
+                  'Success! Your wish list has been deleted.'
                 )
               ).toBeTruthy()
             })
@@ -906,7 +905,7 @@ describe('ShoppingListsPage', () => {
             await waitFor(() => {
               expect(
                 wrapper.getByText(
-                  'Success! Your shopping list has been deleted.'
+                  'Success! Your wish list has been deleted.'
                 )
               ).toBeTruthy()
             })
@@ -942,7 +941,7 @@ describe('ShoppingListsPage', () => {
           expect(window.confirm).toHaveBeenCalled()
 
           await waitFor(() => {
-            expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
+            expect(wrapper.getByText('My Wish List 1')).toBeTruthy()
           })
         })
 
@@ -968,7 +967,7 @@ describe('ShoppingListsPage', () => {
 
           await waitFor(() => {
             expect(
-              wrapper.getByText('OK, your shopping list will not be destroyed.')
+              wrapper.getByText('OK, your wish list will not be destroyed.')
             ).toBeTruthy()
           })
         })
@@ -1011,12 +1010,12 @@ describe('ShoppingListsPage', () => {
         act(() => fireEvent.click(destroyIcon))
 
         expect(window.confirm).toHaveBeenCalledWith(
-          'Are you sure you want to delete the list "My Shopping List 1"? You will also lose any list items on the list. This action cannot be undone.'
+          'Are you sure you want to delete the list "My Wish List 1"? You will also lose any list items on the list. This action cannot be undone.'
         )
 
         await waitFor(() => {
           expect(wrapper.getByText('All Items')).toBeTruthy()
-          expect(wrapper.getByText('My Shopping List 1')).toBeTruthy()
+          expect(wrapper.getByText('My Wish List 1')).toBeTruthy()
           expect(
             wrapper.getByText(
               "Oops! Something unexpected went wrong. We're sorry! Please try again later."
@@ -1123,7 +1122,7 @@ describe('ShoppingListsPage', () => {
           // The flash component should be shown
           expect(
             wrapper.getByText(
-              '2 error(s) prevented your shopping list from being saved:'
+              '2 error(s) prevented your wish list from being saved:'
             )
           ).toBeTruthy()
           expect(
@@ -1214,7 +1213,7 @@ describe('ShoppingListsPage', () => {
         )
 
         const form = (
-          await wrapper.findAllByLabelText('Shopping list item creation form')
+          await wrapper.findAllByLabelText('Wish list item creation form')
         )[0]
         const descField = (await wrapper.findAllByLabelText('Description'))[0]
         const quantityField = (await wrapper.findAllByLabelText('Quantity'))[0]
@@ -1230,7 +1229,7 @@ describe('ShoppingListsPage', () => {
           expect(wrapper.getAllByText('Dwarven metal ingots').length).toEqual(2)
           expect(
             wrapper.getByText(
-              'Success! Your shopping list item has been created.'
+              'Success! Your wish list item has been created.'
             )
           ).toBeTruthy()
         })
@@ -1259,7 +1258,7 @@ describe('ShoppingListsPage', () => {
         )
 
         const form = (
-          await wrapper.findAllByLabelText('Shopping list item creation form')
+          await wrapper.findAllByLabelText('Wish list item creation form')
         )[0]
         const descField = (await wrapper.findAllByLabelText('Description'))[0]
         const quantityField = (await wrapper.findAllByLabelText('Quantity'))[0]
@@ -1277,7 +1276,7 @@ describe('ShoppingListsPage', () => {
           ).toBeFalsy()
           expect(
             wrapper.getByText(
-              '2 error(s) prevented your shopping list item from being saved:'
+              '2 error(s) prevented your wish list item from being saved:'
             )
           ).toBeTruthy()
           expect(
@@ -1312,7 +1311,7 @@ describe('ShoppingListsPage', () => {
         )
 
         const form = (
-          await wrapper.findAllByLabelText('Shopping list item creation form')
+          await wrapper.findAllByLabelText('Wish list item creation form')
         )[0]
         const descField = (await wrapper.findAllByLabelText('Description'))[0]
         const quantityField = (await wrapper.findAllByLabelText('Quantity'))[0]
@@ -1376,7 +1375,7 @@ describe('ShoppingListsPage', () => {
           expect(wrapper.getAllByText('Iron ingot').length).toEqual(2)
           expect(
             wrapper.getByText(
-              'OK, your shopping list item will not be deleted.'
+              'OK, your wish list item will not be deleted.'
             )
           ).toBeTruthy()
         })
@@ -1430,7 +1429,7 @@ describe('ShoppingListsPage', () => {
           // Should show a flash success message
           expect(
             wrapper.getByText(
-              'Success! Your shopping list item has been deleted.'
+              'Success! Your wish list item has been deleted.'
             )
           ).toBeTruthy()
         })
@@ -1632,7 +1631,7 @@ describe('ShoppingListsPage', () => {
               expect(wrapper.queryAllByText('Iron ingot').length).toBeFalsy()
               expect(
                 wrapper.getByText(
-                  'Success! Your shopping list item has been deleted.'
+                  'Success! Your wish list item has been deleted.'
                 )
               ).toBeTruthy()
             })
@@ -1675,7 +1674,7 @@ describe('ShoppingListsPage', () => {
               expect(wrapper.getAllByText('Iron ingot').length).toEqual(2)
               expect(
                 wrapper.getByText(
-                  'OK, your shopping list item will not be deleted.'
+                  'OK, your wish list item will not be deleted.'
                 )
               ).toBeTruthy()
             })
@@ -1761,7 +1760,7 @@ describe('ShoppingListsPage', () => {
 
         expect(
           wrapper.getByText(
-            'Success! Your shopping list item has been updated.'
+            'Success! Your wish list item has been updated.'
           )
         ).toBeTruthy()
         expect(wrapper.getByText('Hello world')).toBeTruthy()
@@ -1805,7 +1804,7 @@ describe('ShoppingListsPage', () => {
         await waitFor(() => {
           expect(
             wrapper.getByText(
-              '2 error(s) prevented your shopping list item from being saved:'
+              '2 error(s) prevented your wish list item from being saved:'
             )
           ).toBeTruthy()
           expect(

--- a/src/pages/shoppingListsPage/shoppingListsPage.tsx
+++ b/src/pages/shoppingListsPage/shoppingListsPage.tsx
@@ -15,7 +15,7 @@ const ShoppingListsPage = () => {
   const { shoppingListsLoadingState } = useShoppingListsContext()
 
   return (
-    <DashboardLayout title="Your Shopping Lists" includeGameSelector>
+    <DashboardLayout title="Your Wish Lists" includeGameSelector>
       <>
         <ShoppingListCreateForm />
         {shoppingListsLoadingState === LOADING && (

--- a/src/routing/pageRoutes.tsx
+++ b/src/routing/pageRoutes.tsx
@@ -67,9 +67,9 @@ const pages: Page[] = [
     path: paths.dashboard.games,
   },
   {
-    pageId: 'dashboard-shopping-lists',
-    title: `${siteTitle} Shopping Lists`,
-    description: 'Manage your shopping lists',
+    pageId: 'dashboard-wish-lists',
+    title: `${siteTitle} Wish Lists`,
+    description: 'Manage your wish lists',
     jsx: (
       <PageProvider>
         <GamesProvider>

--- a/src/routing/paths.ts
+++ b/src/routing/paths.ts
@@ -14,7 +14,7 @@ const paths: Paths = {
   dashboard: {
     main: '/dashboard',
     games: '/games',
-    shoppingLists: '/shopping_lists',
+    shoppingLists: '/wish_lists',
   },
 }
 

--- a/src/support/data/shoppingLists.ts
+++ b/src/support/data/shoppingLists.ts
@@ -33,7 +33,7 @@ export const allShoppingLists: ShoppingList[] = [
     game_id: 32,
     aggregate_list_id: 1,
     aggregate: false,
-    title: 'My Shopping List 1',
+    title: 'My Wish List 1',
     list_items: shoppingListItemsOnList(2),
     created_at: new Date('2023-01-02T03:54:02'),
     updated_at: new Date('2023-01-02T03:54:02'),


### PR DESCRIPTION
## Context

[**Update UI to use WishList nomenclature**](https://trello.com/c/pLEAq7JR/361-update-ui-to-use-wishlist-nomenclature)

Never having been fully satisfied with the naming of "shopping" lists, we are in the process of changing the name to "wish" lists. So far we've changed the names on the back end for everything except controllers and API endpoints (i.e., API calls, request bodies, and response bodies remain the same). We've decided that, before changing the front-end code, we will change the UI to replace references to shopping lists with the "wish list" terminology. This is a less risky change in that it won't break everything - the worst thing that can happen is we missed something and "shopping list" still shows up somewhere in the UI.

Changes have been fully tested in my local.

## Changes

* Change the name of "shopping lists" to "wish lists" in the UI
* Fix broken tests
* Update snapshots
* Update docs

## Required Tasks

- [x] Add/update automated tests
- [ ] ~~Add/update Storybook stories~~
- [x] Add/update docs
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles

## Considerations

I considered whether to change test descriptions to use the new naming scheme as well. However, since the majority of references are in code, not UI text, I've opted to leave the existing "shopping list" language for this. These names will be updated [when we change the name in code](https://trello.com/c/mjlZhEOz/360-rename-shopping-lists-to-wish-lists-in-front-end-code).