### PR TITLE
Don't update Fontawesome or React with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,10 @@ updates:
     reviewers:
       - "oscaralanpierce"
     versioning-strategy: "increase"
-    # All packages published by the Storybook maintainers should be updated
-    # together using `npx storybook@latest upgrade && yarn dedupe`. Updates
-    # are issued very frequently so this should be done once a week or so.
     ignore:
+      # All packages published by the Storybook maintainers should be updated
+      # together using `npx storybook@latest upgrade && yarn dedupe`. Updates
+      # are issued very frequently so this should be done once a week or so.
       - dependency-name: "storybook"
       - dependency-name: "@storybook/addon-actions"
       - dependency-name: "@storybook/addon-essentials"
@@ -30,3 +30,15 @@ updates:
       - dependency-name: "@storybook/cli"
       - dependency-name: "@storybook/react"
       - dependency-name: "@storybook/react-vite"
+      - dependency-name: "@chromatic-com/storybook"
+
+      # All Fontawesome packages also need to be updated together.
+      - dependency-name: "@fortawesome/fontawesome-svg-core"
+      - dependency-name: "@fortawesome/free-regular-svg-icons"
+      - dependency-name: "@fortawesome/free-solid-svg-icons"
+      - dependency-name: "@fortawesome/react-fontawesome"
+
+      # Leave framework updates to the pros
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "@types/react"


### PR DESCRIPTION
## Context

[**Configure Dependabot to not update Storybook, Fontawesome packages**](https://trello.com/c/246YWJnp/389-configure-dependabot-to-not-update-storybook-fontawesome-packages)

Dependabot isn't great about updating dependencies that need to be updated as a group, so we should prevent it from updating Fontawesome and React, which require multiple package updates.

## Changes

* Add Fontawesome packages to ignored dependencies for Dependabot updates
* Add `react`, `react-dom` and `@types/react` to the ignored dependencies

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Comprehensively test final changes in local environment~~
- [ ] ~~Add/update docs~~
- [ ] ~~Run formatter on final changes~~
- [ ] ~~Verify TypeScript compiles~~