### PR TITLE
Update RefObject type parameters to be nullable

### DIFF
--- a/src/components/listEditForm/listEditForm.test.tsx
+++ b/src/components/listEditForm/listEditForm.test.tsx
@@ -11,7 +11,7 @@ interface WrapperProps {
 }
 
 const WrapperComponent = ({ onSubmit }: WrapperProps) => {
-  const formRef = useRef(null)
+  const formRef = useRef<HTMLFormElement>(null)
 
   return (
     <div>

--- a/src/components/wishListItem/wishListItem.tsx
+++ b/src/components/wishListItem/wishListItem.tsx
@@ -88,7 +88,7 @@ const WishListItem = ({
     '--hover-color': hoverColorLight,
   } as CSSProperties
 
-  const refContains = (ref: RefObject<HTMLElement>, el: Node) =>
+  const refContains = (ref: RefObject<HTMLElement | null>, el: Node) =>
     ref.current && (ref.current === el || ref.current.contains(el))
 
   const iconRefContains = (el: Node) =>

--- a/src/hooks/useSize.ts
+++ b/src/hooks/useSize.ts
@@ -1,7 +1,7 @@
 import { useState, useLayoutEffect, type RefObject } from 'react'
 import useResizeObserver from '@react-hook/resize-observer'
 
-const useSize = (target: RefObject<HTMLElement>) => {
+const useSize = (target: RefObject<HTMLElement | null>) => {
   const [size, setSize] = useState<DOMRect | null>(null)
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Context

[**Update RefObject types for React 19 compatibility**](https://trello.com/c/yIeMiGlL/408-update-refobject-types-for-react-19-compatibility)

In React 19’s @types/react, useRef<T>(null) returns RefObject<T | null> instead of RefObject<T>. Any function/component that accepts a RefObject<T> as a parameter will fail to accept the new return type. We can fix this now because RefObject<T> and RefObject<T | null> are structurally identical in React 18 types (both have current: T | null), so this change has zero runtime or type-level impact on React 18.

## Changes

* Change `RefObject<T>` to `RefObject<T | null>` in all cases where we can safely do so

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [x] Comprehensively test final changes in local environment
- [ ] ~~Add/update docs~~
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles

## Manual Test Cases

We need to verify that wish lists, wish list edit forms, and wish list items resize properly.

## Screenshots and GIFs

No observable UI changes.