### PR TITLE
Update @react-hooks/resize-observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@fortawesome/free-regular-svg-icons": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.2.0",
-    "@react-hook/resize-observer": "^1.2.6",
+    "@react-hook/resize-observer": "^2.0.2",
     "classnames": "^2.5.1",
     "firebase": "^11.0.2",
     "react": "^18.3.1",

--- a/src/support/testUtils.tsx
+++ b/src/support/testUtils.tsx
@@ -16,6 +16,14 @@ const setDom = (url?: string) => {
     url: url || 'http://localhost:5173',
   })
 
+  // jsdom doesn't implement ResizeObserver; mock it so hooks that use
+  // @react-hook/resize-observer don't throw during tests.
+  dom.window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
   global.window = dom.window as unknown as Window & typeof globalThis
   global.document = dom.window.document
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,13 +2098,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@juggle/resize-observer@npm:^3.3.1":
-  version: 3.4.0
-  resolution: "@juggle/resize-observer@npm:3.4.0"
-  checksum: 2505028c05cc2e17639fcad06218b1c4b60f932a4ebb4b41ab546ef8c157031ae377e3f560903801f6d01706dbefd4943b6c4704bf19ed86dfa1c62f1473a570
-  languageName: node
-  linkType: hard
-
 "@mdx-js/react@npm:^3.0.0":
   version: 3.1.0
   resolution: "@mdx-js/react@npm:3.1.0"
@@ -2309,16 +2302,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-hook/resize-observer@npm:^1.2.6":
-  version: 1.2.6
-  resolution: "@react-hook/resize-observer@npm:1.2.6"
+"@react-hook/resize-observer@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@react-hook/resize-observer@npm:2.0.2"
   dependencies:
-    "@juggle/resize-observer": ^3.3.1
     "@react-hook/latest": ^1.0.2
     "@react-hook/passive-layout-effect": ^1.2.0
   peerDependencies:
-    react: ">=16.8"
-  checksum: d2ff6c50e847514acad774f2a4010fb1e6782a231ae00c9507c1a98028b3a26399e35f094170918f11b1eeafc581d60da7641bc178d496abf00c56eee8a6b36b
+    react: ">=18"
+  checksum: 30a8d423f94af26a868347d38281344fe92b8cd5ae1235d6cb8cc0e64e7e330c3fda345e7ce12e31e3c4753a4a8e3edfd3879d794e1b3f81736ae6b0c9e35a33
   languageName: node
   linkType: hard
 
@@ -6820,7 +6812,7 @@ __metadata:
     "@fortawesome/free-regular-svg-icons": ^7.2.0
     "@fortawesome/free-solid-svg-icons": ^7.2.0
     "@fortawesome/react-fontawesome": ^3.2.0
-    "@react-hook/resize-observer": ^1.2.6
+    "@react-hook/resize-observer": ^2.0.2
     "@storybook/addon-docs": 10.2.16
     "@storybook/addon-links": 10.2.16
     "@storybook/cli": 10.2.16


### PR DESCRIPTION
## Context

[**Update \@react-hooks/resize-observer to 2.x**](https://trello.com/c/OVkboPYY/382-update-react-hook-resize-observer-to-2x)

We need to update the \@react-hooks/resize-observer package to 2.x. We will soon need to replace this package as it appears to be unmaintained, but we will put it on the latest version first.

## Changes

* Update `@react-hooks/resize-observer` to 2.0.2
* Add `ResizeObserver` to test setup since new version requires it to be defined on `window`

## Required Tasks

- [x] Add/update automated tests
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Comprehensively test final changes in local environment~~
- [ ] ~~Add/update docs~~
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles

## Considerations

Callbacks never fire during tests using the implementation of `window.ResizeObserver` in this PR. We don't rely on those callbacks so this is acceptable, but if we were to in the future, we'd need to upgrade to a proper polyfill. We'll probably consider doing that in the future anyway since this package isn't maintained.

## Manual Test Cases

Places where the `useSize` hook is used include everywhere where there is an accordion component that dynamically resizes:

* Game creation form
* Wish lists and inventory lists
* List items
* List item creation form

We need to ensure that all of these resize smoothly to correct dimensions.

## Screenshots and GIFs

There are no observable UI changes.