### PR TITLE
Use new wish_list and wish_list_item endpoints

### DIFF
--- a/src/support/msw/wishListItems.ts
+++ b/src/support/msw/wishListItems.ts
@@ -9,13 +9,13 @@ const listIds = allWishLists.map(({ id }) => id)
 
 /**
  *
- * POST /shopping_lists/:list_id/list_items
+ * POST /wish_lists/:list_id/list_items
  *
  */
 
 // Handles 201 and 404 responses
 export const postWishListItemsSuccess = http.post(
-  `${BASE_URI}/shopping_lists/:listId/shopping_list_items`,
+  `${BASE_URI}/wish_lists/:listId/wish_list_items`,
   async ({ request, params }) => {
     const listId = Number(params.listId)
 
@@ -33,7 +33,7 @@ export const postWishListItemsSuccess = http.post(
 // Returns the same validation errors regardless of request body
 // submitted
 export const postWishListItemsUnprocessable = http.post(
-  `${BASE_URI}/shopping_lists/:listId/shopping_list_items`,
+  `${BASE_URI}/wish_lists/:listId/wish_list_items`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -48,7 +48,7 @@ export const postWishListItemsUnprocessable = http.post(
 )
 
 export const postWishListItemsServerError = http.post(
-  `${BASE_URI}/shopping_lists/:listId/shopping_list_items`,
+  `${BASE_URI}/wish_lists/:listId/wish_list_items`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -61,12 +61,12 @@ export const postWishListItemsServerError = http.post(
 
 /**
  *
- * PATCH /shopping_list_items/:id
+ * PATCH /wish_list_items/:id
  *
  */
 
 export const incrementWishListItemSuccess = http.patch(
-  `${BASE_URI}/shopping_list_items/:id`,
+  `${BASE_URI}/wish_list_items/:id`,
   ({ params }) => {
     const itemId: number = Number(params.id)
     const item = allWishListItems.find(({ id }) => id === itemId)
@@ -87,7 +87,7 @@ export const incrementWishListItemSuccess = http.patch(
 )
 
 export const decrementWishListItemSuccess = http.patch(
-  `${BASE_URI}/shopping_list_items/:id`,
+  `${BASE_URI}/wish_list_items/:id`,
   ({ request, params }) => {
     const itemId: number = Number(params.id)
     const item = allWishListItems.find(({ id }) => id === itemId)
@@ -118,7 +118,7 @@ export const decrementWishListItemSuccess = http.patch(
 // list item being updated - i.e., none of its other associated list items, if
 // any, have notes. If they did, that, too, would further complicate things.
 export const updateWishListItemSuccess = http.patch(
-  `${BASE_URI}/shopping_list_items/:id`,
+  `${BASE_URI}/wish_list_items/:id`,
   async ({ request, params }) => {
     const itemId: number = Number(params.id)
     const item = allWishListItems.find(({ id }) => id === itemId)
@@ -141,7 +141,7 @@ export const updateWishListItemSuccess = http.patch(
 
 // Returns the same validation errors regardless of request body
 export const updateWishListItemUnprocessable = http.patch(
-  `${BASE_URI}/shopping_list_items/:id`,
+  `${BASE_URI}/wish_list_items/:id`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -156,7 +156,7 @@ export const updateWishListItemUnprocessable = http.patch(
 )
 
 export const updateWishListItemServerError = http.patch(
-  `${BASE_URI}/shopping_list_items/:id`,
+  `${BASE_URI}/wish_list_items/:id`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -169,7 +169,7 @@ export const updateWishListItemServerError = http.patch(
 
 /**
  *
- * DELETE /shopping_list_items/:id
+ * DELETE /wish_list_items/:id
  *
  */
 
@@ -179,7 +179,7 @@ export const updateWishListItemServerError = http.patch(
 //       of whether there are other matching items. This function
 //       does not match the complexity of back-end behaviour.
 export const deleteWishListItemSuccess = http.delete(
-  `${BASE_URI}/shopping_list_items/:id`,
+  `${BASE_URI}/wish_list_items/:id`,
   ({ request, params }) => {
     const itemId = Number(params.id)
     const item = allWishListItems.find(({ id }) => id === itemId)
@@ -209,7 +209,7 @@ export const deleteWishListItemSuccess = http.delete(
 )
 
 export const deleteWishListItemServerError = http.delete(
-  `${BASE_URI}/shopping_list_items/:id`,
+  `${BASE_URI}/wish_list_items/:id`,
   (_) => {
     return new Response(
       JSON.stringify({ errors: ['Something went horribly wrong'] }),

--- a/src/support/msw/wishLists.ts
+++ b/src/support/msw/wishLists.ts
@@ -11,13 +11,13 @@ const listIds = allWishLists.map(({ id }) => id)
 
 /**
  *
- * POST /games/:game_id/shopping_lists
+ * POST /games/:game_id/wish_lists
  *
  */
 
 // Handles both 201 and 404 responses
 export const postWishListsSuccess = http.post(
-  `${BASE_URI}/games/:gameId/shopping_lists`,
+  `${BASE_URI}/games/:gameId/wish_lists`,
   async ({ request, params }) => {
     const gameId = Number(params.gameId)
 
@@ -36,7 +36,7 @@ export const postWishListsSuccess = http.post(
 // Returns the same validation errors regardless of request body
 // submitted
 export const postWishListsUnprocessable = http.post(
-  `${BASE_URI}/games/:gameId/shopping_lists`,
+  `${BASE_URI}/games/:gameId/wish_lists`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -51,7 +51,7 @@ export const postWishListsUnprocessable = http.post(
 )
 
 export const postWishListsServerError = http.post(
-  `${BASE_URI}/games/:gameId/shopping_lists`,
+  `${BASE_URI}/games/:gameId/wish_lists`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -64,13 +64,13 @@ export const postWishListsServerError = http.post(
 
 /**
  *
- * GET /shopping_lists/:id
+ * GET /wish_lists/:id
  *
  */
 
 // Covers both success and 404 cases
 export const getWishListsSuccess = http.get(
-  `${BASE_URI}/games/:gameId/shopping_lists`,
+  `${BASE_URI}/games/:gameId/wish_lists`,
   ({ params }) => {
     const gameId = Number(params.gameId)
 
@@ -81,7 +81,7 @@ export const getWishListsSuccess = http.get(
 )
 
 export const getWishListsEmptySuccess = http.get(
-  `${BASE_URI}/games/:gameId/shopping_lists`,
+  `${BASE_URI}/games/:gameId/wish_lists`,
   (_) => {
     return new Response(JSON.stringify([]), { status: 200 })
   }
@@ -89,13 +89,13 @@ export const getWishListsEmptySuccess = http.get(
 
 /**
  *
- * PATCH /shopping_lists/:id
+ * PATCH /wish_lists/:id
  *
  */
 
 // Covers both success and 404 cases
 export const patchWishListSuccess = http.patch(
-  `${BASE_URI}/shopping_lists/:id`,
+  `${BASE_URI}/wish_lists/:id`,
   async ({ request, params }) => {
     const listId = Number(params.id)
 
@@ -111,7 +111,7 @@ export const patchWishListSuccess = http.patch(
 // Returns the same validation errors regardless of request
 // body submitted
 export const patchWishListUnprocessable = http.patch(
-  `${BASE_URI}/shopping_lists/:id`,
+  `${BASE_URI}/wish_lists/:id`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -126,7 +126,7 @@ export const patchWishListUnprocessable = http.patch(
 )
 
 export const patchWishListServerError = http.patch(
-  `${BASE_URI}/shopping_lists/:id`,
+  `${BASE_URI}/wish_lists/:id`,
   (_) => {
     return new Response(
       JSON.stringify({
@@ -139,13 +139,13 @@ export const patchWishListServerError = http.patch(
 
 /**
  *
- * DELETE /shopping_lists/:id
+ * DELETE /wish_lists/:id
  *
  */
 
 // Covers both success and 404 cases
 export const deleteWishListSuccess = http.delete(
-  `${BASE_URI}/shopping_lists/:listId`,
+  `${BASE_URI}/wish_lists/:listId`,
   ({ params }) => {
     const listId = Number(params.listId)
     const list = allWishLists.find(({ id }) => id === listId)
@@ -171,7 +171,7 @@ export const deleteWishListSuccess = http.delete(
 )
 
 export const deleteWishListServerError = http.delete(
-  `${BASE_URI}/shopping_lists/:listId`,
+  `${BASE_URI}/wish_lists/:listId`,
   (_) => {
     return new Response(
       JSON.stringify({

--- a/src/utils/api/returnValues/wishListItems.d.ts
+++ b/src/utils/api/returnValues/wishListItems.d.ts
@@ -8,7 +8,7 @@ import { UnauthorizedResponse } from './shared'
 
 /**
  *
- * Types used for POST /shopping_lists/:list_id/list_items endpoint
+ * Types used for POST /wish_lists/:list_id/list_items endpoint
  *
  */
 
@@ -61,7 +61,7 @@ export type PostWishListItemsReturnValue =
 
 /**
  *
- * Types used for PATCH /shopping_list_items/:id endpoint
+ * Types used for PATCH /wish_list_items/:id endpoint
  *
  */
 
@@ -114,7 +114,7 @@ export type PatchWishListItemReturnValue =
 
 /**
  *
- * Types used for DELETE /shopping_list_items/:id endpoint
+ * Types used for DELETE /wish_list_items/:id endpoint
  *
  */
 

--- a/src/utils/api/returnValues/wishLists.d.ts
+++ b/src/utils/api/returnValues/wishLists.d.ts
@@ -7,7 +7,7 @@ import { UnauthorizedResponse } from './shared'
 
 /**
  *
- * Types used for POST /games/:game_id/shopping_lists endpoint
+ * Types used for POST /games/:game_id/wish_lists endpoint
  *
  */
 
@@ -56,7 +56,7 @@ export type PostWishListsReturnValue =
 
 /**
  *
- * Types used for GET /games/:game_id/shopping_lists endpoint
+ * Types used for GET /games/:game_id/wish_lists endpoint
  *
  */
 
@@ -105,7 +105,7 @@ export type GetWishListsReturnValue =
 
 /**
  *
- * Types used for PATCH /shopping_lists/:id endpoint
+ * Types used for PATCH /wish_lists/:id endpoint
  *
  */
 
@@ -158,7 +158,7 @@ export type PatchWishListReturnValue =
 
 /**
  *
- * Types used for DELETE /shopping_lists/:id endpoint
+ * Types used for DELETE /wish_lists/:id endpoint
  *
  */
 

--- a/src/utils/api/wrapper/wishListEndpoints.ts
+++ b/src/utils/api/wrapper/wishListEndpoints.ts
@@ -20,7 +20,7 @@ import {
 
 /**
  *
- * POST /games/:game_id/shopping_lists endpoint
+ * POST /games/:game_id/wish_lists endpoint
  *
  */
 
@@ -29,7 +29,7 @@ export const postWishLists = (
   attributes: RequestWishList,
   token: string
 ): Promise<PostWishListsReturnValue> | never => {
-  const uri = `${BASE_URI}/games/${gameId}/shopping_lists`
+  const uri = `${BASE_URI}/games/${gameId}/wish_lists`
   const headers = combinedHeaders(token)
 
   return fetch(uri, {
@@ -57,7 +57,7 @@ export const postWishLists = (
 
 /**
  *
- * GET /games/:game_id/shopping_lists endpoint
+ * GET /games/:game_id/wish_lists endpoint
  *
  */
 
@@ -65,7 +65,7 @@ export const getWishLists = (
   gameId: number,
   token: string
 ): Promise<GetWishListsReturnValue> | never => {
-  const uri = `${BASE_URI}/games/${gameId}/shopping_lists`
+  const uri = `${BASE_URI}/games/${gameId}/wish_lists`
   const headers = combinedHeaders(token)
 
   return fetch(uri, { headers }).then((res) => {
@@ -87,7 +87,7 @@ export const getWishLists = (
 
 /**
  *
- * PATCH /shopping_lists/:id endpoint
+ * PATCH /wish_lists/:id endpoint
  *
  */
 
@@ -96,7 +96,7 @@ export const patchWishList = (
   attributes: RequestWishList,
   token: string
 ): Promise<PatchWishListReturnValue> | never => {
-  const uri = `${BASE_URI}/shopping_lists/${listId}`
+  const uri = `${BASE_URI}/wish_lists/${listId}`
   const headers = combinedHeaders(token)
 
   return fetch(uri, {
@@ -126,7 +126,7 @@ export const patchWishList = (
 
 /**
  *
- * DELETE /shopping_lists/:id endpoint
+ * DELETE /wish_lists/:id endpoint
  *
  */
 
@@ -134,7 +134,7 @@ export const deleteWishList = (
   listId: number,
   token: string
 ): Promise<DeleteWishListReturnValue> | never => {
-  const uri = `${BASE_URI}/shopping_lists/${listId}`
+  const uri = `${BASE_URI}/wish_lists/${listId}`
   const headers = combinedHeaders(token)
 
   return fetch(uri, { method: 'DELETE', headers }).then((res) => {

--- a/src/utils/api/wrapper/wishListItemEndpoints.ts
+++ b/src/utils/api/wrapper/wishListItemEndpoints.ts
@@ -18,7 +18,7 @@ import {
 
 /**
  *
- * POST /shopping_lists/:list_id/list_items endpoint
+ * POST /wish_lists/:list_id/list_items endpoint
  *
  */
 
@@ -27,7 +27,7 @@ export const postWishListItems = (
   attributes: RequestWishListItem,
   token: string
 ): Promise<PostWishListItemsReturnValue> | never => {
-  const uri = `${BASE_URI}/shopping_lists/${listId}/shopping_list_items`
+  const uri = `${BASE_URI}/wish_lists/${listId}/wish_list_items`
   const headers = combinedHeaders(token)
 
   return fetch(uri, {
@@ -57,7 +57,7 @@ export const postWishListItems = (
 
 /**
  *
- * PATCH /shopping_list_items/:id endpoint
+ * PATCH /wish_list_items/:id endpoint
  *
  */
 
@@ -66,7 +66,7 @@ export const patchWishListItem = (
   attributes: RequestWishListItem,
   token: string
 ): Promise<PatchWishListItemReturnValue> | never => {
-  const uri = `${BASE_URI}/shopping_list_items/${itemId}`
+  const uri = `${BASE_URI}/wish_list_items/${itemId}`
   const headers = combinedHeaders(token)
 
   return fetch(uri, {
@@ -96,7 +96,7 @@ export const patchWishListItem = (
 
 /**
  *
- * DELETE /shopping_list_items/:id endpoint
+ * DELETE /wish_list_items/:id endpoint
  *
  */
 
@@ -104,7 +104,7 @@ export const deleteWishListItem = (
   itemId: number,
   token: string
 ): Promise<DeleteWishListItemReturnValue> | never => {
-  const uri = `${BASE_URI}/shopping_list_items/${itemId}`
+  const uri = `${BASE_URI}/wish_list_items/${itemId}`
   const headers = combinedHeaders(token)
 
   return fetch(uri, { method: 'DELETE', headers }).then((res) => {


### PR DESCRIPTION
## Context

[**Update front end to contact "wish-list" named endpoints**](https://trello.com/c/LYDYR0SS/357-update-front-end-to-contact-wish-list-named-endpoints)

In danascheider/skyrim_inventory_management#268, we are updating the API to use the new "wish list" nomenclature instead of the older "shopping list" naming scheme. At the same time, we need to update the front end so it is actually using the new endpoint names. Note that this PR will need to be deployed at the same time as the other, or else the front end will contact endpoints that don't exist or no longer exist.

## Changes

* Use `wish_lists` and `wish_list_items` endpoints instead of older `shopping_lists` and `shopping_list_items`
* Update test mocks

## Required Tasks

- [x] Add/update automated tests
- [ ] ~~Add/update Storybook stories~~
- [x] Comprehensively test final changes in local environment
- [x] Add/update docs
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles

## Considerations

These changes have been tested in the local environment together with the corresponding back-end changes. There were no issues during the manual tests.

## Manual Test Cases

We need to run manual tests contacting each wish list endpoint and ensuring those tests succeed. In a local environment, this can be achieved on the Wish Lists page after running the Rails server on the branch of the linked back-end PR. You will need to:

* Display wish lists for multiple games
* Edit wish list titles
* Create a new wish list
* Destroy a wish list
* Create a new wish list item
* Edit a wish list item using either the edit form or the increment/decrement icons
* Destroy a wish list item

We don't really need to test for edge cases or error cases here - we really just need to know that requests are being made to the correct endpoints. The only thing changed during the course of this epic is naming - this is literally a "find-and-replace" situation - so any issues with the code should surface quickly.