### PR TITLE
Change Context.Provider to just Context

### DIFF
--- a/docs/contexts/login-context.md
+++ b/docs/contexts/login-context.md
@@ -65,9 +65,9 @@ const MyProvider = ({ children }: MyProviderProps) => {
   }
 
   return (
-    <MyContext.Provider value={{ fetchResource }}>
+    <MyContext value={{ fetchResource }}>
       {children}
-    </MyContext.Provider>
+    </MyContext>
   )
 }
 ```

--- a/src/components/dashboardHeader/dashboardHeader.stories.tsx
+++ b/src/components/dashboardHeader/dashboardHeader.stories.tsx
@@ -16,9 +16,9 @@ const meta: Meta<typeof DashboardHeader> = {
   decorators: [
     (Story, { parameters }) => (
       <BrowserRouter>
-        <LoginContext.Provider value={parameters['loginContextValue'] as LoginContextType}>
+        <LoginContext value={parameters['loginContextValue'] as LoginContextType}>
           <Story />
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/components/gameCreateForm/gameCreateForm.stories.tsx
+++ b/src/components/gameCreateForm/gameCreateForm.stories.tsx
@@ -12,9 +12,9 @@ const meta: Meta<typeof GameCreateForm> = {
   decorators: [
     (Story) => (
       <PageProvider>
-        <GamesContext.Provider value={gamesContextValue}>
+        <GamesContext value={gamesContextValue}>
           <Story />
-        </GamesContext.Provider>
+        </GamesContext>
       </PageProvider>
     ),
   ],

--- a/src/components/gameCreateForm/gameCreateForm.test.tsx
+++ b/src/components/gameCreateForm/gameCreateForm.test.tsx
@@ -12,9 +12,9 @@ describe('<GameCreateForm />', () => {
     test('displays the correct fields', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <GameCreateForm />
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -27,9 +27,9 @@ describe('<GameCreateForm />', () => {
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <GameCreateForm />
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -45,11 +45,11 @@ describe('<GameCreateForm />', () => {
 
           const wrapper = renderAuthenticated(
             <PageProvider>
-              <GamesContext.Provider
+              <GamesContext
                 value={{ ...gamesContextValue, createGame }}
               >
                 <GameCreateForm />
-              </GamesContext.Provider>
+              </GamesContext>
             </PageProvider>
           )
 
@@ -74,11 +74,11 @@ describe('<GameCreateForm />', () => {
 
           const wrapper = renderAuthenticated(
             <PageProvider>
-              <GamesContext.Provider
+              <GamesContext
                 value={{ ...gamesContextValue, createGame }}
               >
                 <GameCreateForm />
-              </GamesContext.Provider>
+              </GamesContext>
             </PageProvider>
           )
 
@@ -107,11 +107,11 @@ describe('<GameCreateForm />', () => {
 
           const wrapper = renderAuthenticated(
             <PageProvider>
-              <GamesContext.Provider
+              <GamesContext
                 value={{ ...gamesContextValue, createGame }}
               >
                 <GameCreateForm />
-              </GamesContext.Provider>
+              </GamesContext>
             </PageProvider>
           )
 
@@ -146,9 +146,9 @@ describe('<GameCreateForm />', () => {
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <GameCreateForm disabled />
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 

--- a/src/components/gameLineItem/gameLineItem.stories.tsx
+++ b/src/components/gameLineItem/gameLineItem.stories.tsx
@@ -15,13 +15,13 @@ const meta: Meta<typeof GameLineItem> = {
   component: GameLineItem,
   decorators: [
     (Story) => (
-      <LoginContext.Provider value={loginContextValue}>
+      <LoginContext value={loginContextValue}>
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <Story />
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
-      </LoginContext.Provider>
+      </LoginContext>
     ),
   ],
 }

--- a/src/components/gameLineItem/gameLineItem.test.tsx
+++ b/src/components/gameLineItem/gameLineItem.test.tsx
@@ -15,13 +15,13 @@ describe('GameLineItem', () => {
   test('matches snapshot', () => {
     const wrapper = renderAuthenticated(
       <PageProvider>
-        <GamesContext.Provider value={gamesContextValue}>
+        <GamesContext value={gamesContextValue}>
           <GameLineItem
             gameId={4}
             name="De finibus bonorum et malorum"
             description="This is my game"
           />
-        </GamesContext.Provider>
+        </GamesContext>
       </PageProvider>
     )
     expect(wrapper).toBeTruthy()
@@ -37,13 +37,13 @@ describe('GameLineItem', () => {
 
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={contextValue}>
+          <GamesContext value={contextValue}>
             <GameLineItem
               gameId={4}
               name="De finibus bonorum et malorum"
               description="This is my game"
             />
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -63,13 +63,13 @@ describe('GameLineItem', () => {
 
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={contextValue}>
+          <GamesContext value={contextValue}>
             <GameLineItem
               gameId={4}
               name="De finibus bonorum et malorum"
               description="This is my game"
             />
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 

--- a/src/components/userInfo/userInfo.stories.tsx
+++ b/src/components/userInfo/userInfo.stories.tsx
@@ -16,11 +16,11 @@ const meta: Meta<typeof UserInfo> = {
   decorators: [
     (Story, { parameters }) => (
       <BrowserRouter>
-        <LoginContext.Provider value={parameters['loginContextValue'] as LoginContextType}>
+        <LoginContext value={parameters['loginContextValue'] as LoginContextType}>
           <div style={{ height: '64px', display: 'flex' }}>
             <Story />
           </div>
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/components/wishList/wishList.stories.tsx
+++ b/src/components/wishList/wishList.stories.tsx
@@ -22,10 +22,10 @@ const meta: Meta<typeof WishList> = {
   decorators: [
     (Story) => (
       <BrowserRouter>
-        <LoginContext.Provider value={loginContextValue}>
+        <LoginContext value={loginContextValue}>
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
-              <WishListsContext.Provider value={wishListsContextValue}>
+            <GamesContext value={gamesContextValue}>
+              <WishListsContext value={wishListsContextValue}>
                 <ColorProvider
                   colorScheme={
                     colorSchemes[
@@ -35,10 +35,10 @@ const meta: Meta<typeof WishList> = {
                 >
                   <Story />
                 </ColorProvider>
-              </WishListsContext.Provider>
-            </GamesContext.Provider>
+              </WishListsContext>
+            </GamesContext>
           </PageProvider>
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/components/wishList/wishList.test.tsx
+++ b/src/components/wishList/wishList.test.tsx
@@ -19,11 +19,11 @@ let listContextValue = wishListsContextValue
 const renderWithContexts = (ui: ReactElement) =>
   renderAuthenticated(
     <PageProvider>
-      <GamesContext.Provider value={gamesContextValue}>
-        <WishListsContext.Provider value={listContextValue}>
+      <GamesContext value={gamesContextValue}>
+        <WishListsContext value={listContextValue}>
           <ColorProvider colorScheme={GREEN}>{ui}</ColorProvider>
-        </WishListsContext.Provider>
-      </GamesContext.Provider>
+        </WishListsContext>
+      </GamesContext>
     </PageProvider>
   )
 

--- a/src/components/wishListCreateForm/wishListCreateForm.stories.tsx
+++ b/src/components/wishListCreateForm/wishListCreateForm.stories.tsx
@@ -17,11 +17,11 @@ const meta: Meta<typeof WishListCreateForm> = {
   decorators: [
     (Story, { parameters }) => (
       <PageProvider>
-        <GamesContext.Provider value={parameters['gamesContextValue'] as GamesContextType}>
-          <WishListsContext.Provider value={wishListsContextValue}>
+        <GamesContext value={parameters['gamesContextValue'] as GamesContextType}>
+          <WishListsContext value={wishListsContextValue}>
             <Story />
-          </WishListsContext.Provider>
-        </GamesContext.Provider>
+          </WishListsContext>
+        </GamesContext>
       </PageProvider>
     ),
   ],

--- a/src/components/wishListCreateForm/wishListCreateForm.test.tsx
+++ b/src/components/wishListCreateForm/wishListCreateForm.test.tsx
@@ -31,9 +31,9 @@ import WishListCreateForm from './wishListCreateForm'
 const renderWithContexts = (ui: ReactElement) => {
   return renderAuthenticated(
     <PageProvider>
-      <GamesContext.Provider value={gamesContextValue}>
+      <GamesContext value={gamesContextValue}>
         <WishListsProvider>{ui}</WishListsProvider>
-      </GamesContext.Provider>
+      </GamesContext>
     </PageProvider>
   )
 }
@@ -64,13 +64,13 @@ describe('WishListCreateForm', () => {
     test('is disabled when the wish lists are loading', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext
               value={wishListsContextValueLoading}
             >
               <WishListCreateForm />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -87,13 +87,13 @@ describe('WishListCreateForm', () => {
     test('is disabled when there is a wish list loading error', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext
               value={wishListsContextValueError}
             >
               <WishListCreateForm />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -110,11 +110,11 @@ describe('WishListCreateForm', () => {
     test('is disabled when games are loading', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValueLoading}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValueLoading}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListCreateForm />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -131,11 +131,11 @@ describe('WishListCreateForm', () => {
     test('is disabled when there is a game loading error', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValueError}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValueError}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListCreateForm />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -152,11 +152,11 @@ describe('WishListCreateForm', () => {
     test('is enabled when both games and wish lists have loaded', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListCreateForm />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -182,11 +182,11 @@ describe('WishListCreateForm', () => {
 
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
-              <WishListsContext.Provider value={contextValue}>
+            <GamesContext value={gamesContextValue}>
+              <WishListsContext value={contextValue}>
                 <WishListCreateForm />
-              </WishListsContext.Provider>
-            </GamesContext.Provider>
+              </WishListsContext>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -215,11 +215,11 @@ describe('WishListCreateForm', () => {
 
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
-              <WishListsContext.Provider value={contextValue}>
+            <GamesContext value={gamesContextValue}>
+              <WishListsContext value={contextValue}>
                 <WishListCreateForm />
-              </WishListsContext.Provider>
-            </GamesContext.Provider>
+              </WishListsContext>
+            </GamesContext>
           </PageProvider>
         )
 

--- a/src/components/wishListGrouping/wishListGrouping.stories.tsx
+++ b/src/components/wishListGrouping/wishListGrouping.stories.tsx
@@ -18,13 +18,13 @@ const meta: Meta<typeof WishListGrouping> = {
   decorators: [
     (Story, { parameters }) => (
       <PageProvider>
-        <GamesContext.Provider value={parameters['gamesContextValue'] as GamesContextType}>
-          <WishListsContext.Provider
+        <GamesContext value={parameters['gamesContextValue'] as GamesContextType}>
+          <WishListsContext
             value={parameters['wishListsContextValue'] as WishListsContextType}
           >
             <Story />
-          </WishListsContext.Provider>
-        </GamesContext.Provider>
+          </WishListsContext>
+        </GamesContext>
       </PageProvider>
     ),
   ],

--- a/src/components/wishListGrouping/wishListGrouping.test.tsx
+++ b/src/components/wishListGrouping/wishListGrouping.test.tsx
@@ -15,11 +15,11 @@ describe('WishListGrouping', () => {
     test('displays each list', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -42,11 +42,11 @@ describe('WishListGrouping', () => {
     test('displays the destroy icon for editable lists only', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -61,11 +61,11 @@ describe('WishListGrouping', () => {
     test('displays the destroy icon for editable list items only', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -79,11 +79,11 @@ describe('WishListGrouping', () => {
     test('displays the edit icon for editable lists only', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -98,11 +98,11 @@ describe('WishListGrouping', () => {
     test('displays the edit icon for editable list items only', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -116,11 +116,11 @@ describe('WishListGrouping', () => {
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -132,13 +132,13 @@ describe('WishListGrouping', () => {
     test('displays a message that there are no lists for this game', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext
               value={wishListsContextValueEmpty}
             >
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -148,13 +148,13 @@ describe('WishListGrouping', () => {
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext
               value={wishListsContextValueEmpty}
             >
               <WishListGrouping />
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 

--- a/src/components/wishListItem/wishListItem.stories.tsx
+++ b/src/components/wishListItem/wishListItem.stories.tsx
@@ -19,10 +19,10 @@ const meta: Meta<typeof WishListItem> = {
   component: WishListItem,
   decorators: [
     (Story) => (
-      <LoginContext.Provider value={loginContextValue}>
+      <LoginContext value={loginContextValue}>
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <ColorProvider
                 colorScheme={
                   colorSchemes[Math.floor(Math.random() * colorSchemes.length)]
@@ -30,10 +30,10 @@ const meta: Meta<typeof WishListItem> = {
               >
                 <Story />
               </ColorProvider>
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
-      </LoginContext.Provider>
+      </LoginContext>
     ),
   ],
 }

--- a/src/components/wishListItem/wishListItem.test.tsx
+++ b/src/components/wishListItem/wishListItem.test.tsx
@@ -18,11 +18,11 @@ let listsContextValue = wishListsContextValue
 const renderInContexts = (ui: ReactElement) =>
   renderAuthenticated(
     <PageProvider>
-      <GamesContext.Provider value={gamesContextValue}>
-        <WishListsContext.Provider value={listsContextValue}>
+      <GamesContext value={gamesContextValue}>
+        <WishListsContext value={listsContextValue}>
           <ColorProvider colorScheme={GREEN}>{ui}</ColorProvider>
-        </WishListsContext.Provider>
-      </GamesContext.Provider>
+        </WishListsContext>
+      </GamesContext>
     </PageProvider>
   )
 

--- a/src/components/wishListItemCreateForm/wishListItemCreateForm.stories.tsx
+++ b/src/components/wishListItemCreateForm/wishListItemCreateForm.stories.tsx
@@ -19,17 +19,17 @@ const meta: Meta<typeof WishListItemCreateForm> = {
   component: WishListItemCreateForm,
   decorators: [
     (Story) => (
-      <LoginContext.Provider value={loginContextValue}>
+      <LoginContext value={loginContextValue}>
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider value={wishListsContextValue}>
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext value={wishListsContextValue}>
               <ColorProvider colorScheme={BLUE}>
                 <Story />
               </ColorProvider>
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
-      </LoginContext.Provider>
+      </LoginContext>
     ),
   ],
 }

--- a/src/components/wishListItemCreateForm/wishListItemCreateForm.test.tsx
+++ b/src/components/wishListItemCreateForm/wishListItemCreateForm.test.tsx
@@ -16,13 +16,13 @@ describe('WishListItemCreateForm', () => {
   test('displays correct fields', () => {
     const wrapper = renderAuthenticated(
       <PageProvider>
-        <GamesContext.Provider value={gamesContextValue}>
-          <WishListsContext.Provider value={wishListsContextValue}>
+        <GamesContext value={gamesContextValue}>
+          <WishListsContext value={wishListsContextValue}>
             <ColorProvider colorScheme={YELLOW}>
               <WishListItemCreateForm listId={4} />
             </ColorProvider>
-          </WishListsContext.Provider>
-        </GamesContext.Provider>
+          </WishListsContext>
+        </GamesContext>
       </PageProvider>
     )
 
@@ -37,13 +37,13 @@ describe('WishListItemCreateForm', () => {
   test('matches snapshot', () => {
     const wrapper = renderAuthenticated(
       <PageProvider>
-        <GamesContext.Provider value={gamesContextValue}>
-          <WishListsContext.Provider value={wishListsContextValue}>
+        <GamesContext value={gamesContextValue}>
+          <WishListsContext value={wishListsContextValue}>
             <ColorProvider colorScheme={YELLOW}>
               <WishListItemCreateForm listId={4} />
             </ColorProvider>
-          </WishListsContext.Provider>
-        </GamesContext.Provider>
+          </WishListsContext>
+        </GamesContext>
       </PageProvider>
     )
 
@@ -56,15 +56,15 @@ describe('WishListItemCreateForm', () => {
 
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext
               value={{ ...wishListsContextValue, createWishListItem }}
             >
               <ColorProvider colorScheme={YELLOW}>
                 <WishListItemCreateForm listId={4} />
               </ColorProvider>
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -93,15 +93,15 @@ describe('WishListItemCreateForm', () => {
 
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
-            <WishListsContext.Provider
+          <GamesContext value={gamesContextValue}>
+            <WishListsContext
               value={{ ...wishListsContextValue, createWishListItem }}
             >
               <ColorProvider colorScheme={YELLOW}>
                 <WishListItemCreateForm listId={4} />
               </ColorProvider>
-            </WishListsContext.Provider>
-          </GamesContext.Provider>
+            </WishListsContext>
+          </GamesContext>
         </PageProvider>
       )
 

--- a/src/components/wishListItemEditForm/wishListItemEditForm.stories.tsx
+++ b/src/components/wishListItemEditForm/wishListItemEditForm.stories.tsx
@@ -17,11 +17,11 @@ const meta: Meta<typeof WishListItemEditForm> = {
   decorators: [
     (Story) => (
       <PageProvider>
-        <GamesContext.Provider value={gamesContextValue}>
-          <WishListsContext.Provider value={wishListsContextValue}>
+        <GamesContext value={gamesContextValue}>
+          <WishListsContext value={wishListsContextValue}>
             <Story />
-          </WishListsContext.Provider>
-        </GamesContext.Provider>
+          </WishListsContext>
+        </GamesContext>
       </PageProvider>
     ),
   ],

--- a/src/components/wishListItemEditForm/wishListItemEditForm.test.tsx
+++ b/src/components/wishListItemEditForm/wishListItemEditForm.test.tsx
@@ -17,11 +17,11 @@ let contextValue = wishListsContextValue
 const renderWithContexts = (ui: ReactElement) =>
   renderAuthenticated(
     <PageProvider>
-      <GamesContext.Provider value={gamesContextValue}>
-        <WishListsContext.Provider value={contextValue}>
+      <GamesContext value={gamesContextValue}>
+        <WishListsContext value={contextValue}>
           {ui}
-        </WishListsContext.Provider>
-      </GamesContext.Provider>
+        </WishListsContext>
+      </GamesContext>
     </PageProvider>
   )
 

--- a/src/contexts/colorContext.tsx
+++ b/src/contexts/colorContext.tsx
@@ -9,7 +9,7 @@ interface ColorProviderProps extends ProviderProps {
 }
 
 const ColorProvider = ({ colorScheme, children }: ColorProviderProps) => (
-  <ColorContext.Provider value={colorScheme}>{children}</ColorContext.Provider>
+  <ColorContext value={colorScheme}>{children}</ColorContext>
 )
 
 export { ColorProvider, ColorContext }

--- a/src/contexts/gamesContext.tsx
+++ b/src/contexts/gamesContext.tsx
@@ -331,5 +331,5 @@ export const GamesProvider = ({ children }: ProviderProps) => {
     previousTokenRef.current = token
   }, [authLoading, token])
 
-  return <GamesContext.Provider value={value}>{children}</GamesContext.Provider>
+  return <GamesContext value={value}>{children}</GamesContext>
 }

--- a/src/contexts/loginContext.tsx
+++ b/src/contexts/loginContext.tsx
@@ -67,5 +67,5 @@ export const LoginProvider = ({ children }: ProviderProps) => {
     refreshToken()
   }, [user, authError])
 
-  return <LoginContext.Provider value={value}>{children}</LoginContext.Provider>
+  return <LoginContext value={value}>{children}</LoginContext>
 }

--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -85,7 +85,7 @@ const PageProvider = ({ children }: ProviderProps) => {
     }, 4000)
   }, [flashProps])
 
-  return <PageContext.Provider value={value}>{children}</PageContext.Provider>
+  return <PageContext value={value}>{children}</PageContext>
 }
 
 export { PageContext, PageProvider }

--- a/src/contexts/wishListsContext.tsx
+++ b/src/contexts/wishListsContext.tsx
@@ -747,8 +747,8 @@ export const WishListsProvider = ({ children }: ProviderProps) => {
   }, [requireLogin])
 
   return (
-    <WishListsContext.Provider value={value}>
+    <WishListsContext value={value}>
       {children}
-    </WishListsContext.Provider>
+    </WishListsContext>
   )
 }

--- a/src/layouts/dashboardLayout/dashboardLayout.stories.tsx
+++ b/src/layouts/dashboardLayout/dashboardLayout.stories.tsx
@@ -19,13 +19,13 @@ const meta: Meta<typeof DashboardLayout> = {
   decorators: [
     (Story, { parameters }) => (
       <BrowserRouter>
-        <LoginContext.Provider value={loginContextValue}>
+        <LoginContext value={loginContextValue}>
           <PageProvider>
-            <GamesContext.Provider value={parameters['gamesContextValue'] as GamesContextType}>
+            <GamesContext value={parameters['gamesContextValue'] as GamesContextType}>
               <Story />
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/layouts/dashboardLayout/dashboardLayout.test.tsx
+++ b/src/layouts/dashboardLayout/dashboardLayout.test.tsx
@@ -17,9 +17,9 @@ describe('<DashboardLayout>', () => {
     test('renders the title and content', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout title="Page Title">Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -32,9 +32,9 @@ describe('<DashboardLayout>', () => {
     test('renders the DashboardHeader', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout title="Page Title">Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -49,9 +49,9 @@ describe('<DashboardLayout>', () => {
     test("doesn't display the StyledSelect", () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout title="Page Title">Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -61,9 +61,9 @@ describe('<DashboardLayout>', () => {
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout title="Page Title">Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -75,9 +75,9 @@ describe('<DashboardLayout>', () => {
     test('displays content but not an h2 or hr', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout>Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -93,9 +93,9 @@ describe('<DashboardLayout>', () => {
     test('renders the DashboardHeader', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout>Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -110,9 +110,9 @@ describe('<DashboardLayout>', () => {
     test("doesn't render the StyledSelect", () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout>Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -122,9 +122,9 @@ describe('<DashboardLayout>', () => {
     test('matches snapshot', () => {
       const wrapper = renderAuthenticated(
         <PageProvider>
-          <GamesContext.Provider value={gamesContextValue}>
+          <GamesContext value={gamesContextValue}>
             <DashboardLayout>Hello World</DashboardLayout>
-          </GamesContext.Provider>
+          </GamesContext>
         </PageProvider>
       )
 
@@ -261,11 +261,11 @@ describe('<DashboardLayout>', () => {
         test('matches snapshot', () => {
           const wrapper = renderAuthenticated(
             <PageProvider>
-              <GamesContext.Provider value={gamesContextValue}>
+              <GamesContext value={gamesContextValue}>
                 <DashboardLayout includeGameSelector>
                   Hello World
                 </DashboardLayout>
-              </GamesContext.Provider>
+              </GamesContext>
             </PageProvider>,
             'http://localhost:5173/wish_lists?gameId=51'
           )
@@ -304,11 +304,11 @@ describe('<DashboardLayout>', () => {
         test('matches snapshot', () => {
           const wrapper = renderAuthenticated(
             <PageProvider>
-              <GamesContext.Provider value={gamesContextValue}>
+              <GamesContext value={gamesContextValue}>
                 <DashboardLayout includeGameSelector>
                   Hello World
                 </DashboardLayout>
-              </GamesContext.Provider>
+              </GamesContext>
             </PageProvider>,
             'http://localhost:5173/wish_lists?gameId=67'
           )

--- a/src/pages/dashboardPage/dashboardPage.stories.tsx
+++ b/src/pages/dashboardPage/dashboardPage.stories.tsx
@@ -16,11 +16,11 @@ const meta: Meta<typeof DashboardPage> = {
   decorators: [
     (Story, { parameters }) => (
       <BrowserRouter>
-        <LoginContext.Provider value={parameters['loginContextValue'] as LoginContextType}>
+        <LoginContext value={parameters['loginContextValue'] as LoginContextType}>
           <PageProvider>
             <Story />
           </PageProvider>
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/pages/gamesPage/gamesPage.stories.tsx
+++ b/src/pages/gamesPage/gamesPage.stories.tsx
@@ -21,13 +21,13 @@ const meta: Meta<typeof GamesPage> = {
   decorators: [
     (Story, { parameters }) => (
       <BrowserRouter>
-        <LoginContext.Provider value={parameters['loginContextValue'] as LoginContextType}>
+        <LoginContext value={parameters['loginContextValue'] as LoginContextType}>
           <PageProvider>
             <GamesProvider>
               <Story />
             </GamesProvider>
           </PageProvider>
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/pages/gamesPage/gamesPage.test.tsx
+++ b/src/pages/gamesPage/gamesPage.test.tsx
@@ -305,9 +305,9 @@ describe('<GamesPage />', () => {
 
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={contextValue}>
+            <GamesContext value={contextValue}>
               <GamesPage />
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 

--- a/src/pages/homePage/homePage.stories.tsx
+++ b/src/pages/homePage/homePage.stories.tsx
@@ -15,9 +15,9 @@ const meta: Meta<typeof HomePage> = {
   decorators: [
     (Story, { parameters }) => (
       <BrowserRouter>
-        <LoginContext.Provider value={parameters['loginContextValue'] as LoginContextType}>
+        <LoginContext value={parameters['loginContextValue'] as LoginContextType}>
           <Story />
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/pages/wishListsPage/wishListsPage.stories.tsx
+++ b/src/pages/wishListsPage/wishListsPage.stories.tsx
@@ -23,17 +23,17 @@ const meta: Meta<typeof WishListsPage> = {
   decorators: [
     (Story, { parameters }) => (
       <BrowserRouter>
-        <LoginContext.Provider value={loginContextValue}>
+        <LoginContext value={loginContextValue}>
           <PageProvider>
-            <GamesContext.Provider value={parameters['gamesContextValue'] as GamesContextType}>
-              <WishListsContext.Provider
+            <GamesContext value={parameters['gamesContextValue'] as GamesContextType}>
+              <WishListsContext
                 value={parameters['wishListsContextValue'] as WishListsContextType}
               >
                 <Story />
-              </WishListsContext.Provider>
-            </GamesContext.Provider>
+              </WishListsContext>
+            </GamesContext>
           </PageProvider>
-        </LoginContext.Provider>
+        </LoginContext>
       </BrowserRouter>
     ),
   ],

--- a/src/pages/wishListsPage/wishListsPage.test.tsx
+++ b/src/pages/wishListsPage/wishListsPage.test.tsx
@@ -1199,11 +1199,11 @@ describe('WishListsPage', () => {
       test('adds the new item to the list and aggregate list', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1244,11 +1244,11 @@ describe('WishListsPage', () => {
       test('displays a flash error message', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1297,11 +1297,11 @@ describe('WishListsPage', () => {
       test('displays a flash error message', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1349,11 +1349,11 @@ describe('WishListsPage', () => {
       test("doesn't remove the item", async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1396,11 +1396,11 @@ describe('WishListsPage', () => {
       test('removes the item from the regular and aggregate list', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1450,11 +1450,11 @@ describe('WishListsPage', () => {
       test('displays a flash error message', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1492,11 +1492,11 @@ describe('WishListsPage', () => {
       test('increments quantity of affected items', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1525,11 +1525,11 @@ describe('WishListsPage', () => {
       test('displays a flash error', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1566,11 +1566,11 @@ describe('WishListsPage', () => {
         test('decrements quantity of affected items', async () => {
           const wrapper = renderAuthenticated(
             <PageProvider>
-              <GamesContext.Provider value={gamesContextValue}>
+              <GamesContext value={gamesContextValue}>
                 <WishListsProvider>
                   <WishListsPage />
                 </WishListsProvider>
-              </GamesContext.Provider>
+              </GamesContext>
             </PageProvider>
           )
 
@@ -1606,11 +1606,11 @@ describe('WishListsPage', () => {
           test('deletes the item', async () => {
             const wrapper = renderAuthenticated(
               <PageProvider>
-                <GamesContext.Provider value={gamesContextValue}>
+                <GamesContext value={gamesContextValue}>
                   <WishListsProvider>
                     <WishListsPage />
                   </WishListsProvider>
-                </GamesContext.Provider>
+                </GamesContext>
               </PageProvider>
             )
 
@@ -1649,11 +1649,11 @@ describe('WishListsPage', () => {
           test("doesn't delete the item", async () => {
             const wrapper = renderAuthenticated(
               <PageProvider>
-                <GamesContext.Provider value={gamesContextValue}>
+                <GamesContext value={gamesContextValue}>
                   <WishListsProvider>
                     <WishListsPage />
                   </WishListsProvider>
-                </GamesContext.Provider>
+                </GamesContext>
               </PageProvider>
             )
 
@@ -1691,11 +1691,11 @@ describe('WishListsPage', () => {
       test('displays a flash error', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1731,11 +1731,11 @@ describe('WishListsPage', () => {
       test('hides the form, shows the flash message and updates the items', async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1776,11 +1776,11 @@ describe('WishListsPage', () => {
       test("shows the validation errors and doesn't hide the form", async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 
@@ -1828,11 +1828,11 @@ describe('WishListsPage', () => {
       test("shows an error message and doesn't hide the form", async () => {
         const wrapper = renderAuthenticated(
           <PageProvider>
-            <GamesContext.Provider value={gamesContextValue}>
+            <GamesContext value={gamesContextValue}>
               <WishListsProvider>
                 <WishListsPage />
               </WishListsProvider>
-            </GamesContext.Provider>
+            </GamesContext>
           </PageProvider>
         )
 

--- a/src/support/testUtils.tsx
+++ b/src/support/testUtils.tsx
@@ -45,24 +45,24 @@ export const renderWithRouter = (ui: ReactElement, url?: string) =>
 
 export const renderAuthenticated = (ui: ReactElement, url?: string) =>
   renderWithRouter(
-    <LoginContext.Provider value={loginContextValue}>
+    <LoginContext value={loginContextValue}>
       {ui}
-    </LoginContext.Provider>,
+    </LoginContext>,
     url
   )
 
 export const renderUnauthenticated = (ui: ReactElement, url?: string) =>
   renderWithRouter(
-    <LoginContext.Provider value={unauthenticatedLoginContextValue}>
+    <LoginContext value={unauthenticatedLoginContextValue}>
       {ui}
-    </LoginContext.Provider>,
+    </LoginContext>,
     url
   )
 
 export const renderAuthLoading = (ui: ReactElement, url?: string) =>
   renderWithRouter(
-    <LoginContext.Provider value={loadingLoginContextValue}>
+    <LoginContext value={loadingLoginContextValue}>
       {ui}
-    </LoginContext.Provider>,
+    </LoginContext>,
     url
   )


### PR DESCRIPTION
## Context

[**Change Context.Provider to Context**](https://trello.com/c/gNLDyNEB/412-change-contextprovider-to-context)

In React 19, the `Context.Provider` syntax is deprecated and we should use `Context`.

## Changes

* Change `Context.Provider` to `Context` throughout

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [x] Comprehensively test final changes in local environment
- [ ] ~~Add/update docs~~
- [x] Run formatter on final changes
- [x] Verify TypeScript compiles
