### PR TITLE
Fix deploys

### DIFF
--- a/src/components/styledSelect/styledSelect.tsx
+++ b/src/components/styledSelect/styledSelect.tsx
@@ -73,7 +73,7 @@ const StyledSelect = ({
     setIsComponentVisible,
     componentRef,
     triggerRef,
-  } = useComponentVisible()
+  } = useComponentVisible<HTMLDivElement, HTMLDivElement>()
   const size = useSize(triggerRef)
   const inputRef = useRef<HTMLInputElement>(null)
 

--- a/src/components/wishList/wishList.tsx
+++ b/src/components/wishList/wishList.tsx
@@ -50,7 +50,7 @@ const WishList = ({
     triggerRef,
     isComponentVisible,
     setIsComponentVisible,
-  } = useComponentVisible()
+  } = useComponentVisible<HTMLFormElement, HTMLButtonElement>()
 
   const {
     schemeColorDarkest,

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -67,12 +67,12 @@ export const GamesProvider = ({ children }: ProviderProps) => {
 
     if (e.code === 401) signOut()
 
-    if (Array.isArray(e.message)) {
+    if (Array.isArray(e.errors)) {
       setFlashProps({
         hidden: false,
         type: 'error',
-        header: `${e.message.length} error(s) prevented your game from being saved:`,
-        message: e.message,
+        header: `${e.errors.length} error(s) prevented your game from being saved:`,
+        message: e.errors,
       })
     } else {
       const message =

--- a/src/contexts/wishListsContext.tsx
+++ b/src/contexts/wishListsContext.tsx
@@ -115,10 +115,10 @@ export const WishListsProvider = ({ children }: ProviderProps) => {
       setFlashProps({
         hidden: false,
         type: 'error',
-        header: `${e.message.length} error(s) prevented your wish ${
+        header: `${e.errors.length} error(s) prevented your wish ${
           resource || 'list'
         } from being saved:`,
-        message: e.message,
+        message: e.errors,
       })
     } else {
       const message =

--- a/src/hooks/useComponentVisible.ts
+++ b/src/hooks/useComponentVisible.ts
@@ -1,9 +1,12 @@
 import { useState, useRef, useEffect } from 'react'
 
-const useComponentVisible = () => {
+const useComponentVisible = <
+  C extends HTMLElement = HTMLElement,
+  T extends HTMLElement = HTMLElement,
+>() => {
   const [isComponentVisible, setIsComponentVisible] = useState(false)
-  const componentRef = useRef<HTMLElement>(null)
-  const triggerRef = useRef<HTMLElement>(null)
+  const componentRef = useRef<C>(null)
+  const triggerRef = useRef<T>(null)
 
   const componentRefContains = (element: Node) =>
     componentRef.current?.contains(element)

--- a/src/types/errors.d.ts
+++ b/src/types/errors.d.ts
@@ -1,4 +1,4 @@
 export interface ApiError extends Error {
-  message: string | string[]
+  errors: string | string[]
   code: 401 | 404 | 405 | 422 | 500
 }

--- a/src/utils/api/apiErrors.ts
+++ b/src/utils/api/apiErrors.ts
@@ -2,14 +2,14 @@ import { type ApiError } from '../../types/errors'
 
 export class AuthorizationError extends Error implements ApiError {
   readonly code: 401
-  override readonly message: string
+  readonly errors: string
   override readonly name: 'AuthorizationError'
 
   constructor(message: string = '401 Unauthorized') {
     super(message)
     this.code = 401
     this.name = 'AuthorizationError'
-    this.message = message
+    this.errors = message
 
     Object.setPrototypeOf(this, AuthorizationError.prototype)
   }
@@ -17,14 +17,14 @@ export class AuthorizationError extends Error implements ApiError {
 
 export class NotFoundError extends Error implements ApiError {
   readonly code: 404
-  override readonly message: string
+  readonly errors: string
   override readonly name: 'NotFoundError'
 
   constructor(message: string = '404 Not Found') {
     super(message)
     this.code = 404
     this.name = 'NotFoundError'
-    this.message = message
+    this.errors = message
 
     Object.setPrototypeOf(this, NotFoundError.prototype)
   }
@@ -32,14 +32,14 @@ export class NotFoundError extends Error implements ApiError {
 
 export class MethodNotAllowedError extends Error implements ApiError {
   readonly code: 405
-  override readonly message: string
+  readonly errors: string
   override readonly name: 'MethodNotAllowedError'
 
   constructor(message: string = '405 Method Not Allowed') {
     super(message)
     this.code = 405
     this.name = 'MethodNotAllowedError'
-    this.message = message
+    this.errors = message
 
     Object.setPrototypeOf(this, MethodNotAllowedError.prototype)
   }
@@ -47,14 +47,14 @@ export class MethodNotAllowedError extends Error implements ApiError {
 
 export class UnprocessableEntityError extends Error implements ApiError {
   readonly code: 422
-  override readonly message: string | string[]
+  readonly errors: string | string[]
   override readonly name: 'UnprocessableEntityError'
 
   constructor(message: string | string[] = '422 Unprocessable Entity') {
     super(Array.isArray(message) ? message.join(', ') : message)
     this.code = 422
     this.name = 'UnprocessableEntityError'
-    this.message = message
+    this.errors = message
 
     Object.setPrototypeOf(this, UnprocessableEntityError.prototype)
   }
@@ -62,14 +62,14 @@ export class UnprocessableEntityError extends Error implements ApiError {
 
 export class InternalServerError extends Error implements ApiError {
   readonly code: 500
-  override readonly message: string
+  readonly errors: string
   override readonly name: 'InternalServerError'
 
   constructor(message: string = '500 Internal Server Error') {
     super(message)
     this.code = 500
     this.name = 'InternalServerError'
-    this.message = message
+    this.errors = message
 
     Object.setPrototypeOf(this, InternalServerError.prototype)
   }

--- a/src/utils/api/wrapper/gameEndpoints.ts
+++ b/src/utils/api/wrapper/gameEndpoints.ts
@@ -53,7 +53,7 @@ export const postGames = (
       if (returnValue.status === 422)
         throw new UnprocessableEntityError((json as ErrorObject).errors)
 
-      return returnValue
+      return returnValue as PostGamesReturnValue
     })
   })
 }
@@ -83,7 +83,7 @@ export const getGames = (
           (json as ErrorObject).errors.join(', ')
         )
 
-      return returnValue
+      return returnValue as GetGamesReturnValue
     })
   })
 }
@@ -122,7 +122,7 @@ export const patchGame = (
       if (returnValue.status === 422)
         throw new UnprocessableEntityError((json as ErrorObject).errors)
 
-      return returnValue
+      return returnValue as PatchGameReturnValue
     })
   })
 }

--- a/src/utils/api/wrapper/wishListEndpoints.ts
+++ b/src/utils/api/wrapper/wishListEndpoints.ts
@@ -56,7 +56,7 @@ export const postWishLists = (
           (json as ErrorObject).errors.join(', ')
         )
 
-      return returnValue
+      return returnValue as PostWishListsReturnValue
     })
   })
 }
@@ -88,7 +88,7 @@ export const getWishLists = (
           (json as ErrorObject).errors.join(', ')
         )
 
-      return returnValue
+      return returnValue as GetWishListsReturnValue
     })
   })
 }
@@ -131,7 +131,7 @@ export const patchWishList = (
           (json as ErrorObject).errors.join(', ')
         )
 
-      return returnValue
+      return returnValue as PatchWishListReturnValue
     })
   })
 }
@@ -174,7 +174,7 @@ export const deleteWishList = (
             (json as ErrorObject).errors.join(', ')
           )
 
-        return returnValue
+        return returnValue as DeleteWishListReturnValue
       })
   })
 }

--- a/src/utils/api/wrapper/wishListItemEndpoints.ts
+++ b/src/utils/api/wrapper/wishListItemEndpoints.ts
@@ -59,7 +59,7 @@ export const postWishListItems = (
           (json as ErrorObject).errors.join(', ')
         )
 
-      return returnValue
+      return returnValue as PostWishListItemsReturnValue
     })
   })
 }
@@ -104,7 +104,7 @@ export const patchWishListItem = (
             (json as ErrorObject).errors.join(', ')
           )
 
-        return returnValue
+        return returnValue as PatchWishListItemReturnValue
       })
   })
 }
@@ -140,7 +140,7 @@ export const deleteWishListItem = (
           (json as ErrorObject).errors.join(', ')
         )
 
-      return returnValue
+      return returnValue as DeleteWishListItemReturnValue
     })
   })
 }


### PR DESCRIPTION
## Context

Our ESLint changes introduced type issues when generating a production build. 

## Changes

* Use type parameters to make `useComponentVisible` generic
* Replaced `message: string | string[]` with `errors: string | string[]` for API errors since to be errors message has to be a string
* Cast return values of endpoints to specific response types