### PR TITLE
Make sure GitHub Actions run on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: format
       run: yarn format
     - name: build storybook
-      run: yarn build-storybook\
+      run: yarn build-storybook
     - name: Run Chromatic visual tests
       uses: chromaui/action@latest
       env:


### PR DESCRIPTION
GitHub Actions has stopped running on merge to main. It is still running on PRs but once they are merged it doesn't run. I have a feeling this may be the first of multiple PRs as I try to figure out the cause (since we won't know if it worked til they're merged 🙃)