### PR TITLE
Update @types/react from 18.2.57 to 18.2.64

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@testing-library/react": "^14.2.1",
     "@types/jsdom": "^21.1.6",
     "@types/node": "^20.11.20",
-    "@types/react": "^18.2.57",
+    "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/parser": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5072,14 +5072,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18.2.57":
-  version: 18.2.57
-  resolution: "@types/react@npm:18.2.57"
+"@types/react@npm:^18.2.64":
+  version: 18.2.64
+  resolution: "@types/react@npm:18.2.64"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 01e7a3424162468428f3b28acec5e5c6cd1e26775ff605d0f46c883dea2d835924873d36b9ea0b75e40c9593aa78ca56a8ccde66bd58dbf6ecb0dd95af28609d
+  checksum: 1fd28dc5e5d191619e0b001485f428a070bad11f55683a212d3bd937bdc979335913f90f4ca4f0510871e5f35d8f46b169a23276fb048d06584623d3652cc0f3
   languageName: node
   linkType: hard
 
@@ -11842,7 +11842,7 @@ __metadata:
     "@testing-library/react": ^14.2.1
     "@types/jsdom": ^21.1.6
     "@types/node": ^20.11.20
-    "@types/react": ^18.2.57
+    "@types/react": ^18.2.64
     "@types/react-dom": ^18.2.21
     "@types/react-router-dom": ^5.3.3
     "@typescript-eslint/parser": ^7.1.1


### PR DESCRIPTION
## Context

In #440, Dependabot updated this package, but the PR had to be closed due to merge conflicts. This updates the package without the need for a rebase.