### PR TITLE
Prevent Dependabot from opening PRs for Storybook packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,16 @@ updates:
     reviewers:
       - "danascheider"
     versioning-strategy: "increase"
+    # All packages published by the Storybook maintainers should be updated
+    # together using `npx storybook@latest upgrade && yarn dedupe`. Updates
+    # are issued very frequently so this should be done once a week or so.
+    ignore:
+      - dependency_name: "storybook"
+      - dependency_name: "@storybook/addon-actions"
+      - dependency_name: "@storybook/addon-essentials"
+      - dependency_name: "@storybook/addon-interactions"
+      - dependency_name: "@storybook/addon-links"
+      - dependency_name: "@storybook/addon-mdx-gfm"
+      - dependency_name: "@storybook/cli"
+      - dependency_name: "@storybook/react"
+      - dependency_name: "@storybook/react-vite"


### PR DESCRIPTION
## Context

[**Configure Dependabot to not update Storybook packages**](https://trello.com/c/aW3mRGFQ/368-configure-dependabot-to-not-update-storybook-packages)

Several packages released by Storybook maintainers need to be updated simultaneously with Storybook (see card or code changes for a list). However, Dependabot doesn't know this and opens individual PRs for the 9 relevant packages. This could break Storybook so we should update it as the maintainers recommend, using:
```
npx storybook@latest upgrade && yarn dedupe
```

## Changes

* Configure Dependabot to ignore Storybook updates

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Comprehensively test final changes in local environment~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [ ] ~~Verify TypeScript compiles~~

## Considerations

Initially, we allowed Dependabot to open these PRs because it seemed beneficial to be reminded to update. However, Storybook sometimes updates multiple times a week, and when Dependabot isn't allowed more than 8 open PRs at a time, this is significantly cutting into the number of updates it can make. Since it works in alphabetical order, this can mean packages at the end of the alphabet don't get updated as quickly.