### PR TITLE
Fix deploys by using Vite convention

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
Firebase deploys are broken. This fixes them by changing the module resolution in the tsconfig from "Node" to "bundler", consistent with Vite convention.