### PR TITLE
Upgrade Vitest and regenerate snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.56.1",
     "unplugin-fonts": "^1.4.0",
     "vite": "^7.3.1",
-    "vitest": "3.1.4"
+    "vitest": "^4.0.18"
   },
   "packageManager": "yarn@3.6.4"
 }

--- a/src/components/dashboardHeader/__snapshots__/dashboardHeader.test.tsx.snap
+++ b/src/components/dashboardHeader/__snapshots__/dashboardHeader.test.tsx.snap
@@ -6,29 +6,29 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -36,18 +36,18 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -59,29 +59,29 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -100,7 +100,7 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -113,29 +113,29 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <header
-      class="_root_c29812"
+      class="_root_faea2d"
     >
       <div
-        class="_bar_c29812"
+        class="_bar_faea2d"
       >
         <span
-          class="_headerContainer_c29812"
+          class="_headerContainer_faea2d"
         >
           <h1
-            class="_header_c29812"
+            class="_header_faea2d"
           >
             <a
-              class="_headerLinkLarge_c29812"
+              class="_headerLinkLarge_faea2d"
               href="/dashboard"
             >
               Skyrim Inventory
               <br
-                class="_bp_c29812"
+                class="_bp_faea2d"
               />
                Management
             </a>
             <a
-              class="_headerLinkSmall_c29812"
+              class="_headerLinkSmall_faea2d"
               href="/dashboard"
             >
               S. I. M.
@@ -143,18 +143,18 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
           </h1>
         </span>
         <span
-          class="_root_d263fb"
+          class="_root_658745"
         >
           <div
-            class="_main_d263fb"
+            class="_main_658745"
           >
             <div
-              class="_button_d263fb"
+              class="_button_658745"
               role="button"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-bars _hamburger_d263fb"
+                class="svg-inline--fa fa-bars _hamburger_658745"
                 data-icon="bars"
                 data-prefix="fas"
                 role="img"
@@ -166,29 +166,29 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
                 />
               </svg>
               <span
-                class="_info_d263fb"
+                class="_info_658745"
               >
                 <p
-                  class="_name_d263fb"
+                  class="_name_658745"
                 >
                   Edna St. Vincent Millay
                 </p>
                 <p
-                  class="_email_d263fb"
+                  class="_email_658745"
                 >
                   edna@gmail.com
                 </p>
               </span>
               <img
                 alt="User profile image"
-                class="_img_d263fb"
+                class="_img_658745"
                 referrerpolicy="no-referrer"
                 src="/src/support/testProfileImg.png"
               />
             </div>
           </div>
           <menu
-            class="_dropdown_d263fb"
+            class="_dropdown_658745"
           >
             <div
               role="button"
@@ -207,7 +207,7 @@ exports[`<DashboardHeader /> > matches snapshot 1`] = `
                 />
               </svg>
               <p
-                class="_signOutText_d263fb"
+                class="_signOutText_658745"
               >
                 Sign Out
               </p>

--- a/src/components/flashMessage/__snapshots__/flashMessage.test.tsx.snap
+++ b/src/components/flashMessage/__snapshots__/flashMessage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FlashMessage > when there is a string message > matches snapshot 1`] = 
   "baseElement": <body>
     <div>
       <div
-        class="_root_91d025"
+        class="_root_ca8db5"
         style="--text-color: #4e6d83;"
       >
         Hello world.
@@ -15,7 +15,7 @@ exports[`FlashMessage > when there is a string message > matches snapshot 1`] = 
   </body>,
   "container": <div>
     <div
-      class="_root_91d025"
+      class="_root_ca8db5"
       style="--text-color: #4e6d83;"
     >
       Hello world.
@@ -81,11 +81,11 @@ exports[`FlashMessage > when there is a string message > when there is a header 
   "baseElement": <body>
     <div>
       <div
-        class="_root_91d025"
+        class="_root_ca8db5"
         style="--text-color: #4e6d83;"
       >
         <p
-          class="_header_91d025"
+          class="_header_ca8db5"
         >
           Greetings!
         </p>
@@ -95,11 +95,11 @@ exports[`FlashMessage > when there is a string message > when there is a header 
   </body>,
   "container": <div>
     <div
-      class="_root_91d025"
+      class="_root_ca8db5"
       style="--text-color: #4e6d83;"
     >
       <p
-        class="_header_91d025"
+        class="_header_ca8db5"
       >
         Greetings!
       </p>
@@ -166,24 +166,24 @@ exports[`FlashMessage > when there is an array message > matches snapshot 1`] = 
   "baseElement": <body>
     <div>
       <div
-        class="_root_91d025"
+        class="_root_ca8db5"
         style="--text-color: #4e6d83;"
       >
         <ul
-          class="_list_91d025"
+          class="_list_ca8db5"
         >
           <li
-            class="_msg_91d025"
+            class="_msg_ca8db5"
           >
             You will be assimilated.
           </li>
           <li
-            class="_msg_91d025"
+            class="_msg_ca8db5"
           >
             Your biological and technological distinctiveness will be added to our own.
           </li>
           <li
-            class="_msg_91d025"
+            class="_msg_ca8db5"
           >
             Resistance is futile.
           </li>
@@ -193,24 +193,24 @@ exports[`FlashMessage > when there is an array message > matches snapshot 1`] = 
   </body>,
   "container": <div>
     <div
-      class="_root_91d025"
+      class="_root_ca8db5"
       style="--text-color: #4e6d83;"
     >
       <ul
-        class="_list_91d025"
+        class="_list_ca8db5"
       >
         <li
-          class="_msg_91d025"
+          class="_msg_ca8db5"
         >
           You will be assimilated.
         </li>
         <li
-          class="_msg_91d025"
+          class="_msg_ca8db5"
         >
           Your biological and technological distinctiveness will be added to our own.
         </li>
         <li
-          class="_msg_91d025"
+          class="_msg_ca8db5"
         >
           Resistance is futile.
         </li>
@@ -277,29 +277,29 @@ exports[`FlashMessage > when there is an array message > when there is a header 
   "baseElement": <body>
     <div>
       <div
-        class="_root_91d025"
+        class="_root_ca8db5"
         style="--text-color: #4e6d83;"
       >
         <p
-          class="_header_91d025"
+          class="_header_ca8db5"
         >
           We are the Borg.
         </p>
         <ul
-          class="_list_91d025"
+          class="_list_ca8db5"
         >
           <li
-            class="_msg_91d025"
+            class="_msg_ca8db5"
           >
             You will be assimilated.
           </li>
           <li
-            class="_msg_91d025"
+            class="_msg_ca8db5"
           >
             Your biological and technological distinctiveness will be added to our own.
           </li>
           <li
-            class="_msg_91d025"
+            class="_msg_ca8db5"
           >
             Resistance is futile.
           </li>
@@ -309,29 +309,29 @@ exports[`FlashMessage > when there is an array message > when there is a header 
   </body>,
   "container": <div>
     <div
-      class="_root_91d025"
+      class="_root_ca8db5"
       style="--text-color: #4e6d83;"
     >
       <p
-        class="_header_91d025"
+        class="_header_ca8db5"
       >
         We are the Borg.
       </p>
       <ul
-        class="_list_91d025"
+        class="_list_ca8db5"
       >
         <li
-          class="_msg_91d025"
+          class="_msg_ca8db5"
         >
           You will be assimilated.
         </li>
         <li
-          class="_msg_91d025"
+          class="_msg_ca8db5"
         >
           Your biological and technological distinctiveness will be added to our own.
         </li>
         <li
-          class="_msg_91d025"
+          class="_msg_ca8db5"
         >
           Resistance is futile.
         </li>

--- a/src/components/gameCreateForm/__snapshots__/gameCreateForm.test.tsx.snap
+++ b/src/components/gameCreateForm/__snapshots__/gameCreateForm.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_83bedb"
+        class="_root_92a111"
         style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
       >
         <h3
           aria-controls="gameCreateForm"
           aria-expanded="false"
-          class="_toggle_83bedb"
+          class="_toggle_92a111"
           role="button"
         >
           Create Game...
@@ -27,15 +27,15 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
             style="display: none;"
           >
             <form
-              class="_form_83bedb"
+              class="_form_92a111"
               data-testid="gameCreateFormForm"
             >
               <fieldset
-                class="_fieldset_83bedb"
+                class="_fieldset_92a111"
               >
                 <input
                   aria-label="Name"
-                  class="_input_83bedb"
+                  class="_input_92a111"
                   data-testid="createNameField"
                   disabled=""
                   name="name"
@@ -46,11 +46,11 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
                 />
               </fieldset>
               <fieldset
-                class="_fieldset_83bedb"
+                class="_fieldset_92a111"
               >
                 <input
                   aria-label="Description"
-                  class="_input_83bedb"
+                  class="_input_92a111"
                   data-testid="createDescriptionField"
                   disabled=""
                   name="description"
@@ -59,7 +59,7 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
                 />
               </fieldset>
               <button
-                class="_button_83bedb"
+                class="_button_92a111"
                 data-testid="createGameSubmit"
                 disabled=""
                 type="submit"
@@ -74,13 +74,13 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_83bedb"
+      class="_root_92a111"
       style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
     >
       <h3
         aria-controls="gameCreateForm"
         aria-expanded="false"
-        class="_toggle_83bedb"
+        class="_toggle_92a111"
         role="button"
       >
         Create Game...
@@ -95,15 +95,15 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
           style="display: none;"
         >
           <form
-            class="_form_83bedb"
+            class="_form_92a111"
             data-testid="gameCreateFormForm"
           >
             <fieldset
-              class="_fieldset_83bedb"
+              class="_fieldset_92a111"
             >
               <input
                 aria-label="Name"
-                class="_input_83bedb"
+                class="_input_92a111"
                 data-testid="createNameField"
                 disabled=""
                 name="name"
@@ -114,11 +114,11 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
               />
             </fieldset>
             <fieldset
-              class="_fieldset_83bedb"
+              class="_fieldset_92a111"
             >
               <input
                 aria-label="Description"
-                class="_input_83bedb"
+                class="_input_92a111"
                 data-testid="createDescriptionField"
                 disabled=""
                 name="description"
@@ -127,7 +127,7 @@ exports[`<GameCreateForm /> > when disabled > matches snapshot 1`] = `
               />
             </fieldset>
             <button
-              class="_button_83bedb"
+              class="_button_92a111"
               data-testid="createGameSubmit"
               disabled=""
               type="submit"
@@ -199,13 +199,13 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_83bedb"
+        class="_root_92a111"
         style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
       >
         <h3
           aria-controls="gameCreateForm"
           aria-expanded="false"
-          class="_toggle_83bedb"
+          class="_toggle_92a111"
           role="button"
         >
           Create Game...
@@ -220,15 +220,15 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
             style="display: none;"
           >
             <form
-              class="_form_83bedb"
+              class="_form_92a111"
               data-testid="gameCreateFormForm"
             >
               <fieldset
-                class="_fieldset_83bedb"
+                class="_fieldset_92a111"
               >
                 <input
                   aria-label="Name"
-                  class="_input_83bedb"
+                  class="_input_92a111"
                   data-testid="createNameField"
                   name="name"
                   pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
@@ -238,11 +238,11 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
                 />
               </fieldset>
               <fieldset
-                class="_fieldset_83bedb"
+                class="_fieldset_92a111"
               >
                 <input
                   aria-label="Description"
-                  class="_input_83bedb"
+                  class="_input_92a111"
                   data-testid="createDescriptionField"
                   name="description"
                   placeholder="Description"
@@ -250,7 +250,7 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
                 />
               </fieldset>
               <button
-                class="_button_83bedb"
+                class="_button_92a111"
                 data-testid="createGameSubmit"
                 type="submit"
               >
@@ -264,13 +264,13 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_83bedb"
+      class="_root_92a111"
       style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
     >
       <h3
         aria-controls="gameCreateForm"
         aria-expanded="false"
-        class="_toggle_83bedb"
+        class="_toggle_92a111"
         role="button"
       >
         Create Game...
@@ -285,15 +285,15 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
           style="display: none;"
         >
           <form
-            class="_form_83bedb"
+            class="_form_92a111"
             data-testid="gameCreateFormForm"
           >
             <fieldset
-              class="_fieldset_83bedb"
+              class="_fieldset_92a111"
             >
               <input
                 aria-label="Name"
-                class="_input_83bedb"
+                class="_input_92a111"
                 data-testid="createNameField"
                 name="name"
                 pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
@@ -303,11 +303,11 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
               />
             </fieldset>
             <fieldset
-              class="_fieldset_83bedb"
+              class="_fieldset_92a111"
             >
               <input
                 aria-label="Description"
-                class="_input_83bedb"
+                class="_input_92a111"
                 data-testid="createDescriptionField"
                 name="description"
                 placeholder="Description"
@@ -315,7 +315,7 @@ exports[`<GameCreateForm /> > when enabled > matches snapshot 1`] = `
               />
             </fieldset>
             <button
-              class="_button_83bedb"
+              class="_button_92a111"
               data-testid="createGameSubmit"
               type="submit"
             >

--- a/src/components/gameForm/__snapshots__/gameForm.test.tsx.snap
+++ b/src/components/gameForm/__snapshots__/gameForm.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`GameForm > create form matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_31bf4a"
+        class="_root_4fb064"
       >
         <h3
-          class="_header_31bf4a"
+          class="_header_4fb064"
         >
           Create Game
         </h3>
@@ -18,14 +18,14 @@ exports[`GameForm > create form matches snapshot 1`] = `
           style="--button-background-color: #00a323; --button-text-color: #fff; --button-hover-color: #00921f; --button-border-color: #00821c;"
         >
           <fieldset
-            class="_fieldset_31bf4a"
+            class="_fieldset_4fb064"
           >
             <label
-              class="_label_31bf4a"
+              class="_label_4fb064"
             >
               Name
               <input
-                class="_input_31bf4a"
+                class="_input_4fb064"
                 name="name"
                 pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
                 placeholder="Name"
@@ -35,21 +35,21 @@ exports[`GameForm > create form matches snapshot 1`] = `
             </label>
           </fieldset>
           <fieldset
-            class="_fieldset_31bf4a"
+            class="_fieldset_4fb064"
           >
             <label
-              class="_label_31bf4a"
+              class="_label_4fb064"
             >
               Description
               <input
-                class="_input_31bf4a"
+                class="_input_4fb064"
                 name="description"
                 placeholder="Description"
               />
             </label>
           </fieldset>
           <button
-            class="_submit_31bf4a"
+            class="_submit_4fb064"
             data-testid="gameFormSubmit"
             type="submit"
           >
@@ -61,10 +61,10 @@ exports[`GameForm > create form matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_31bf4a"
+      class="_root_4fb064"
     >
       <h3
-        class="_header_31bf4a"
+        class="_header_4fb064"
       >
         Create Game
       </h3>
@@ -73,14 +73,14 @@ exports[`GameForm > create form matches snapshot 1`] = `
         style="--button-background-color: #00a323; --button-text-color: #fff; --button-hover-color: #00921f; --button-border-color: #00821c;"
       >
         <fieldset
-          class="_fieldset_31bf4a"
+          class="_fieldset_4fb064"
         >
           <label
-            class="_label_31bf4a"
+            class="_label_4fb064"
           >
             Name
             <input
-              class="_input_31bf4a"
+              class="_input_4fb064"
               name="name"
               pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
               placeholder="Name"
@@ -90,21 +90,21 @@ exports[`GameForm > create form matches snapshot 1`] = `
           </label>
         </fieldset>
         <fieldset
-          class="_fieldset_31bf4a"
+          class="_fieldset_4fb064"
         >
           <label
-            class="_label_31bf4a"
+            class="_label_4fb064"
           >
             Description
             <input
-              class="_input_31bf4a"
+              class="_input_4fb064"
               name="description"
               placeholder="Description"
             />
           </label>
         </fieldset>
         <button
-          class="_submit_31bf4a"
+          class="_submit_4fb064"
           data-testid="gameFormSubmit"
           type="submit"
         >
@@ -173,10 +173,10 @@ exports[`GameForm > edit form matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_31bf4a"
+        class="_root_4fb064"
       >
         <h3
-          class="_header_31bf4a"
+          class="_header_4fb064"
         >
           Update Game
         </h3>
@@ -185,14 +185,14 @@ exports[`GameForm > edit form matches snapshot 1`] = `
           style="--button-background-color: #00a323; --button-text-color: #fff; --button-hover-color: #00921f; --button-border-color: #00821c;"
         >
           <fieldset
-            class="_fieldset_31bf4a"
+            class="_fieldset_4fb064"
           >
             <label
-              class="_label_31bf4a"
+              class="_label_4fb064"
             >
               Name
               <input
-                class="_input_31bf4a"
+                class="_input_4fb064"
                 name="name"
                 pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
                 placeholder="Name"
@@ -203,14 +203,14 @@ exports[`GameForm > edit form matches snapshot 1`] = `
             </label>
           </fieldset>
           <fieldset
-            class="_fieldset_31bf4a"
+            class="_fieldset_4fb064"
           >
             <label
-              class="_label_31bf4a"
+              class="_label_4fb064"
             >
               Description
               <input
-                class="_input_31bf4a"
+                class="_input_4fb064"
                 name="description"
                 placeholder="Description"
                 value="This game has a description"
@@ -218,7 +218,7 @@ exports[`GameForm > edit form matches snapshot 1`] = `
             </label>
           </fieldset>
           <button
-            class="_submit_31bf4a"
+            class="_submit_4fb064"
             data-testid="gameFormSubmit"
             type="submit"
           >
@@ -230,10 +230,10 @@ exports[`GameForm > edit form matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_31bf4a"
+      class="_root_4fb064"
     >
       <h3
-        class="_header_31bf4a"
+        class="_header_4fb064"
       >
         Update Game
       </h3>
@@ -242,14 +242,14 @@ exports[`GameForm > edit form matches snapshot 1`] = `
         style="--button-background-color: #00a323; --button-text-color: #fff; --button-hover-color: #00921f; --button-border-color: #00821c;"
       >
         <fieldset
-          class="_fieldset_31bf4a"
+          class="_fieldset_4fb064"
         >
           <label
-            class="_label_31bf4a"
+            class="_label_4fb064"
           >
             Name
             <input
-              class="_input_31bf4a"
+              class="_input_4fb064"
               name="name"
               pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
               placeholder="Name"
@@ -260,14 +260,14 @@ exports[`GameForm > edit form matches snapshot 1`] = `
           </label>
         </fieldset>
         <fieldset
-          class="_fieldset_31bf4a"
+          class="_fieldset_4fb064"
         >
           <label
-            class="_label_31bf4a"
+            class="_label_4fb064"
           >
             Description
             <input
-              class="_input_31bf4a"
+              class="_input_4fb064"
               name="description"
               placeholder="Description"
               value="This game has a description"
@@ -275,7 +275,7 @@ exports[`GameForm > edit form matches snapshot 1`] = `
           </label>
         </fieldset>
         <button
-          class="_submit_31bf4a"
+          class="_submit_4fb064"
           data-testid="gameFormSubmit"
           type="submit"
         >

--- a/src/components/gameLineItem/__snapshots__/gameLineItem.test.tsx.snap
+++ b/src/components/gameLineItem/__snapshots__/gameLineItem.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`GameLineItem > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_fd0dcf"
+        class="_root_124268"
       >
         <div
-          class="_summary_fd0dcf"
+          class="_summary_124268"
         >
           <span>
             <button
-              class="_icon_fd0dcf"
+              class="_icon_124268"
               data-testid="destroyGame4"
             >
               <svg
@@ -31,7 +31,7 @@ exports[`GameLineItem > matches snapshot 1`] = `
               </svg>
             </button>
             <button
-              class="_icon_fd0dcf"
+              class="_icon_124268"
               data-testid="editGame4"
             >
               <svg
@@ -52,7 +52,7 @@ exports[`GameLineItem > matches snapshot 1`] = `
           <h3
             aria-controls="game4Details"
             aria-expanded="false"
-            class="_header_fd0dcf"
+            class="_header_124268"
             role="button"
           >
             De finibus bonorum et malorum
@@ -68,7 +68,7 @@ exports[`GameLineItem > matches snapshot 1`] = `
             style="display: none;"
           >
             <p
-              class="_description_fd0dcf"
+              class="_description_124268"
             >
               This is my game
             </p>
@@ -79,14 +79,14 @@ exports[`GameLineItem > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_fd0dcf"
+      class="_root_124268"
     >
       <div
-        class="_summary_fd0dcf"
+        class="_summary_124268"
       >
         <span>
           <button
-            class="_icon_fd0dcf"
+            class="_icon_124268"
             data-testid="destroyGame4"
           >
             <svg
@@ -104,7 +104,7 @@ exports[`GameLineItem > matches snapshot 1`] = `
             </svg>
           </button>
           <button
-            class="_icon_fd0dcf"
+            class="_icon_124268"
             data-testid="editGame4"
           >
             <svg
@@ -125,7 +125,7 @@ exports[`GameLineItem > matches snapshot 1`] = `
         <h3
           aria-controls="game4Details"
           aria-expanded="false"
-          class="_header_fd0dcf"
+          class="_header_124268"
           role="button"
         >
           De finibus bonorum et malorum
@@ -141,7 +141,7 @@ exports[`GameLineItem > matches snapshot 1`] = `
           style="display: none;"
         >
           <p
-            class="_description_fd0dcf"
+            class="_description_124268"
           >
             This is my game
           </p>

--- a/src/components/modal/__snapshots__/modal.test.tsx.snap
+++ b/src/components/modal/__snapshots__/modal.test.tsx.snap
@@ -6,20 +6,20 @@ exports[`Modal > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_753dd0"
+        class="_root_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           >
             <div
-              class="_root_31bf4a"
+              class="_root_4fb064"
             >
               <h3
-                class="_header_31bf4a"
+                class="_header_4fb064"
               >
                 Create Game
               </h3>
@@ -28,14 +28,14 @@ exports[`Modal > matches snapshot 1`] = `
                 style="--button-background-color: #ffbf00; --button-text-color: #4c3900; --button-hover-color: #e5ab00; --button-border-color: #cc9800;"
               >
                 <fieldset
-                  class="_fieldset_31bf4a"
+                  class="_fieldset_4fb064"
                 >
                   <label
-                    class="_label_31bf4a"
+                    class="_label_4fb064"
                   >
                     Name
                     <input
-                      class="_input_31bf4a"
+                      class="_input_4fb064"
                       name="name"
                       pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
                       placeholder="Name"
@@ -45,21 +45,21 @@ exports[`Modal > matches snapshot 1`] = `
                   </label>
                 </fieldset>
                 <fieldset
-                  class="_fieldset_31bf4a"
+                  class="_fieldset_4fb064"
                 >
                   <label
-                    class="_label_31bf4a"
+                    class="_label_4fb064"
                   >
                     Description
                     <input
-                      class="_input_31bf4a"
+                      class="_input_4fb064"
                       name="description"
                       placeholder="Description"
                     />
                   </label>
                 </fieldset>
                 <button
-                  class="_submit_31bf4a"
+                  class="_submit_4fb064"
                   data-testid="gameFormSubmit"
                   type="submit"
                 >
@@ -74,20 +74,20 @@ exports[`Modal > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_753dd0"
+      class="_root_c33b14"
       data-testid="modal"
     >
       <div
-        class="_container_753dd0"
+        class="_container_c33b14"
       >
         <div
-          class="_content_753dd0"
+          class="_content_c33b14"
         >
           <div
-            class="_root_31bf4a"
+            class="_root_4fb064"
           >
             <h3
-              class="_header_31bf4a"
+              class="_header_4fb064"
             >
               Create Game
             </h3>
@@ -96,14 +96,14 @@ exports[`Modal > matches snapshot 1`] = `
               style="--button-background-color: #ffbf00; --button-text-color: #4c3900; --button-hover-color: #e5ab00; --button-border-color: #cc9800;"
             >
               <fieldset
-                class="_fieldset_31bf4a"
+                class="_fieldset_4fb064"
               >
                 <label
-                  class="_label_31bf4a"
+                  class="_label_4fb064"
                 >
                   Name
                   <input
-                    class="_input_31bf4a"
+                    class="_input_4fb064"
                     name="name"
                     pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
                     placeholder="Name"
@@ -113,21 +113,21 @@ exports[`Modal > matches snapshot 1`] = `
                 </label>
               </fieldset>
               <fieldset
-                class="_fieldset_31bf4a"
+                class="_fieldset_4fb064"
               >
                 <label
-                  class="_label_31bf4a"
+                  class="_label_4fb064"
                 >
                   Description
                   <input
-                    class="_input_31bf4a"
+                    class="_input_4fb064"
                     name="description"
                     placeholder="Description"
                   />
                 </label>
               </fieldset>
               <button
-                class="_submit_31bf4a"
+                class="_submit_4fb064"
                 data-testid="gameFormSubmit"
                 type="submit"
               >

--- a/src/components/navigationCard/__snapshots__/navigationCard.test.tsx.snap
+++ b/src/components/navigationCard/__snapshots__/navigationCard.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`NavigationCard component > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <a
-        class="_root_396ea1"
+        class="_root_c08070"
         href="/"
         style="--background-color: #2274a5; --hover-color: #1e6894; --text-color: #fff;"
       >
@@ -16,7 +16,7 @@ exports[`NavigationCard component > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <a
-      class="_root_396ea1"
+      class="_root_c08070"
       href="/"
       style="--background-color: #2274a5; --hover-color: #1e6894; --text-color: #fff;"
     >

--- a/src/components/navigationMosaic/__snapshots__/navigationMosaic.test.tsx.snap
+++ b/src/components/navigationMosaic/__snapshots__/navigationMosaic.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_dcf87f"
+        class="_root_55a329"
       >
         <div
-          class="_card_dcf87f"
+          class="_card_55a329"
         >
           <a
-            class="_root_396ea1"
+            class="_root_c08070"
             href="/yellow"
             style="--background-color: #ffbf00; --hover-color: #e5ab00; --text-color: #4c3900;"
           >
@@ -20,10 +20,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
           </a>
         </div>
         <div
-          class="_card_dcf87f"
+          class="_card_55a329"
         >
           <a
-            class="_root_396ea1"
+            class="_root_c08070"
             href="/pink"
             style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
           >
@@ -31,10 +31,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
           </a>
         </div>
         <div
-          class="_card_dcf87f"
+          class="_card_55a329"
         >
           <a
-            class="_root_396ea1"
+            class="_root_c08070"
             href="/blue"
             style="--background-color: #2274a5; --hover-color: #1e6894; --text-color: #fff;"
           >
@@ -42,10 +42,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
           </a>
         </div>
         <div
-          class="_card_dcf87f"
+          class="_card_55a329"
         >
           <a
-            class="_root_396ea1"
+            class="_root_c08070"
             href="/green"
             style="--background-color: #00a323; --hover-color: #00921f; --text-color: #fff;"
           >
@@ -53,10 +53,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
           </a>
         </div>
         <div
-          class="_card_dcf87f"
+          class="_card_55a329"
         >
           <a
-            class="_root_396ea1"
+            class="_root_c08070"
             href="/aqua"
             style="--background-color: #20e2e9; --hover-color: #11cbd1; --text-color: #094345;"
           >
@@ -68,13 +68,13 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_dcf87f"
+      class="_root_55a329"
     >
       <div
-        class="_card_dcf87f"
+        class="_card_55a329"
       >
         <a
-          class="_root_396ea1"
+          class="_root_c08070"
           href="/yellow"
           style="--background-color: #ffbf00; --hover-color: #e5ab00; --text-color: #4c3900;"
         >
@@ -82,10 +82,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
         </a>
       </div>
       <div
-        class="_card_dcf87f"
+        class="_card_55a329"
       >
         <a
-          class="_root_396ea1"
+          class="_root_c08070"
           href="/pink"
           style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
         >
@@ -93,10 +93,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
         </a>
       </div>
       <div
-        class="_card_dcf87f"
+        class="_card_55a329"
       >
         <a
-          class="_root_396ea1"
+          class="_root_c08070"
           href="/blue"
           style="--background-color: #2274a5; --hover-color: #1e6894; --text-color: #fff;"
         >
@@ -104,10 +104,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
         </a>
       </div>
       <div
-        class="_card_dcf87f"
+        class="_card_55a329"
       >
         <a
-          class="_root_396ea1"
+          class="_root_c08070"
           href="/green"
           style="--background-color: #00a323; --hover-color: #00921f; --text-color: #fff;"
         >
@@ -115,10 +115,10 @@ exports[`NavigationMosaic component > matches snapshot 1`] = `
         </a>
       </div>
       <div
-        class="_card_dcf87f"
+        class="_card_55a329"
       >
         <a
-          class="_root_396ea1"
+          class="_root_c08070"
           href="/aqua"
           style="--background-color: #20e2e9; --hover-color: #11cbd1; --text-color: #094345;"
         >

--- a/src/components/styledSelect/__snapshots__/styledSelect.test.tsx.snap
+++ b/src/components/styledSelect/__snapshots__/styledSelect.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
   "baseElement": <body>
     <div>
       <div
-        class="_root_0a8ecf"
+        class="_root_706192"
         data-testid="styledSelect"
         style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
       >
@@ -15,19 +15,19 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-owns="selectListbox"
-          class="_header_0a8ecf"
+          class="_header_706192"
           role="combobox"
         >
           <input
             aria-label="Add or Select Option"
-            class="_headerText_0a8ecf"
+            class="_headerText_706192"
           />
           <button
-            class="_trigger_0a8ecf"
+            class="_trigger_706192"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+              class="svg-inline--fa fa-angle-down _fa_706192"
               data-icon="angle-down"
               data-prefix="fas"
               role="img"
@@ -41,27 +41,27 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
           </button>
         </div>
         <ul
-          class="_dropdown_0a8ecf _hidden_0a8ecf"
+          class="_dropdown_706192 _hidden_706192"
           id="selectListbox"
           role="listbox"
         >
           <li
             aria-selected="false"
-            class="_root_b75fe4"
+            class="_root_6af4e6"
             data-option-value="32"
             role="option"
             tabindex="0"
           />
           <li
             aria-selected="true"
-            class="_root_b75fe4"
+            class="_root_6af4e6"
             data-option-value="51"
             role="option"
             tabindex="0"
           />
           <li
             aria-selected="false"
-            class="_root_b75fe4"
+            class="_root_6af4e6"
             data-option-value="77"
             role="option"
             tabindex="0"
@@ -72,7 +72,7 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
   </body>,
   "container": <div>
     <div
-      class="_root_0a8ecf"
+      class="_root_706192"
       data-testid="styledSelect"
       style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
     >
@@ -81,19 +81,19 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-owns="selectListbox"
-        class="_header_0a8ecf"
+        class="_header_706192"
         role="combobox"
       >
         <input
           aria-label="Add or Select Option"
-          class="_headerText_0a8ecf"
+          class="_headerText_706192"
         />
         <button
-          class="_trigger_0a8ecf"
+          class="_trigger_706192"
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+            class="svg-inline--fa fa-angle-down _fa_706192"
             data-icon="angle-down"
             data-prefix="fas"
             role="img"
@@ -107,27 +107,27 @@ exports[`StyledSelect > when a default option is given > matches snapshot 1`] = 
         </button>
       </div>
       <ul
-        class="_dropdown_0a8ecf _hidden_0a8ecf"
+        class="_dropdown_706192 _hidden_706192"
         id="selectListbox"
         role="listbox"
       >
         <li
           aria-selected="false"
-          class="_root_b75fe4"
+          class="_root_6af4e6"
           data-option-value="32"
           role="option"
           tabindex="0"
         />
         <li
           aria-selected="true"
-          class="_root_b75fe4"
+          class="_root_6af4e6"
           data-option-value="51"
           role="option"
           tabindex="0"
         />
         <li
           aria-selected="false"
-          class="_root_b75fe4"
+          class="_root_6af4e6"
           data-option-value="77"
           role="option"
           tabindex="0"
@@ -195,7 +195,7 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_0a8ecf"
+        class="_root_706192"
         data-testid="styledSelect"
         style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
       >
@@ -204,19 +204,19 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-owns="selectListbox"
-          class="_header_0a8ecf"
+          class="_header_706192"
           role="combobox"
         >
           <input
             aria-label="Add or Select Option"
-            class="_headerText_0a8ecf"
+            class="_headerText_706192"
           />
           <button
-            class="_trigger_0a8ecf"
+            class="_trigger_706192"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+              class="svg-inline--fa fa-angle-down _fa_706192"
               data-icon="angle-down"
               data-prefix="fas"
               role="img"
@@ -230,7 +230,7 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
           </button>
         </div>
         <ul
-          class="_dropdown_0a8ecf _hidden_0a8ecf"
+          class="_dropdown_706192 _hidden_706192"
           id="selectListbox"
           role="listbox"
         />
@@ -239,7 +239,7 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_0a8ecf"
+      class="_root_706192"
       data-testid="styledSelect"
       style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
     >
@@ -248,19 +248,19 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-owns="selectListbox"
-        class="_header_0a8ecf"
+        class="_header_706192"
         role="combobox"
       >
         <input
           aria-label="Add or Select Option"
-          class="_headerText_0a8ecf"
+          class="_headerText_706192"
         />
         <button
-          class="_trigger_0a8ecf"
+          class="_trigger_706192"
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+            class="svg-inline--fa fa-angle-down _fa_706192"
             data-icon="angle-down"
             data-prefix="fas"
             role="img"
@@ -274,7 +274,7 @@ exports[`StyledSelect > when there are no options > matches snapshot 1`] = `
         </button>
       </div>
       <ul
-        class="_dropdown_0a8ecf _hidden_0a8ecf"
+        class="_dropdown_706192 _hidden_706192"
         id="selectListbox"
         role="listbox"
       />
@@ -340,7 +340,7 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_0a8ecf"
+        class="_root_706192"
         data-testid="styledSelect"
         style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
       >
@@ -349,19 +349,19 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-owns="selectListbox"
-          class="_header_0a8ecf"
+          class="_header_706192"
           role="combobox"
         >
           <input
             aria-label="Add or Select Option"
-            class="_headerText_0a8ecf"
+            class="_headerText_706192"
           />
           <button
-            class="_trigger_0a8ecf"
+            class="_trigger_706192"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+              class="svg-inline--fa fa-angle-down _fa_706192"
               data-icon="angle-down"
               data-prefix="fas"
               role="img"
@@ -375,27 +375,27 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
           </button>
         </div>
         <ul
-          class="_dropdown_0a8ecf _hidden_0a8ecf"
+          class="_dropdown_706192 _hidden_706192"
           id="selectListbox"
           role="listbox"
         >
           <li
             aria-selected="false"
-            class="_root_b75fe4"
+            class="_root_6af4e6"
             data-option-value="32"
             role="option"
             tabindex="0"
           />
           <li
             aria-selected="false"
-            class="_root_b75fe4"
+            class="_root_6af4e6"
             data-option-value="51"
             role="option"
             tabindex="0"
           />
           <li
             aria-selected="false"
-            class="_root_b75fe4"
+            class="_root_6af4e6"
             data-option-value="77"
             role="option"
             tabindex="0"
@@ -406,7 +406,7 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_0a8ecf"
+      class="_root_706192"
       data-testid="styledSelect"
       style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
     >
@@ -415,19 +415,19 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-owns="selectListbox"
-        class="_header_0a8ecf"
+        class="_header_706192"
         role="combobox"
       >
         <input
           aria-label="Add or Select Option"
-          class="_headerText_0a8ecf"
+          class="_headerText_706192"
         />
         <button
-          class="_trigger_0a8ecf"
+          class="_trigger_706192"
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+            class="svg-inline--fa fa-angle-down _fa_706192"
             data-icon="angle-down"
             data-prefix="fas"
             role="img"
@@ -441,27 +441,27 @@ exports[`StyledSelect > when there are options > matches snapshot 1`] = `
         </button>
       </div>
       <ul
-        class="_dropdown_0a8ecf _hidden_0a8ecf"
+        class="_dropdown_706192 _hidden_706192"
         id="selectListbox"
         role="listbox"
       >
         <li
           aria-selected="false"
-          class="_root_b75fe4"
+          class="_root_6af4e6"
           data-option-value="32"
           role="option"
           tabindex="0"
         />
         <li
           aria-selected="false"
-          class="_root_b75fe4"
+          class="_root_6af4e6"
           data-option-value="51"
           role="option"
           tabindex="0"
         />
         <li
           aria-selected="false"
-          class="_root_b75fe4"
+          class="_root_6af4e6"
           data-option-value="77"
           role="option"
           tabindex="0"

--- a/src/components/styledSelectOption/__snapshots__/styledSelectOption.test.tsx.snap
+++ b/src/components/styledSelectOption/__snapshots__/styledSelectOption.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`StyledSelectOption > displaying the option > when not selected > when t
     <div>
       <li
         aria-selected="false"
-        class="_root_b75fe4"
+        class="_root_6af4e6"
         data-option-value="De Finibus"
         role="option"
         tabindex="0"
@@ -17,7 +17,7 @@ exports[`StyledSelectOption > displaying the option > when not selected > when t
   "container": <div>
     <li
       aria-selected="false"
-      class="_root_b75fe4"
+      class="_root_6af4e6"
       data-option-value="De Finibus"
       role="option"
       tabindex="0"
@@ -84,7 +84,7 @@ exports[`StyledSelectOption > displaying the option > when not selected > when t
     <div>
       <li
         aria-selected="false"
-        class="_root_b75fe4"
+        class="_root_6af4e6"
         data-option-value="22"
         role="option"
         tabindex="0"
@@ -94,7 +94,7 @@ exports[`StyledSelectOption > displaying the option > when not selected > when t
   "container": <div>
     <li
       aria-selected="false"
-      class="_root_b75fe4"
+      class="_root_6af4e6"
       data-option-value="22"
       role="option"
       tabindex="0"
@@ -161,7 +161,7 @@ exports[`StyledSelectOption > displaying the option > when selected > matches sn
     <div>
       <li
         aria-selected="true"
-        class="_root_b75fe4"
+        class="_root_6af4e6"
         data-option-value="1"
         role="option"
         tabindex="0"
@@ -171,7 +171,7 @@ exports[`StyledSelectOption > displaying the option > when selected > matches sn
   "container": <div>
     <li
       aria-selected="true"
-      class="_root_b75fe4"
+      class="_root_6af4e6"
       data-option-value="1"
       role="option"
       tabindex="0"

--- a/src/components/userInfo/__snapshots__/userInfo.test.tsx.snap
+++ b/src/components/userInfo/__snapshots__/userInfo.test.tsx.snap
@@ -6,18 +6,18 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <span
-        class="_root_d263fb"
+        class="_root_658745"
       >
         <div
-          class="_main_d263fb"
+          class="_main_658745"
         >
           <div
-            class="_button_d263fb"
+            class="_button_658745"
             role="button"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-bars _hamburger_d263fb"
+              class="svg-inline--fa fa-bars _hamburger_658745"
               data-icon="bars"
               data-prefix="fas"
               role="img"
@@ -29,29 +29,29 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
               />
             </svg>
             <span
-              class="_info_d263fb"
+              class="_info_658745"
             >
               <p
-                class="_name_d263fb"
+                class="_name_658745"
               >
                 Edna St. Vincent Millay
               </p>
               <p
-                class="_email_d263fb"
+                class="_email_658745"
               >
                 edna@gmail.com
               </p>
             </span>
             <img
               alt="User profile image"
-              class="_img_d263fb"
+              class="_img_658745"
               referrerpolicy="no-referrer"
               src="/src/support/testProfileImg.png"
             />
           </div>
         </div>
         <menu
-          class="_dropdown_d263fb"
+          class="_dropdown_658745"
         >
           <div
             role="button"
@@ -70,7 +70,7 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
               />
             </svg>
             <p
-              class="_signOutText_d263fb"
+              class="_signOutText_658745"
             >
               Sign Out
             </p>
@@ -81,18 +81,18 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
   </body>,
   "container": <div>
     <span
-      class="_root_d263fb"
+      class="_root_658745"
     >
       <div
-        class="_main_d263fb"
+        class="_main_658745"
       >
         <div
-          class="_button_d263fb"
+          class="_button_658745"
           role="button"
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-bars _hamburger_d263fb"
+            class="svg-inline--fa fa-bars _hamburger_658745"
             data-icon="bars"
             data-prefix="fas"
             role="img"
@@ -104,29 +104,29 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
             />
           </svg>
           <span
-            class="_info_d263fb"
+            class="_info_658745"
           >
             <p
-              class="_name_d263fb"
+              class="_name_658745"
             >
               Edna St. Vincent Millay
             </p>
             <p
-              class="_email_d263fb"
+              class="_email_658745"
             >
               edna@gmail.com
             </p>
           </span>
           <img
             alt="User profile image"
-            class="_img_d263fb"
+            class="_img_658745"
             referrerpolicy="no-referrer"
             src="/src/support/testProfileImg.png"
           />
         </div>
       </div>
       <menu
-        class="_dropdown_d263fb"
+        class="_dropdown_658745"
       >
         <div
           role="button"
@@ -145,7 +145,7 @@ exports[`<UserInfo /> > UserInfo matches snapshot 1`] = `
             />
           </svg>
           <p
-            class="_signOutText_d263fb"
+            class="_signOutText_658745"
           >
             Sign Out
           </p>

--- a/src/components/wishList/__snapshots__/wishList.test.tsx.snap
+++ b/src/components/wishList/__snapshots__/wishList.test.tsx.snap
@@ -6,25 +6,25 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
   "baseElement": <body>
     <div>
       <div
-        class="_root_ec6c68"
+        class="_root_015e9f"
         style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
       >
         <div
           aria-controls="list3Details"
           aria-expanded="false"
-          class="_trigger_ec6c68"
+          class="_trigger_015e9f"
           role="button"
         >
           <span
-            class="_icons_ec6c68"
+            class="_icons_015e9f"
           >
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="destroyWishList3"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-xmark _fa_ec6c68"
+                class="svg-inline--fa fa-xmark _fa_015e9f"
                 data-icon="xmark"
                 data-prefix="fas"
                 role="img"
@@ -37,12 +37,12 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
               </svg>
             </button>
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="editWishList3"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                 data-icon="pen-to-square"
                 data-prefix="fas"
                 role="img"
@@ -56,7 +56,7 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
             </button>
           </span>
           <h3
-            class="_title_ec6c68"
+            class="_title_015e9f"
           >
             My Wish List
           </h3>
@@ -71,19 +71,19 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
             style="display: none;"
           >
             <div
-              class="_details_ec6c68"
+              class="_details_015e9f"
             >
               <div
-                class="_root_8112da _collapsed_8112da"
+                class="_root_1a276c _collapsed_1a276c"
                 style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
               >
                 <div
-                  class="_triggerContainer_8112da"
+                  class="_triggerContainer_1a276c"
                 >
                   <button
                     aria-controls="addItemToWishList3"
                     aria-expanded="false"
-                    class="_trigger_8112da"
+                    class="_trigger_1a276c"
                   >
                     Add item to list...
                   </button>
@@ -99,14 +99,14 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                   >
                     <form
                       aria-label="Wish list item creation form"
-                      class="_form_8112da"
+                      class="_form_1a276c"
                     >
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Description
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="description"
                           placeholder="Description"
                           required=""
@@ -114,11 +114,11 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Quantity
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="numeric"
                           min="1"
                           name="quantity"
@@ -131,11 +131,11 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Unit Weight
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="decimal"
                           min="0"
                           name="unit_weight"
@@ -145,18 +145,18 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Notes
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="notes"
                           placeholder="Notes"
                           type="text"
                         />
                       </label>
                       <button
-                        class="_submit_8112da"
+                        class="_submit_1a276c"
                         type="submit"
                       >
                         Add to List
@@ -173,25 +173,25 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
   </body>,
   "container": <div>
     <div
-      class="_root_ec6c68"
+      class="_root_015e9f"
       style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
     >
       <div
         aria-controls="list3Details"
         aria-expanded="false"
-        class="_trigger_ec6c68"
+        class="_trigger_015e9f"
         role="button"
       >
         <span
-          class="_icons_ec6c68"
+          class="_icons_015e9f"
         >
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="destroyWishList3"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-xmark _fa_ec6c68"
+              class="svg-inline--fa fa-xmark _fa_015e9f"
               data-icon="xmark"
               data-prefix="fas"
               role="img"
@@ -204,12 +204,12 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
             </svg>
           </button>
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="editWishList3"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+              class="svg-inline--fa fa-pen-to-square _fa_015e9f"
               data-icon="pen-to-square"
               data-prefix="fas"
               role="img"
@@ -223,7 +223,7 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
           </button>
         </span>
         <h3
-          class="_title_ec6c68"
+          class="_title_015e9f"
         >
           My Wish List
         </h3>
@@ -238,19 +238,19 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
           style="display: none;"
         >
           <div
-            class="_details_ec6c68"
+            class="_details_015e9f"
           >
             <div
-              class="_root_8112da _collapsed_8112da"
+              class="_root_1a276c _collapsed_1a276c"
               style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
             >
               <div
-                class="_triggerContainer_8112da"
+                class="_triggerContainer_1a276c"
               >
                 <button
                   aria-controls="addItemToWishList3"
                   aria-expanded="false"
-                  class="_trigger_8112da"
+                  class="_trigger_1a276c"
                 >
                   Add item to list...
                 </button>
@@ -266,14 +266,14 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                 >
                   <form
                     aria-label="Wish list item creation form"
-                    class="_form_8112da"
+                    class="_form_1a276c"
                   >
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Description
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="description"
                         placeholder="Description"
                         required=""
@@ -281,11 +281,11 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Quantity
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="numeric"
                         min="1"
                         name="quantity"
@@ -298,11 +298,11 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Unit Weight
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="decimal"
                         min="0"
                         name="unit_weight"
@@ -312,18 +312,18 @@ exports[`WishList > displaying a list > when the list is not editable > matches 
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Notes
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="notes"
                         placeholder="Notes"
                         type="text"
                       />
                     </label>
                     <button
-                      class="_submit_8112da"
+                      class="_submit_1a276c"
                       type="submit"
                     >
                       Add to List
@@ -397,25 +397,25 @@ exports[`WishList > displaying a list > when there are list items > matches snap
   "baseElement": <body>
     <div>
       <div
-        class="_root_ec6c68"
+        class="_root_015e9f"
         style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
       >
         <div
           aria-controls="list4Details"
           aria-expanded="false"
-          class="_trigger_ec6c68"
+          class="_trigger_015e9f"
           role="button"
         >
           <span
-            class="_icons_ec6c68"
+            class="_icons_015e9f"
           >
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="destroyWishList4"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-xmark _fa_ec6c68"
+                class="svg-inline--fa fa-xmark _fa_015e9f"
                 data-icon="xmark"
                 data-prefix="fas"
                 role="img"
@@ -428,12 +428,12 @@ exports[`WishList > displaying a list > when there are list items > matches snap
               </svg>
             </button>
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="editWishList4"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                 data-icon="pen-to-square"
                 data-prefix="fas"
                 role="img"
@@ -447,7 +447,7 @@ exports[`WishList > displaying a list > when there are list items > matches snap
             </button>
           </span>
           <h3
-            class="_title_ec6c68"
+            class="_title_015e9f"
           >
             My Wish List
           </h3>
@@ -462,19 +462,19 @@ exports[`WishList > displaying a list > when there are list items > matches snap
             style="display: none;"
           >
             <div
-              class="_details_ec6c68"
+              class="_details_015e9f"
             >
               <div
-                class="_root_8112da _collapsed_8112da"
+                class="_root_1a276c _collapsed_1a276c"
                 style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
               >
                 <div
-                  class="_triggerContainer_8112da"
+                  class="_triggerContainer_1a276c"
                 >
                   <button
                     aria-controls="addItemToWishList4"
                     aria-expanded="false"
-                    class="_trigger_8112da"
+                    class="_trigger_1a276c"
                   >
                     Add item to list...
                   </button>
@@ -490,14 +490,14 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                   >
                     <form
                       aria-label="Wish list item creation form"
-                      class="_form_8112da"
+                      class="_form_1a276c"
                     >
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Description
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="description"
                           placeholder="Description"
                           required=""
@@ -505,11 +505,11 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Quantity
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="numeric"
                           min="1"
                           name="quantity"
@@ -522,11 +522,11 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Unit Weight
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="decimal"
                           min="0"
                           name="unit_weight"
@@ -536,18 +536,18 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Notes
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="notes"
                           placeholder="Notes"
                           type="text"
                         />
                       </label>
                       <button
-                        class="_submit_8112da"
+                        class="_submit_1a276c"
                         type="submit"
                       >
                         Add to List
@@ -557,27 +557,27 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                 </div>
               </div>
               <div
-                class="_root_54cfce"
+                class="_root_8f9b4a"
                 style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
               >
                 <div
                   aria-controls="wishListItem1Details"
                   aria-expanded="false"
-                  class="_trigger_54cfce"
+                  class="_trigger_8f9b4a"
                 >
                   <span
-                    class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                    class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                   >
                     <span
-                      class="_editIcons_54cfce"
+                      class="_editIcons_8f9b4a"
                     >
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="destroyWishListItem1"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-xmark _fa_54cfce"
+                          class="svg-inline--fa fa-xmark _fa_8f9b4a"
                           data-icon="xmark"
                           data-prefix="fas"
                           role="img"
@@ -590,12 +590,12 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                         </svg>
                       </button>
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="editWishListItem1"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                          class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                           data-icon="pen-to-square"
                           data-prefix="fas"
                           role="img"
@@ -609,21 +609,21 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       </button>
                     </span>
                     <h3
-                      class="_description_54cfce"
+                      class="_description_8f9b4a"
                     >
                       List Item 1
                     </h3>
                   </span>
                   <span
-                    class="_quantityEditable_54cfce"
+                    class="_quantityEditable_8f9b4a"
                   >
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="incrementWishListItem1"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                        class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                         data-icon="chevron-up"
                         data-prefix="fas"
                         role="img"
@@ -636,17 +636,17 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       </svg>
                     </button>
                     <span
-                      class="_quantityContent_54cfce"
+                      class="_quantityContent_8f9b4a"
                     >
                       4
                     </span>
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="decrementWishListItem1"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                        class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                         data-icon="chevron-down"
                         data-prefix="fas"
                         role="img"
@@ -670,25 +670,25 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                     style="display: none;"
                   >
                     <div
-                      class="_details_54cfce"
+                      class="_details_8f9b4a"
                     >
                       <h4
-                        class="_label_54cfce"
+                        class="_label_8f9b4a"
                       >
                         Unit Weight:
                       </h4>
                       <p
-                        class="_value_54cfce"
+                        class="_value_8f9b4a"
                       >
                         -
                       </p>
                       <h4
-                        class="_label_54cfce"
+                        class="_label_8f9b4a"
                       >
                         Notes:
                       </h4>
                       <p
-                        class="_value_54cfce"
+                        class="_value_8f9b4a"
                       >
                         -
                       </p>
@@ -697,27 +697,27 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                 </div>
               </div>
               <div
-                class="_root_54cfce"
+                class="_root_8f9b4a"
                 style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
               >
                 <div
                   aria-controls="wishListItem2Details"
                   aria-expanded="false"
-                  class="_trigger_54cfce"
+                  class="_trigger_8f9b4a"
                 >
                   <span
-                    class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                    class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                   >
                     <span
-                      class="_editIcons_54cfce"
+                      class="_editIcons_8f9b4a"
                     >
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="destroyWishListItem2"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-xmark _fa_54cfce"
+                          class="svg-inline--fa fa-xmark _fa_8f9b4a"
                           data-icon="xmark"
                           data-prefix="fas"
                           role="img"
@@ -730,12 +730,12 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                         </svg>
                       </button>
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="editWishListItem2"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                          class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                           data-icon="pen-to-square"
                           data-prefix="fas"
                           role="img"
@@ -749,21 +749,21 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       </button>
                     </span>
                     <h3
-                      class="_description_54cfce"
+                      class="_description_8f9b4a"
                     >
                       List Item 2
                     </h3>
                   </span>
                   <span
-                    class="_quantityEditable_54cfce"
+                    class="_quantityEditable_8f9b4a"
                   >
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="incrementWishListItem2"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                        class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                         data-icon="chevron-up"
                         data-prefix="fas"
                         role="img"
@@ -776,17 +776,17 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       </svg>
                     </button>
                     <span
-                      class="_quantityContent_54cfce"
+                      class="_quantityContent_8f9b4a"
                     >
                       1
                     </span>
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="decrementWishListItem2"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                        class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                         data-icon="chevron-down"
                         data-prefix="fas"
                         role="img"
@@ -810,25 +810,25 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                     style="display: none;"
                   >
                     <div
-                      class="_details_54cfce"
+                      class="_details_8f9b4a"
                     >
                       <h4
-                        class="_label_54cfce"
+                        class="_label_8f9b4a"
                       >
                         Unit Weight:
                       </h4>
                       <p
-                        class="_value_54cfce"
+                        class="_value_8f9b4a"
                       >
                         -
                       </p>
                       <h4
-                        class="_label_54cfce"
+                        class="_label_8f9b4a"
                       >
                         Notes:
                       </h4>
                       <p
-                        class="_value_54cfce"
+                        class="_value_8f9b4a"
                       >
                         -
                       </p>
@@ -844,25 +844,25 @@ exports[`WishList > displaying a list > when there are list items > matches snap
   </body>,
   "container": <div>
     <div
-      class="_root_ec6c68"
+      class="_root_015e9f"
       style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
     >
       <div
         aria-controls="list4Details"
         aria-expanded="false"
-        class="_trigger_ec6c68"
+        class="_trigger_015e9f"
         role="button"
       >
         <span
-          class="_icons_ec6c68"
+          class="_icons_015e9f"
         >
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="destroyWishList4"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-xmark _fa_ec6c68"
+              class="svg-inline--fa fa-xmark _fa_015e9f"
               data-icon="xmark"
               data-prefix="fas"
               role="img"
@@ -875,12 +875,12 @@ exports[`WishList > displaying a list > when there are list items > matches snap
             </svg>
           </button>
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="editWishList4"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+              class="svg-inline--fa fa-pen-to-square _fa_015e9f"
               data-icon="pen-to-square"
               data-prefix="fas"
               role="img"
@@ -894,7 +894,7 @@ exports[`WishList > displaying a list > when there are list items > matches snap
           </button>
         </span>
         <h3
-          class="_title_ec6c68"
+          class="_title_015e9f"
         >
           My Wish List
         </h3>
@@ -909,19 +909,19 @@ exports[`WishList > displaying a list > when there are list items > matches snap
           style="display: none;"
         >
           <div
-            class="_details_ec6c68"
+            class="_details_015e9f"
           >
             <div
-              class="_root_8112da _collapsed_8112da"
+              class="_root_1a276c _collapsed_1a276c"
               style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
             >
               <div
-                class="_triggerContainer_8112da"
+                class="_triggerContainer_1a276c"
               >
                 <button
                   aria-controls="addItemToWishList4"
                   aria-expanded="false"
-                  class="_trigger_8112da"
+                  class="_trigger_1a276c"
                 >
                   Add item to list...
                 </button>
@@ -937,14 +937,14 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                 >
                   <form
                     aria-label="Wish list item creation form"
-                    class="_form_8112da"
+                    class="_form_1a276c"
                   >
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Description
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="description"
                         placeholder="Description"
                         required=""
@@ -952,11 +952,11 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Quantity
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="numeric"
                         min="1"
                         name="quantity"
@@ -969,11 +969,11 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Unit Weight
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="decimal"
                         min="0"
                         name="unit_weight"
@@ -983,18 +983,18 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Notes
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="notes"
                         placeholder="Notes"
                         type="text"
                       />
                     </label>
                     <button
-                      class="_submit_8112da"
+                      class="_submit_1a276c"
                       type="submit"
                     >
                       Add to List
@@ -1004,27 +1004,27 @@ exports[`WishList > displaying a list > when there are list items > matches snap
               </div>
             </div>
             <div
-              class="_root_54cfce"
+              class="_root_8f9b4a"
               style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
             >
               <div
                 aria-controls="wishListItem1Details"
                 aria-expanded="false"
-                class="_trigger_54cfce"
+                class="_trigger_8f9b4a"
               >
                 <span
-                  class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                  class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                 >
                   <span
-                    class="_editIcons_54cfce"
+                    class="_editIcons_8f9b4a"
                   >
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="destroyWishListItem1"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-xmark _fa_54cfce"
+                        class="svg-inline--fa fa-xmark _fa_8f9b4a"
                         data-icon="xmark"
                         data-prefix="fas"
                         role="img"
@@ -1037,12 +1037,12 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       </svg>
                     </button>
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="editWishListItem1"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                        class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                         data-icon="pen-to-square"
                         data-prefix="fas"
                         role="img"
@@ -1056,21 +1056,21 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                     </button>
                   </span>
                   <h3
-                    class="_description_54cfce"
+                    class="_description_8f9b4a"
                   >
                     List Item 1
                   </h3>
                 </span>
                 <span
-                  class="_quantityEditable_54cfce"
+                  class="_quantityEditable_8f9b4a"
                 >
                   <button
-                    class="_icon_54cfce"
+                    class="_icon_8f9b4a"
                     data-testid="incrementWishListItem1"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                      class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                       data-icon="chevron-up"
                       data-prefix="fas"
                       role="img"
@@ -1083,17 +1083,17 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                     </svg>
                   </button>
                   <span
-                    class="_quantityContent_54cfce"
+                    class="_quantityContent_8f9b4a"
                   >
                     4
                   </span>
                   <button
-                    class="_icon_54cfce"
+                    class="_icon_8f9b4a"
                     data-testid="decrementWishListItem1"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                      class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                       data-icon="chevron-down"
                       data-prefix="fas"
                       role="img"
@@ -1117,25 +1117,25 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                   style="display: none;"
                 >
                   <div
-                    class="_details_54cfce"
+                    class="_details_8f9b4a"
                   >
                     <h4
-                      class="_label_54cfce"
+                      class="_label_8f9b4a"
                     >
                       Unit Weight:
                     </h4>
                     <p
-                      class="_value_54cfce"
+                      class="_value_8f9b4a"
                     >
                       -
                     </p>
                     <h4
-                      class="_label_54cfce"
+                      class="_label_8f9b4a"
                     >
                       Notes:
                     </h4>
                     <p
-                      class="_value_54cfce"
+                      class="_value_8f9b4a"
                     >
                       -
                     </p>
@@ -1144,27 +1144,27 @@ exports[`WishList > displaying a list > when there are list items > matches snap
               </div>
             </div>
             <div
-              class="_root_54cfce"
+              class="_root_8f9b4a"
               style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
             >
               <div
                 aria-controls="wishListItem2Details"
                 aria-expanded="false"
-                class="_trigger_54cfce"
+                class="_trigger_8f9b4a"
               >
                 <span
-                  class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                  class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                 >
                   <span
-                    class="_editIcons_54cfce"
+                    class="_editIcons_8f9b4a"
                   >
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="destroyWishListItem2"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-xmark _fa_54cfce"
+                        class="svg-inline--fa fa-xmark _fa_8f9b4a"
                         data-icon="xmark"
                         data-prefix="fas"
                         role="img"
@@ -1177,12 +1177,12 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                       </svg>
                     </button>
                     <button
-                      class="_icon_54cfce"
+                      class="_icon_8f9b4a"
                       data-testid="editWishListItem2"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                        class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                         data-icon="pen-to-square"
                         data-prefix="fas"
                         role="img"
@@ -1196,21 +1196,21 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                     </button>
                   </span>
                   <h3
-                    class="_description_54cfce"
+                    class="_description_8f9b4a"
                   >
                     List Item 2
                   </h3>
                 </span>
                 <span
-                  class="_quantityEditable_54cfce"
+                  class="_quantityEditable_8f9b4a"
                 >
                   <button
-                    class="_icon_54cfce"
+                    class="_icon_8f9b4a"
                     data-testid="incrementWishListItem2"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                      class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                       data-icon="chevron-up"
                       data-prefix="fas"
                       role="img"
@@ -1223,17 +1223,17 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                     </svg>
                   </button>
                   <span
-                    class="_quantityContent_54cfce"
+                    class="_quantityContent_8f9b4a"
                   >
                     1
                   </span>
                   <button
-                    class="_icon_54cfce"
+                    class="_icon_8f9b4a"
                     data-testid="decrementWishListItem2"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                      class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                       data-icon="chevron-down"
                       data-prefix="fas"
                       role="img"
@@ -1257,25 +1257,25 @@ exports[`WishList > displaying a list > when there are list items > matches snap
                   style="display: none;"
                 >
                   <div
-                    class="_details_54cfce"
+                    class="_details_8f9b4a"
                   >
                     <h4
-                      class="_label_54cfce"
+                      class="_label_8f9b4a"
                     >
                       Unit Weight:
                     </h4>
                     <p
-                      class="_value_54cfce"
+                      class="_value_8f9b4a"
                     >
                       -
                     </p>
                     <h4
-                      class="_label_54cfce"
+                      class="_label_8f9b4a"
                     >
                       Notes:
                     </h4>
                     <p
-                      class="_value_54cfce"
+                      class="_value_8f9b4a"
                     >
                       -
                     </p>
@@ -1348,25 +1348,25 @@ exports[`WishList > displaying a list > when there are no list items > matches s
   "baseElement": <body>
     <div>
       <div
-        class="_root_ec6c68"
+        class="_root_015e9f"
         style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
       >
         <div
           aria-controls="list4Details"
           aria-expanded="false"
-          class="_trigger_ec6c68"
+          class="_trigger_015e9f"
           role="button"
         >
           <span
-            class="_icons_ec6c68"
+            class="_icons_015e9f"
           >
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="destroyWishList4"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-xmark _fa_ec6c68"
+                class="svg-inline--fa fa-xmark _fa_015e9f"
                 data-icon="xmark"
                 data-prefix="fas"
                 role="img"
@@ -1379,12 +1379,12 @@ exports[`WishList > displaying a list > when there are no list items > matches s
               </svg>
             </button>
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="editWishList4"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                 data-icon="pen-to-square"
                 data-prefix="fas"
                 role="img"
@@ -1398,7 +1398,7 @@ exports[`WishList > displaying a list > when there are no list items > matches s
             </button>
           </span>
           <h3
-            class="_title_ec6c68"
+            class="_title_015e9f"
           >
             My Wish List
           </h3>
@@ -1413,19 +1413,19 @@ exports[`WishList > displaying a list > when there are no list items > matches s
             style="display: none;"
           >
             <div
-              class="_details_ec6c68"
+              class="_details_015e9f"
             >
               <div
-                class="_root_8112da _collapsed_8112da"
+                class="_root_1a276c _collapsed_1a276c"
                 style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
               >
                 <div
-                  class="_triggerContainer_8112da"
+                  class="_triggerContainer_1a276c"
                 >
                   <button
                     aria-controls="addItemToWishList4"
                     aria-expanded="false"
-                    class="_trigger_8112da"
+                    class="_trigger_1a276c"
                   >
                     Add item to list...
                   </button>
@@ -1441,14 +1441,14 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                   >
                     <form
                       aria-label="Wish list item creation form"
-                      class="_form_8112da"
+                      class="_form_1a276c"
                     >
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Description
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="description"
                           placeholder="Description"
                           required=""
@@ -1456,11 +1456,11 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Quantity
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="numeric"
                           min="1"
                           name="quantity"
@@ -1473,11 +1473,11 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Unit Weight
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="decimal"
                           min="0"
                           name="unit_weight"
@@ -1487,18 +1487,18 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Notes
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="notes"
                           placeholder="Notes"
                           type="text"
                         />
                       </label>
                       <button
-                        class="_submit_8112da"
+                        class="_submit_1a276c"
                         type="submit"
                       >
                         Add to List
@@ -1515,25 +1515,25 @@ exports[`WishList > displaying a list > when there are no list items > matches s
   </body>,
   "container": <div>
     <div
-      class="_root_ec6c68"
+      class="_root_015e9f"
       style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
     >
       <div
         aria-controls="list4Details"
         aria-expanded="false"
-        class="_trigger_ec6c68"
+        class="_trigger_015e9f"
         role="button"
       >
         <span
-          class="_icons_ec6c68"
+          class="_icons_015e9f"
         >
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="destroyWishList4"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-xmark _fa_ec6c68"
+              class="svg-inline--fa fa-xmark _fa_015e9f"
               data-icon="xmark"
               data-prefix="fas"
               role="img"
@@ -1546,12 +1546,12 @@ exports[`WishList > displaying a list > when there are no list items > matches s
             </svg>
           </button>
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="editWishList4"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+              class="svg-inline--fa fa-pen-to-square _fa_015e9f"
               data-icon="pen-to-square"
               data-prefix="fas"
               role="img"
@@ -1565,7 +1565,7 @@ exports[`WishList > displaying a list > when there are no list items > matches s
           </button>
         </span>
         <h3
-          class="_title_ec6c68"
+          class="_title_015e9f"
         >
           My Wish List
         </h3>
@@ -1580,19 +1580,19 @@ exports[`WishList > displaying a list > when there are no list items > matches s
           style="display: none;"
         >
           <div
-            class="_details_ec6c68"
+            class="_details_015e9f"
           >
             <div
-              class="_root_8112da _collapsed_8112da"
+              class="_root_1a276c _collapsed_1a276c"
               style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
             >
               <div
-                class="_triggerContainer_8112da"
+                class="_triggerContainer_1a276c"
               >
                 <button
                   aria-controls="addItemToWishList4"
                   aria-expanded="false"
-                  class="_trigger_8112da"
+                  class="_trigger_1a276c"
                 >
                   Add item to list...
                 </button>
@@ -1608,14 +1608,14 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                 >
                   <form
                     aria-label="Wish list item creation form"
-                    class="_form_8112da"
+                    class="_form_1a276c"
                   >
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Description
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="description"
                         placeholder="Description"
                         required=""
@@ -1623,11 +1623,11 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Quantity
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="numeric"
                         min="1"
                         name="quantity"
@@ -1640,11 +1640,11 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Unit Weight
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="decimal"
                         min="0"
                         name="unit_weight"
@@ -1654,18 +1654,18 @@ exports[`WishList > displaying a list > when there are no list items > matches s
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Notes
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="notes"
                         placeholder="Notes"
                         type="text"
                       />
                     </label>
                     <button
-                      class="_submit_8112da"
+                      class="_submit_1a276c"
                       type="submit"
                     >
                       Add to List
@@ -1739,25 +1739,25 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_ec6c68"
+        class="_root_015e9f"
         style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
       >
         <div
           aria-controls="list3Details"
           aria-expanded="false"
-          class="_trigger_ec6c68"
+          class="_trigger_015e9f"
           role="button"
         >
           <span
-            class="_icons_ec6c68"
+            class="_icons_015e9f"
           >
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="destroyWishList3"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-xmark _fa_ec6c68"
+                class="svg-inline--fa fa-xmark _fa_015e9f"
                 data-icon="xmark"
                 data-prefix="fas"
                 role="img"
@@ -1770,12 +1770,12 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
               </svg>
             </button>
             <button
-              class="_icon_ec6c68"
+              class="_icon_015e9f"
               data-testid="editWishList3"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                 data-icon="pen-to-square"
                 data-prefix="fas"
                 role="img"
@@ -1790,12 +1790,12 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
           </span>
           <form
             aria-label="List title edit form"
-            class="_form_ec6c68 _root_8f85e1"
+            class="_form_015e9f _root_ed6063"
             style="--scheme-color: #00a323; --text-color: #fff; --border-color: #00821c; --icon-hover-color: #ccecd3; --max-width: 16px;"
           >
             <input
               aria-label="title"
-              class="_input_8f85e1"
+              class="_input_ed6063"
               data-testid="editListTitle"
               name="title"
               pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
@@ -1805,13 +1805,13 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
               value="My Wish List"
             />
             <button
-              class="_submit_8f85e1"
+              class="_submit_ed6063"
               name="submit"
               type="submit"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-square-check _fa_8f85e1"
+                class="svg-inline--fa fa-square-check _fa_ed6063"
                 data-icon="square-check"
                 data-prefix="far"
                 role="img"
@@ -1835,19 +1835,19 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
             style="display: none;"
           >
             <div
-              class="_details_ec6c68"
+              class="_details_015e9f"
             >
               <div
-                class="_root_8112da _collapsed_8112da"
+                class="_root_1a276c _collapsed_1a276c"
                 style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
               >
                 <div
-                  class="_triggerContainer_8112da"
+                  class="_triggerContainer_1a276c"
                 >
                   <button
                     aria-controls="addItemToWishList3"
                     aria-expanded="false"
-                    class="_trigger_8112da"
+                    class="_trigger_1a276c"
                   >
                     Add item to list...
                   </button>
@@ -1863,14 +1863,14 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                   >
                     <form
                       aria-label="Wish list item creation form"
-                      class="_form_8112da"
+                      class="_form_1a276c"
                     >
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Description
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="description"
                           placeholder="Description"
                           required=""
@@ -1878,11 +1878,11 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Quantity
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="numeric"
                           min="1"
                           name="quantity"
@@ -1895,11 +1895,11 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Unit Weight
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           inputmode="decimal"
                           min="0"
                           name="unit_weight"
@@ -1909,18 +1909,18 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                         />
                       </label>
                       <label
-                        class="_label_8112da"
+                        class="_label_1a276c"
                       >
                         Notes
                         <input
-                          class="_input_8112da"
+                          class="_input_1a276c"
                           name="notes"
                           placeholder="Notes"
                           type="text"
                         />
                       </label>
                       <button
-                        class="_submit_8112da"
+                        class="_submit_1a276c"
                         type="submit"
                       >
                         Add to List
@@ -1937,25 +1937,25 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_ec6c68"
+      class="_root_015e9f"
       style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
     >
       <div
         aria-controls="list3Details"
         aria-expanded="false"
-        class="_trigger_ec6c68"
+        class="_trigger_015e9f"
         role="button"
       >
         <span
-          class="_icons_ec6c68"
+          class="_icons_015e9f"
         >
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="destroyWishList3"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-xmark _fa_ec6c68"
+              class="svg-inline--fa fa-xmark _fa_015e9f"
               data-icon="xmark"
               data-prefix="fas"
               role="img"
@@ -1968,12 +1968,12 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
             </svg>
           </button>
           <button
-            class="_icon_ec6c68"
+            class="_icon_015e9f"
             data-testid="editWishList3"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+              class="svg-inline--fa fa-pen-to-square _fa_015e9f"
               data-icon="pen-to-square"
               data-prefix="fas"
               role="img"
@@ -1988,12 +1988,12 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
         </span>
         <form
           aria-label="List title edit form"
-          class="_form_ec6c68 _root_8f85e1"
+          class="_form_015e9f _root_ed6063"
           style="--scheme-color: #00a323; --text-color: #fff; --border-color: #00821c; --icon-hover-color: #ccecd3; --max-width: 16px;"
         >
           <input
             aria-label="title"
-            class="_input_8f85e1"
+            class="_input_ed6063"
             data-testid="editListTitle"
             name="title"
             pattern="^\\s*[A-Za-z0-9 \\-',]*\\s*$"
@@ -2003,13 +2003,13 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
             value="My Wish List"
           />
           <button
-            class="_submit_8f85e1"
+            class="_submit_ed6063"
             name="submit"
             type="submit"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-square-check _fa_8f85e1"
+              class="svg-inline--fa fa-square-check _fa_ed6063"
               data-icon="square-check"
               data-prefix="far"
               role="img"
@@ -2033,19 +2033,19 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
           style="display: none;"
         >
           <div
-            class="_details_ec6c68"
+            class="_details_015e9f"
           >
             <div
-              class="_root_8112da _collapsed_8112da"
+              class="_root_1a276c _collapsed_1a276c"
               style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
             >
               <div
-                class="_triggerContainer_8112da"
+                class="_triggerContainer_1a276c"
               >
                 <button
                   aria-controls="addItemToWishList3"
                   aria-expanded="false"
-                  class="_trigger_8112da"
+                  class="_trigger_1a276c"
                 >
                   Add item to list...
                 </button>
@@ -2061,14 +2061,14 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                 >
                   <form
                     aria-label="Wish list item creation form"
-                    class="_form_8112da"
+                    class="_form_1a276c"
                   >
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Description
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="description"
                         placeholder="Description"
                         required=""
@@ -2076,11 +2076,11 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Quantity
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="numeric"
                         min="1"
                         name="quantity"
@@ -2093,11 +2093,11 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Unit Weight
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         inputmode="decimal"
                         min="0"
                         name="unit_weight"
@@ -2107,18 +2107,18 @@ exports[`WishList > displaying the edit form > matches snapshot 1`] = `
                       />
                     </label>
                     <label
-                      class="_label_8112da"
+                      class="_label_1a276c"
                     >
                       Notes
                       <input
-                        class="_input_8112da"
+                        class="_input_1a276c"
                         name="notes"
                         placeholder="Notes"
                         type="text"
                       />
                     </label>
                     <button
-                      class="_submit_8112da"
+                      class="_submit_1a276c"
                       type="submit"
                     >
                       Add to List

--- a/src/components/wishListCreateForm/__snapshots__/wishListCreateForm.test.tsx.snap
+++ b/src/components/wishListCreateForm/__snapshots__/wishListCreateForm.test.tsx.snap
@@ -6,15 +6,15 @@ exports[`WishListCreateForm > displaying the form > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <form
-        class="_root_15ecd1"
+        class="_root_f9e5f5"
         style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
       >
         <fieldset
-          class="_fieldset_15ecd1"
+          class="_fieldset_f9e5f5"
         >
           <input
             aria-label="Title"
-            class="_input_15ecd1"
+            class="_input_f9e5f5"
             disabled=""
             name="title"
             pattern="\\s*[A-Za-z0-9 \\-',]*\\s*"
@@ -23,7 +23,7 @@ exports[`WishListCreateForm > displaying the form > matches snapshot 1`] = `
             type="text"
           />
           <button
-            class="_button_15ecd1"
+            class="_button_f9e5f5"
             disabled=""
             type="submit"
           >
@@ -35,15 +35,15 @@ exports[`WishListCreateForm > displaying the form > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <form
-      class="_root_15ecd1"
+      class="_root_f9e5f5"
       style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
     >
       <fieldset
-        class="_fieldset_15ecd1"
+        class="_fieldset_f9e5f5"
       >
         <input
           aria-label="Title"
-          class="_input_15ecd1"
+          class="_input_f9e5f5"
           disabled=""
           name="title"
           pattern="\\s*[A-Za-z0-9 \\-',]*\\s*"
@@ -52,7 +52,7 @@ exports[`WishListCreateForm > displaying the form > matches snapshot 1`] = `
           type="text"
         />
         <button
-          class="_button_15ecd1"
+          class="_button_f9e5f5"
           disabled=""
           type="submit"
         >

--- a/src/components/wishListGrouping/__snapshots__/wishListGrouping.test.tsx.snap
+++ b/src/components/wishListGrouping/__snapshots__/wishListGrouping.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`WishListGrouping > when there are no wish lists > matches snapshot 1`] 
   "baseElement": <body>
     <div>
       <p
-        class="_noLists_da4596"
+        class="_noLists_8bc9d7"
       >
         This game has no wish lists.
       </p>
@@ -14,7 +14,7 @@ exports[`WishListGrouping > when there are no wish lists > matches snapshot 1`] 
   </body>,
   "container": <div>
     <p
-      class="_noLists_da4596"
+      class="_noLists_8bc9d7"
     >
       This game has no wish lists.
     </p>
@@ -79,23 +79,23 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_da4596"
+        class="_root_8bc9d7"
       >
         <div
-          class="_wishList_da4596"
+          class="_wishList_8bc9d7"
         >
           <div
-            class="_root_ec6c68"
+            class="_root_015e9f"
             style="--scheme-color: #ffbf00; --border-color: #cc9800; --text-color-primary: #4c3900; --text-color-secondary: #4c3900; --hover-color: #e5ab00; --scheme-color-lighter: #ffcb32; --scheme-color-lightest: #fff2cc; --max-title-width: -32px;"
           >
             <div
               aria-controls="list3Details"
               aria-expanded="false"
-              class="_trigger_ec6c68"
+              class="_trigger_015e9f"
               role="button"
             >
               <h3
-                class="_title_ec6c68"
+                class="_title_015e9f"
               >
                 All Items
               </h3>
@@ -110,31 +110,31 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 style="display: none;"
               >
                 <div
-                  class="_details_ec6c68"
+                  class="_details_015e9f"
                 >
                   <div
-                    class="_root_54cfce"
+                    class="_root_8f9b4a"
                     style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                   >
                     <div
                       aria-controls="wishListItem6Details"
                       aria-expanded="false"
-                      class="_trigger_54cfce"
+                      class="_trigger_8f9b4a"
                     >
                       <span
-                        class="_descriptionContainer_54cfce"
+                        class="_descriptionContainer_8f9b4a"
                       >
                         <h3
-                          class="_description_54cfce"
+                          class="_description_8f9b4a"
                         >
                           Dwarven Cog
                         </h3>
                       </span>
                       <span
-                        class="_quantity_54cfce"
+                        class="_quantity_8f9b4a"
                       >
                         <span
-                          class="_quantityContent_54cfce"
+                          class="_quantityContent_8f9b4a"
                         >
                           11
                         </span>
@@ -150,15 +150,15 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         style="display: none;"
                       >
                         <div
-                          class="_details_54cfce"
+                          class="_details_8f9b4a"
                         >
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Unit Weight:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             10
                           </p>
@@ -167,28 +167,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="_root_54cfce"
+                    class="_root_8f9b4a"
                     style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                   >
                     <div
                       aria-controls="wishListItem9Details"
                       aria-expanded="false"
-                      class="_trigger_54cfce"
+                      class="_trigger_8f9b4a"
                     >
                       <span
-                        class="_descriptionContainer_54cfce"
+                        class="_descriptionContainer_8f9b4a"
                       >
                         <h3
-                          class="_description_54cfce"
+                          class="_description_8f9b4a"
                         >
                           This item has a really really really really really long description for testing purposes
                         </h3>
                       </span>
                       <span
-                        class="_quantity_54cfce"
+                        class="_quantity_8f9b4a"
                       >
                         <span
-                          class="_quantityContent_54cfce"
+                          class="_quantityContent_8f9b4a"
                         >
                           200000000000
                         </span>
@@ -204,15 +204,15 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         style="display: none;"
                       >
                         <div
-                          class="_details_54cfce"
+                          class="_details_8f9b4a"
                         >
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Unit Weight:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             400000000000
                           </p>
@@ -226,28 +226,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="_wishList_da4596"
+          class="_wishList_8bc9d7"
         >
           <div
-            class="_root_ec6c68"
+            class="_root_015e9f"
             style="--scheme-color: #e83f6f; --border-color: #b93258; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #d03863; --scheme-color-lighter: #ec658b; --scheme-color-lightest: #fad8e2; --max-title-width: -16px;"
           >
             <div
               aria-controls="list4Details"
               aria-expanded="false"
-              class="_trigger_ec6c68"
+              class="_trigger_015e9f"
               role="button"
             >
               <span
-                class="_icons_ec6c68"
+                class="_icons_015e9f"
               >
                 <button
-                  class="_icon_ec6c68"
+                  class="_icon_015e9f"
                   data-testid="destroyWishList4"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-xmark _fa_ec6c68"
+                    class="svg-inline--fa fa-xmark _fa_015e9f"
                     data-icon="xmark"
                     data-prefix="fas"
                     role="img"
@@ -260,12 +260,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                   </svg>
                 </button>
                 <button
-                  class="_icon_ec6c68"
+                  class="_icon_015e9f"
                   data-testid="editWishList4"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                    class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                     data-icon="pen-to-square"
                     data-prefix="fas"
                     role="img"
@@ -279,7 +279,7 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 </button>
               </span>
               <h3
-                class="_title_ec6c68"
+                class="_title_015e9f"
               >
                 Honeyside
               </h3>
@@ -294,19 +294,19 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 style="display: none;"
               >
                 <div
-                  class="_details_ec6c68"
+                  class="_details_015e9f"
                 >
                   <div
-                    class="_root_8112da _collapsed_8112da"
+                    class="_root_1a276c _collapsed_1a276c"
                     style="--base-color: #ec658b; --hover-color: #ea527d; --body-color: #fad8e2; --border-color: #b93258; --text-color-main: #fff; --text-color-secondary: #451221;"
                   >
                     <div
-                      class="_triggerContainer_8112da"
+                      class="_triggerContainer_1a276c"
                     >
                       <button
                         aria-controls="addItemToWishList4"
                         aria-expanded="false"
-                        class="_trigger_8112da"
+                        class="_trigger_1a276c"
                       >
                         Add item to list...
                       </button>
@@ -322,14 +322,14 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       >
                         <form
                           aria-label="Wish list item creation form"
-                          class="_form_8112da"
+                          class="_form_1a276c"
                         >
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Description
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               name="description"
                               placeholder="Description"
                               required=""
@@ -337,11 +337,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Quantity
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               inputmode="numeric"
                               min="1"
                               name="quantity"
@@ -354,11 +354,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Unit Weight
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               inputmode="decimal"
                               min="0"
                               name="unit_weight"
@@ -368,18 +368,18 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Notes
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               name="notes"
                               placeholder="Notes"
                               type="text"
                             />
                           </label>
                           <button
-                            class="_submit_8112da"
+                            class="_submit_1a276c"
                             type="submit"
                           >
                             Add to List
@@ -389,27 +389,27 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="_root_54cfce"
+                    class="_root_8f9b4a"
                     style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                   >
                     <div
                       aria-controls="wishListItem8Details"
                       aria-expanded="false"
-                      class="_trigger_54cfce"
+                      class="_trigger_8f9b4a"
                     >
                       <span
-                        class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                        class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                       >
                         <span
-                          class="_editIcons_54cfce"
+                          class="_editIcons_8f9b4a"
                         >
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="destroyWishListItem8"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-xmark _fa_54cfce"
+                              class="svg-inline--fa fa-xmark _fa_8f9b4a"
                               data-icon="xmark"
                               data-prefix="fas"
                               role="img"
@@ -422,12 +422,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             </svg>
                           </button>
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="editWishListItem8"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                              class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                               data-icon="pen-to-square"
                               data-prefix="fas"
                               role="img"
@@ -441,21 +441,21 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </button>
                         </span>
                         <h3
-                          class="_description_54cfce"
+                          class="_description_8f9b4a"
                         >
                           This item has a really really really really really long description for testing purposes
                         </h3>
                       </span>
                       <span
-                        class="_quantityEditable_54cfce"
+                        class="_quantityEditable_8f9b4a"
                       >
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="incrementWishListItem8"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                            class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                             data-icon="chevron-up"
                             data-prefix="fas"
                             role="img"
@@ -468,17 +468,17 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </svg>
                         </button>
                         <span
-                          class="_quantityContent_54cfce"
+                          class="_quantityContent_8f9b4a"
                         >
                           200000000000
                         </span>
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="decrementWishListItem8"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                            class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                             data-icon="chevron-down"
                             data-prefix="fas"
                             role="img"
@@ -502,25 +502,25 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         style="display: none;"
                       >
                         <div
-                          class="_details_54cfce"
+                          class="_details_8f9b4a"
                         >
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Unit Weight:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             400000000000
                           </p>
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Notes:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             -
                           </p>
@@ -529,27 +529,27 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="_root_54cfce"
+                    class="_root_8f9b4a"
                     style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                   >
                     <div
                       aria-controls="wishListItem5Details"
                       aria-expanded="false"
-                      class="_trigger_54cfce"
+                      class="_trigger_8f9b4a"
                     >
                       <span
-                        class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                        class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                       >
                         <span
-                          class="_editIcons_54cfce"
+                          class="_editIcons_8f9b4a"
                         >
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="destroyWishListItem5"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-xmark _fa_54cfce"
+                              class="svg-inline--fa fa-xmark _fa_8f9b4a"
                               data-icon="xmark"
                               data-prefix="fas"
                               role="img"
@@ -562,12 +562,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             </svg>
                           </button>
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="editWishListItem5"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                              class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                               data-icon="pen-to-square"
                               data-prefix="fas"
                               role="img"
@@ -581,21 +581,21 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </button>
                         </span>
                         <h3
-                          class="_description_54cfce"
+                          class="_description_8f9b4a"
                         >
                           Dwarven Cog
                         </h3>
                       </span>
                       <span
-                        class="_quantityEditable_54cfce"
+                        class="_quantityEditable_8f9b4a"
                       >
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="incrementWishListItem5"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                            class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                             data-icon="chevron-up"
                             data-prefix="fas"
                             role="img"
@@ -608,17 +608,17 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </svg>
                         </button>
                         <span
-                          class="_quantityContent_54cfce"
+                          class="_quantityContent_8f9b4a"
                         >
                           1
                         </span>
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="decrementWishListItem5"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                            class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                             data-icon="chevron-down"
                             data-prefix="fas"
                             role="img"
@@ -642,25 +642,25 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         style="display: none;"
                       >
                         <div
-                          class="_details_54cfce"
+                          class="_details_8f9b4a"
                         >
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Unit Weight:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             10
                           </p>
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Notes:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             For trophy room
                           </p>
@@ -674,28 +674,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="_wishList_da4596"
+          class="_wishList_8bc9d7"
         >
           <div
-            class="_root_ec6c68"
+            class="_root_015e9f"
             style="--scheme-color: #2274a5; --border-color: #1b5c84; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #1e6894; --scheme-color-lighter: #4e8fb7; --scheme-color-lightest: #d2e3ed; --max-title-width: -16px;"
           >
             <div
               aria-controls="list5Details"
               aria-expanded="false"
-              class="_trigger_ec6c68"
+              class="_trigger_015e9f"
               role="button"
             >
               <span
-                class="_icons_ec6c68"
+                class="_icons_015e9f"
               >
                 <button
-                  class="_icon_ec6c68"
+                  class="_icon_015e9f"
                   data-testid="destroyWishList5"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-xmark _fa_ec6c68"
+                    class="svg-inline--fa fa-xmark _fa_015e9f"
                     data-icon="xmark"
                     data-prefix="fas"
                     role="img"
@@ -708,12 +708,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                   </svg>
                 </button>
                 <button
-                  class="_icon_ec6c68"
+                  class="_icon_015e9f"
                   data-testid="editWishList5"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                    class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                     data-icon="pen-to-square"
                     data-prefix="fas"
                     role="img"
@@ -727,7 +727,7 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 </button>
               </span>
               <h3
-                class="_title_ec6c68"
+                class="_title_015e9f"
               >
                 Breezehome
               </h3>
@@ -742,19 +742,19 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 style="display: none;"
               >
                 <div
-                  class="_details_ec6c68"
+                  class="_details_015e9f"
                 >
                   <div
-                    class="_root_8112da _collapsed_8112da"
+                    class="_root_1a276c _collapsed_1a276c"
                     style="--base-color: #4e8fb7; --hover-color: #3881ae; --body-color: #d2e3ed; --border-color: #1b5c84; --text-color-main: #fff; --text-color-secondary: #0d2e42;"
                   >
                     <div
-                      class="_triggerContainer_8112da"
+                      class="_triggerContainer_1a276c"
                     >
                       <button
                         aria-controls="addItemToWishList5"
                         aria-expanded="false"
-                        class="_trigger_8112da"
+                        class="_trigger_1a276c"
                       >
                         Add item to list...
                       </button>
@@ -770,14 +770,14 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       >
                         <form
                           aria-label="Wish list item creation form"
-                          class="_form_8112da"
+                          class="_form_1a276c"
                         >
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Description
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               name="description"
                               placeholder="Description"
                               required=""
@@ -785,11 +785,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Quantity
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               inputmode="numeric"
                               min="1"
                               name="quantity"
@@ -802,11 +802,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Unit Weight
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               inputmode="decimal"
                               min="0"
                               name="unit_weight"
@@ -816,18 +816,18 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Notes
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               name="notes"
                               placeholder="Notes"
                               type="text"
                             />
                           </label>
                           <button
-                            class="_submit_8112da"
+                            class="_submit_1a276c"
                             type="submit"
                           >
                             Add to List
@@ -837,27 +837,27 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="_root_54cfce"
+                    class="_root_8f9b4a"
                     style="--main-color: #4e8fb7; --title-text-color: #fff; --border-color: #1b5c84; --body-background-color: #d2e3ed; --body-text-color: #0d2e42; --hover-color: #3881ae;"
                   >
                     <div
                       aria-controls="wishListItem7Details"
                       aria-expanded="false"
-                      class="_trigger_54cfce"
+                      class="_trigger_8f9b4a"
                     >
                       <span
-                        class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                        class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                       >
                         <span
-                          class="_editIcons_54cfce"
+                          class="_editIcons_8f9b4a"
                         >
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="destroyWishListItem7"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-xmark _fa_54cfce"
+                              class="svg-inline--fa fa-xmark _fa_8f9b4a"
                               data-icon="xmark"
                               data-prefix="fas"
                               role="img"
@@ -870,12 +870,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             </svg>
                           </button>
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="editWishListItem7"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                              class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                               data-icon="pen-to-square"
                               data-prefix="fas"
                               role="img"
@@ -889,21 +889,21 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </button>
                         </span>
                         <h3
-                          class="_description_54cfce"
+                          class="_description_8f9b4a"
                         >
                           Dwarven Cog
                         </h3>
                       </span>
                       <span
-                        class="_quantityEditable_54cfce"
+                        class="_quantityEditable_8f9b4a"
                       >
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="incrementWishListItem7"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                            class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                             data-icon="chevron-up"
                             data-prefix="fas"
                             role="img"
@@ -916,17 +916,17 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </svg>
                         </button>
                         <span
-                          class="_quantityContent_54cfce"
+                          class="_quantityContent_8f9b4a"
                         >
                           10
                         </span>
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="decrementWishListItem7"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                            class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                             data-icon="chevron-down"
                             data-prefix="fas"
                             role="img"
@@ -950,25 +950,25 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         style="display: none;"
                       >
                         <div
-                          class="_details_54cfce"
+                          class="_details_8f9b4a"
                         >
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Unit Weight:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             10
                           </p>
                           <h4
-                            class="_label_54cfce"
+                            class="_label_8f9b4a"
                           >
                             Notes:
                           </h4>
                           <p
-                            class="_value_54cfce"
+                            class="_value_8f9b4a"
                           >
                             For Arniel Gane
                           </p>
@@ -982,28 +982,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="_wishList_da4596"
+          class="_wishList_8bc9d7"
         >
           <div
-            class="_root_ec6c68"
+            class="_root_015e9f"
             style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
           >
             <div
               aria-controls="list6Details"
               aria-expanded="false"
-              class="_trigger_ec6c68"
+              class="_trigger_015e9f"
               role="button"
             >
               <span
-                class="_icons_ec6c68"
+                class="_icons_015e9f"
               >
                 <button
-                  class="_icon_ec6c68"
+                  class="_icon_015e9f"
                   data-testid="destroyWishList6"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-xmark _fa_ec6c68"
+                    class="svg-inline--fa fa-xmark _fa_015e9f"
                     data-icon="xmark"
                     data-prefix="fas"
                     role="img"
@@ -1016,12 +1016,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                   </svg>
                 </button>
                 <button
-                  class="_icon_ec6c68"
+                  class="_icon_015e9f"
                   data-testid="editWishList6"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                    class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                     data-icon="pen-to-square"
                     data-prefix="fas"
                     role="img"
@@ -1035,7 +1035,7 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 </button>
               </span>
               <h3
-                class="_title_ec6c68"
+                class="_title_015e9f"
               >
                 Hjerim
               </h3>
@@ -1050,19 +1050,19 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 style="display: none;"
               >
                 <div
-                  class="_details_ec6c68"
+                  class="_details_015e9f"
                 >
                   <div
-                    class="_root_8112da _collapsed_8112da"
+                    class="_root_1a276c _collapsed_1a276c"
                     style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
                   >
                     <div
-                      class="_triggerContainer_8112da"
+                      class="_triggerContainer_1a276c"
                     >
                       <button
                         aria-controls="addItemToWishList6"
                         aria-expanded="false"
-                        class="_trigger_8112da"
+                        class="_trigger_1a276c"
                       >
                         Add item to list...
                       </button>
@@ -1078,14 +1078,14 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       >
                         <form
                           aria-label="Wish list item creation form"
-                          class="_form_8112da"
+                          class="_form_1a276c"
                         >
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Description
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               name="description"
                               placeholder="Description"
                               required=""
@@ -1093,11 +1093,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Quantity
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               inputmode="numeric"
                               min="1"
                               name="quantity"
@@ -1110,11 +1110,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Unit Weight
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               inputmode="decimal"
                               min="0"
                               name="unit_weight"
@@ -1124,18 +1124,18 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                             />
                           </label>
                           <label
-                            class="_label_8112da"
+                            class="_label_1a276c"
                           >
                             Notes
                             <input
-                              class="_input_8112da"
+                              class="_input_1a276c"
                               name="notes"
                               placeholder="Notes"
                               type="text"
                             />
                           </label>
                           <button
-                            class="_submit_8112da"
+                            class="_submit_1a276c"
                             type="submit"
                           >
                             Add to List
@@ -1154,23 +1154,23 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_da4596"
+      class="_root_8bc9d7"
     >
       <div
-        class="_wishList_da4596"
+        class="_wishList_8bc9d7"
       >
         <div
-          class="_root_ec6c68"
+          class="_root_015e9f"
           style="--scheme-color: #ffbf00; --border-color: #cc9800; --text-color-primary: #4c3900; --text-color-secondary: #4c3900; --hover-color: #e5ab00; --scheme-color-lighter: #ffcb32; --scheme-color-lightest: #fff2cc; --max-title-width: -32px;"
         >
           <div
             aria-controls="list3Details"
             aria-expanded="false"
-            class="_trigger_ec6c68"
+            class="_trigger_015e9f"
             role="button"
           >
             <h3
-              class="_title_ec6c68"
+              class="_title_015e9f"
             >
               All Items
             </h3>
@@ -1185,31 +1185,31 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
               style="display: none;"
             >
               <div
-                class="_details_ec6c68"
+                class="_details_015e9f"
               >
                 <div
-                  class="_root_54cfce"
+                  class="_root_8f9b4a"
                   style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                 >
                   <div
                     aria-controls="wishListItem6Details"
                     aria-expanded="false"
-                    class="_trigger_54cfce"
+                    class="_trigger_8f9b4a"
                   >
                     <span
-                      class="_descriptionContainer_54cfce"
+                      class="_descriptionContainer_8f9b4a"
                     >
                       <h3
-                        class="_description_54cfce"
+                        class="_description_8f9b4a"
                       >
                         Dwarven Cog
                       </h3>
                     </span>
                     <span
-                      class="_quantity_54cfce"
+                      class="_quantity_8f9b4a"
                     >
                       <span
-                        class="_quantityContent_54cfce"
+                        class="_quantityContent_8f9b4a"
                       >
                         11
                       </span>
@@ -1225,15 +1225,15 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       style="display: none;"
                     >
                       <div
-                        class="_details_54cfce"
+                        class="_details_8f9b4a"
                       >
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Unit Weight:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           10
                         </p>
@@ -1242,28 +1242,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="_root_54cfce"
+                  class="_root_8f9b4a"
                   style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                 >
                   <div
                     aria-controls="wishListItem9Details"
                     aria-expanded="false"
-                    class="_trigger_54cfce"
+                    class="_trigger_8f9b4a"
                   >
                     <span
-                      class="_descriptionContainer_54cfce"
+                      class="_descriptionContainer_8f9b4a"
                     >
                       <h3
-                        class="_description_54cfce"
+                        class="_description_8f9b4a"
                       >
                         This item has a really really really really really long description for testing purposes
                       </h3>
                     </span>
                     <span
-                      class="_quantity_54cfce"
+                      class="_quantity_8f9b4a"
                     >
                       <span
-                        class="_quantityContent_54cfce"
+                        class="_quantityContent_8f9b4a"
                       >
                         200000000000
                       </span>
@@ -1279,15 +1279,15 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       style="display: none;"
                     >
                       <div
-                        class="_details_54cfce"
+                        class="_details_8f9b4a"
                       >
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Unit Weight:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           400000000000
                         </p>
@@ -1301,28 +1301,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="_wishList_da4596"
+        class="_wishList_8bc9d7"
       >
         <div
-          class="_root_ec6c68"
+          class="_root_015e9f"
           style="--scheme-color: #e83f6f; --border-color: #b93258; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #d03863; --scheme-color-lighter: #ec658b; --scheme-color-lightest: #fad8e2; --max-title-width: -16px;"
         >
           <div
             aria-controls="list4Details"
             aria-expanded="false"
-            class="_trigger_ec6c68"
+            class="_trigger_015e9f"
             role="button"
           >
             <span
-              class="_icons_ec6c68"
+              class="_icons_015e9f"
             >
               <button
-                class="_icon_ec6c68"
+                class="_icon_015e9f"
                 data-testid="destroyWishList4"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-xmark _fa_ec6c68"
+                  class="svg-inline--fa fa-xmark _fa_015e9f"
                   data-icon="xmark"
                   data-prefix="fas"
                   role="img"
@@ -1335,12 +1335,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 </svg>
               </button>
               <button
-                class="_icon_ec6c68"
+                class="_icon_015e9f"
                 data-testid="editWishList4"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                  class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                   data-icon="pen-to-square"
                   data-prefix="fas"
                   role="img"
@@ -1354,7 +1354,7 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
               </button>
             </span>
             <h3
-              class="_title_ec6c68"
+              class="_title_015e9f"
             >
               Honeyside
             </h3>
@@ -1369,19 +1369,19 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
               style="display: none;"
             >
               <div
-                class="_details_ec6c68"
+                class="_details_015e9f"
               >
                 <div
-                  class="_root_8112da _collapsed_8112da"
+                  class="_root_1a276c _collapsed_1a276c"
                   style="--base-color: #ec658b; --hover-color: #ea527d; --body-color: #fad8e2; --border-color: #b93258; --text-color-main: #fff; --text-color-secondary: #451221;"
                 >
                   <div
-                    class="_triggerContainer_8112da"
+                    class="_triggerContainer_1a276c"
                   >
                     <button
                       aria-controls="addItemToWishList4"
                       aria-expanded="false"
-                      class="_trigger_8112da"
+                      class="_trigger_1a276c"
                     >
                       Add item to list...
                     </button>
@@ -1397,14 +1397,14 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                     >
                       <form
                         aria-label="Wish list item creation form"
-                        class="_form_8112da"
+                        class="_form_1a276c"
                       >
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Description
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             name="description"
                             placeholder="Description"
                             required=""
@@ -1412,11 +1412,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Quantity
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             inputmode="numeric"
                             min="1"
                             name="quantity"
@@ -1429,11 +1429,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Unit Weight
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             inputmode="decimal"
                             min="0"
                             name="unit_weight"
@@ -1443,18 +1443,18 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Notes
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             name="notes"
                             placeholder="Notes"
                             type="text"
                           />
                         </label>
                         <button
-                          class="_submit_8112da"
+                          class="_submit_1a276c"
                           type="submit"
                         >
                           Add to List
@@ -1464,27 +1464,27 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="_root_54cfce"
+                  class="_root_8f9b4a"
                   style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                 >
                   <div
                     aria-controls="wishListItem8Details"
                     aria-expanded="false"
-                    class="_trigger_54cfce"
+                    class="_trigger_8f9b4a"
                   >
                     <span
-                      class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                      class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                     >
                       <span
-                        class="_editIcons_54cfce"
+                        class="_editIcons_8f9b4a"
                       >
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="destroyWishListItem8"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-xmark _fa_54cfce"
+                            class="svg-inline--fa fa-xmark _fa_8f9b4a"
                             data-icon="xmark"
                             data-prefix="fas"
                             role="img"
@@ -1497,12 +1497,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </svg>
                         </button>
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="editWishListItem8"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                            class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                             data-icon="pen-to-square"
                             data-prefix="fas"
                             role="img"
@@ -1516,21 +1516,21 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         </button>
                       </span>
                       <h3
-                        class="_description_54cfce"
+                        class="_description_8f9b4a"
                       >
                         This item has a really really really really really long description for testing purposes
                       </h3>
                     </span>
                     <span
-                      class="_quantityEditable_54cfce"
+                      class="_quantityEditable_8f9b4a"
                     >
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="incrementWishListItem8"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                          class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                           data-icon="chevron-up"
                           data-prefix="fas"
                           role="img"
@@ -1543,17 +1543,17 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         </svg>
                       </button>
                       <span
-                        class="_quantityContent_54cfce"
+                        class="_quantityContent_8f9b4a"
                       >
                         200000000000
                       </span>
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="decrementWishListItem8"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                          class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                           data-icon="chevron-down"
                           data-prefix="fas"
                           role="img"
@@ -1577,25 +1577,25 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       style="display: none;"
                     >
                       <div
-                        class="_details_54cfce"
+                        class="_details_8f9b4a"
                       >
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Unit Weight:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           400000000000
                         </p>
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Notes:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           -
                         </p>
@@ -1604,27 +1604,27 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="_root_54cfce"
+                  class="_root_8f9b4a"
                   style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                 >
                   <div
                     aria-controls="wishListItem5Details"
                     aria-expanded="false"
-                    class="_trigger_54cfce"
+                    class="_trigger_8f9b4a"
                   >
                     <span
-                      class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                      class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                     >
                       <span
-                        class="_editIcons_54cfce"
+                        class="_editIcons_8f9b4a"
                       >
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="destroyWishListItem5"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-xmark _fa_54cfce"
+                            class="svg-inline--fa fa-xmark _fa_8f9b4a"
                             data-icon="xmark"
                             data-prefix="fas"
                             role="img"
@@ -1637,12 +1637,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </svg>
                         </button>
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="editWishListItem5"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                            class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                             data-icon="pen-to-square"
                             data-prefix="fas"
                             role="img"
@@ -1656,21 +1656,21 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         </button>
                       </span>
                       <h3
-                        class="_description_54cfce"
+                        class="_description_8f9b4a"
                       >
                         Dwarven Cog
                       </h3>
                     </span>
                     <span
-                      class="_quantityEditable_54cfce"
+                      class="_quantityEditable_8f9b4a"
                     >
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="incrementWishListItem5"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                          class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                           data-icon="chevron-up"
                           data-prefix="fas"
                           role="img"
@@ -1683,17 +1683,17 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         </svg>
                       </button>
                       <span
-                        class="_quantityContent_54cfce"
+                        class="_quantityContent_8f9b4a"
                       >
                         1
                       </span>
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="decrementWishListItem5"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                          class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                           data-icon="chevron-down"
                           data-prefix="fas"
                           role="img"
@@ -1717,25 +1717,25 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       style="display: none;"
                     >
                       <div
-                        class="_details_54cfce"
+                        class="_details_8f9b4a"
                       >
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Unit Weight:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           10
                         </p>
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Notes:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           For trophy room
                         </p>
@@ -1749,28 +1749,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="_wishList_da4596"
+        class="_wishList_8bc9d7"
       >
         <div
-          class="_root_ec6c68"
+          class="_root_015e9f"
           style="--scheme-color: #2274a5; --border-color: #1b5c84; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #1e6894; --scheme-color-lighter: #4e8fb7; --scheme-color-lightest: #d2e3ed; --max-title-width: -16px;"
         >
           <div
             aria-controls="list5Details"
             aria-expanded="false"
-            class="_trigger_ec6c68"
+            class="_trigger_015e9f"
             role="button"
           >
             <span
-              class="_icons_ec6c68"
+              class="_icons_015e9f"
             >
               <button
-                class="_icon_ec6c68"
+                class="_icon_015e9f"
                 data-testid="destroyWishList5"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-xmark _fa_ec6c68"
+                  class="svg-inline--fa fa-xmark _fa_015e9f"
                   data-icon="xmark"
                   data-prefix="fas"
                   role="img"
@@ -1783,12 +1783,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 </svg>
               </button>
               <button
-                class="_icon_ec6c68"
+                class="_icon_015e9f"
                 data-testid="editWishList5"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                  class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                   data-icon="pen-to-square"
                   data-prefix="fas"
                   role="img"
@@ -1802,7 +1802,7 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
               </button>
             </span>
             <h3
-              class="_title_ec6c68"
+              class="_title_015e9f"
             >
               Breezehome
             </h3>
@@ -1817,19 +1817,19 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
               style="display: none;"
             >
               <div
-                class="_details_ec6c68"
+                class="_details_015e9f"
               >
                 <div
-                  class="_root_8112da _collapsed_8112da"
+                  class="_root_1a276c _collapsed_1a276c"
                   style="--base-color: #4e8fb7; --hover-color: #3881ae; --body-color: #d2e3ed; --border-color: #1b5c84; --text-color-main: #fff; --text-color-secondary: #0d2e42;"
                 >
                   <div
-                    class="_triggerContainer_8112da"
+                    class="_triggerContainer_1a276c"
                   >
                     <button
                       aria-controls="addItemToWishList5"
                       aria-expanded="false"
-                      class="_trigger_8112da"
+                      class="_trigger_1a276c"
                     >
                       Add item to list...
                     </button>
@@ -1845,14 +1845,14 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                     >
                       <form
                         aria-label="Wish list item creation form"
-                        class="_form_8112da"
+                        class="_form_1a276c"
                       >
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Description
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             name="description"
                             placeholder="Description"
                             required=""
@@ -1860,11 +1860,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Quantity
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             inputmode="numeric"
                             min="1"
                             name="quantity"
@@ -1877,11 +1877,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Unit Weight
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             inputmode="decimal"
                             min="0"
                             name="unit_weight"
@@ -1891,18 +1891,18 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Notes
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             name="notes"
                             placeholder="Notes"
                             type="text"
                           />
                         </label>
                         <button
-                          class="_submit_8112da"
+                          class="_submit_1a276c"
                           type="submit"
                         >
                           Add to List
@@ -1912,27 +1912,27 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="_root_54cfce"
+                  class="_root_8f9b4a"
                   style="--main-color: #4e8fb7; --title-text-color: #fff; --border-color: #1b5c84; --body-background-color: #d2e3ed; --body-text-color: #0d2e42; --hover-color: #3881ae;"
                 >
                   <div
                     aria-controls="wishListItem7Details"
                     aria-expanded="false"
-                    class="_trigger_54cfce"
+                    class="_trigger_8f9b4a"
                   >
                     <span
-                      class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                      class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                     >
                       <span
-                        class="_editIcons_54cfce"
+                        class="_editIcons_8f9b4a"
                       >
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="destroyWishListItem7"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-xmark _fa_54cfce"
+                            class="svg-inline--fa fa-xmark _fa_8f9b4a"
                             data-icon="xmark"
                             data-prefix="fas"
                             role="img"
@@ -1945,12 +1945,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           </svg>
                         </button>
                         <button
-                          class="_icon_54cfce"
+                          class="_icon_8f9b4a"
                           data-testid="editWishListItem7"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                            class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                             data-icon="pen-to-square"
                             data-prefix="fas"
                             role="img"
@@ -1964,21 +1964,21 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         </button>
                       </span>
                       <h3
-                        class="_description_54cfce"
+                        class="_description_8f9b4a"
                       >
                         Dwarven Cog
                       </h3>
                     </span>
                     <span
-                      class="_quantityEditable_54cfce"
+                      class="_quantityEditable_8f9b4a"
                     >
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="incrementWishListItem7"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                          class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                           data-icon="chevron-up"
                           data-prefix="fas"
                           role="img"
@@ -1991,17 +1991,17 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                         </svg>
                       </button>
                       <span
-                        class="_quantityContent_54cfce"
+                        class="_quantityContent_8f9b4a"
                       >
                         10
                       </span>
                       <button
-                        class="_icon_54cfce"
+                        class="_icon_8f9b4a"
                         data-testid="decrementWishListItem7"
                       >
                         <svg
                           aria-hidden="true"
-                          class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                          class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                           data-icon="chevron-down"
                           data-prefix="fas"
                           role="img"
@@ -2025,25 +2025,25 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                       style="display: none;"
                     >
                       <div
-                        class="_details_54cfce"
+                        class="_details_8f9b4a"
                       >
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Unit Weight:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           10
                         </p>
                         <h4
-                          class="_label_54cfce"
+                          class="_label_8f9b4a"
                         >
                           Notes:
                         </h4>
                         <p
-                          class="_value_54cfce"
+                          class="_value_8f9b4a"
                         >
                           For Arniel Gane
                         </p>
@@ -2057,28 +2057,28 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="_wishList_da4596"
+        class="_wishList_8bc9d7"
       >
         <div
-          class="_root_ec6c68"
+          class="_root_015e9f"
           style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
         >
           <div
             aria-controls="list6Details"
             aria-expanded="false"
-            class="_trigger_ec6c68"
+            class="_trigger_015e9f"
             role="button"
           >
             <span
-              class="_icons_ec6c68"
+              class="_icons_015e9f"
             >
               <button
-                class="_icon_ec6c68"
+                class="_icon_015e9f"
                 data-testid="destroyWishList6"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-xmark _fa_ec6c68"
+                  class="svg-inline--fa fa-xmark _fa_015e9f"
                   data-icon="xmark"
                   data-prefix="fas"
                   role="img"
@@ -2091,12 +2091,12 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                 </svg>
               </button>
               <button
-                class="_icon_ec6c68"
+                class="_icon_015e9f"
                 data-testid="editWishList6"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                  class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                   data-icon="pen-to-square"
                   data-prefix="fas"
                   role="img"
@@ -2110,7 +2110,7 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
               </button>
             </span>
             <h3
-              class="_title_ec6c68"
+              class="_title_015e9f"
             >
               Hjerim
             </h3>
@@ -2125,19 +2125,19 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
               style="display: none;"
             >
               <div
-                class="_details_ec6c68"
+                class="_details_015e9f"
               >
                 <div
-                  class="_root_8112da _collapsed_8112da"
+                  class="_root_1a276c _collapsed_1a276c"
                   style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
                 >
                   <div
-                    class="_triggerContainer_8112da"
+                    class="_triggerContainer_1a276c"
                   >
                     <button
                       aria-controls="addItemToWishList6"
                       aria-expanded="false"
-                      class="_trigger_8112da"
+                      class="_trigger_1a276c"
                     >
                       Add item to list...
                     </button>
@@ -2153,14 +2153,14 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                     >
                       <form
                         aria-label="Wish list item creation form"
-                        class="_form_8112da"
+                        class="_form_1a276c"
                       >
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Description
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             name="description"
                             placeholder="Description"
                             required=""
@@ -2168,11 +2168,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Quantity
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             inputmode="numeric"
                             min="1"
                             name="quantity"
@@ -2185,11 +2185,11 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Unit Weight
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             inputmode="decimal"
                             min="0"
                             name="unit_weight"
@@ -2199,18 +2199,18 @@ exports[`WishListGrouping > when there are wish lists > matches snapshot 1`] = `
                           />
                         </label>
                         <label
-                          class="_label_8112da"
+                          class="_label_1a276c"
                         >
                           Notes
                           <input
-                            class="_input_8112da"
+                            class="_input_1a276c"
                             name="notes"
                             placeholder="Notes"
                             type="text"
                           />
                         </label>
                         <button
-                          class="_submit_8112da"
+                          class="_submit_1a276c"
                           type="submit"
                         >
                           Add to List

--- a/src/components/wishListItem/__snapshots__/wishListItem.test.tsx.snap
+++ b/src/components/wishListItem/__snapshots__/wishListItem.test.tsx.snap
@@ -6,27 +6,27 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
   "baseElement": <body>
     <div>
       <div
-        class="_root_54cfce"
+        class="_root_8f9b4a"
         style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
       >
         <div
           aria-controls="wishListItem2Details"
           aria-expanded="false"
-          class="_trigger_54cfce"
+          class="_trigger_8f9b4a"
         >
           <span
-            class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+            class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
           >
             <span
-              class="_editIcons_54cfce"
+              class="_editIcons_8f9b4a"
             >
               <button
-                class="_icon_54cfce"
+                class="_icon_8f9b4a"
                 data-testid="destroyWishListItem2"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-xmark _fa_54cfce"
+                  class="svg-inline--fa fa-xmark _fa_8f9b4a"
                   data-icon="xmark"
                   data-prefix="fas"
                   role="img"
@@ -39,12 +39,12 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
                 </svg>
               </button>
               <button
-                class="_icon_54cfce"
+                class="_icon_8f9b4a"
                 data-testid="editWishListItem2"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                  class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                   data-icon="pen-to-square"
                   data-prefix="fas"
                   role="img"
@@ -58,21 +58,21 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
               </button>
             </span>
             <h3
-              class="_description_54cfce"
+              class="_description_8f9b4a"
             >
               Silver Necklace
             </h3>
           </span>
           <span
-            class="_quantityEditable_54cfce"
+            class="_quantityEditable_8f9b4a"
           >
             <button
-              class="_icon_54cfce"
+              class="_icon_8f9b4a"
               data-testid="incrementWishListItem2"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                 data-icon="chevron-up"
                 data-prefix="fas"
                 role="img"
@@ -85,17 +85,17 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
               </svg>
             </button>
             <span
-              class="_quantityContent_54cfce"
+              class="_quantityContent_8f9b4a"
             >
               2
             </span>
             <button
-              class="_icon_54cfce"
+              class="_icon_8f9b4a"
               data-testid="decrementWishListItem2"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                 data-icon="chevron-down"
                 data-prefix="fas"
                 role="img"
@@ -119,25 +119,25 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
             style="display: none;"
           >
             <div
-              class="_details_54cfce"
+              class="_details_8f9b4a"
             >
               <h4
-                class="_label_54cfce"
+                class="_label_8f9b4a"
               >
                 Unit Weight:
               </h4>
               <p
-                class="_value_54cfce"
+                class="_value_8f9b4a"
               >
                 0.3
               </p>
               <h4
-                class="_label_54cfce"
+                class="_label_8f9b4a"
               >
                 Notes:
               </h4>
               <p
-                class="_value_54cfce"
+                class="_value_8f9b4a"
               >
                 To enchant
               </p>
@@ -149,27 +149,27 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
   </body>,
   "container": <div>
     <div
-      class="_root_54cfce"
+      class="_root_8f9b4a"
       style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
     >
       <div
         aria-controls="wishListItem2Details"
         aria-expanded="false"
-        class="_trigger_54cfce"
+        class="_trigger_8f9b4a"
       >
         <span
-          class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+          class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
         >
           <span
-            class="_editIcons_54cfce"
+            class="_editIcons_8f9b4a"
           >
             <button
-              class="_icon_54cfce"
+              class="_icon_8f9b4a"
               data-testid="destroyWishListItem2"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-xmark _fa_54cfce"
+                class="svg-inline--fa fa-xmark _fa_8f9b4a"
                 data-icon="xmark"
                 data-prefix="fas"
                 role="img"
@@ -182,12 +182,12 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
               </svg>
             </button>
             <button
-              class="_icon_54cfce"
+              class="_icon_8f9b4a"
               data-testid="editWishListItem2"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                 data-icon="pen-to-square"
                 data-prefix="fas"
                 role="img"
@@ -201,21 +201,21 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
             </button>
           </span>
           <h3
-            class="_description_54cfce"
+            class="_description_8f9b4a"
           >
             Silver Necklace
           </h3>
         </span>
         <span
-          class="_quantityEditable_54cfce"
+          class="_quantityEditable_8f9b4a"
         >
           <button
-            class="_icon_54cfce"
+            class="_icon_8f9b4a"
             data-testid="incrementWishListItem2"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-chevron-up _fa_54cfce"
+              class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
               data-icon="chevron-up"
               data-prefix="fas"
               role="img"
@@ -228,17 +228,17 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
             </svg>
           </button>
           <span
-            class="_quantityContent_54cfce"
+            class="_quantityContent_8f9b4a"
           >
             2
           </span>
           <button
-            class="_icon_54cfce"
+            class="_icon_8f9b4a"
             data-testid="decrementWishListItem2"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-chevron-down _fa_54cfce"
+              class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
               data-icon="chevron-down"
               data-prefix="fas"
               role="img"
@@ -262,25 +262,25 @@ exports[`WishListItem > displaying the list item > when the list item is editabl
           style="display: none;"
         >
           <div
-            class="_details_54cfce"
+            class="_details_8f9b4a"
           >
             <h4
-              class="_label_54cfce"
+              class="_label_8f9b4a"
             >
               Unit Weight:
             </h4>
             <p
-              class="_value_54cfce"
+              class="_value_8f9b4a"
             >
               0.3
             </p>
             <h4
-              class="_label_54cfce"
+              class="_label_8f9b4a"
             >
               Notes:
             </h4>
             <p
-              class="_value_54cfce"
+              class="_value_8f9b4a"
             >
               To enchant
             </p>
@@ -349,28 +349,28 @@ exports[`WishListItem > displaying the list item > when the list item is not edi
   "baseElement": <body>
     <div>
       <div
-        class="_root_54cfce"
+        class="_root_8f9b4a"
         style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
       >
         <div
           aria-controls="wishListItem2Details"
           aria-expanded="false"
-          class="_trigger_54cfce"
+          class="_trigger_8f9b4a"
         >
           <span
-            class="_descriptionContainer_54cfce"
+            class="_descriptionContainer_8f9b4a"
           >
             <h3
-              class="_description_54cfce"
+              class="_description_8f9b4a"
             >
               Silver Necklace
             </h3>
           </span>
           <span
-            class="_quantity_54cfce"
+            class="_quantity_8f9b4a"
           >
             <span
-              class="_quantityContent_54cfce"
+              class="_quantityContent_8f9b4a"
             >
               2
             </span>
@@ -386,15 +386,15 @@ exports[`WishListItem > displaying the list item > when the list item is not edi
             style="display: none;"
           >
             <div
-              class="_details_54cfce"
+              class="_details_8f9b4a"
             >
               <h4
-                class="_label_54cfce"
+                class="_label_8f9b4a"
               >
                 Unit Weight:
               </h4>
               <p
-                class="_value_54cfce"
+                class="_value_8f9b4a"
               >
                 0.3
               </p>
@@ -406,28 +406,28 @@ exports[`WishListItem > displaying the list item > when the list item is not edi
   </body>,
   "container": <div>
     <div
-      class="_root_54cfce"
+      class="_root_8f9b4a"
       style="--main-color: #32b54e; --title-text-color: #fff; --border-color: #00821c; --body-background-color: #ccecd3; --body-text-color: #00410e; --hover-color: #19ac38;"
     >
       <div
         aria-controls="wishListItem2Details"
         aria-expanded="false"
-        class="_trigger_54cfce"
+        class="_trigger_8f9b4a"
       >
         <span
-          class="_descriptionContainer_54cfce"
+          class="_descriptionContainer_8f9b4a"
         >
           <h3
-            class="_description_54cfce"
+            class="_description_8f9b4a"
           >
             Silver Necklace
           </h3>
         </span>
         <span
-          class="_quantity_54cfce"
+          class="_quantity_8f9b4a"
         >
           <span
-            class="_quantityContent_54cfce"
+            class="_quantityContent_8f9b4a"
           >
             2
           </span>
@@ -443,15 +443,15 @@ exports[`WishListItem > displaying the list item > when the list item is not edi
           style="display: none;"
         >
           <div
-            class="_details_54cfce"
+            class="_details_8f9b4a"
           >
             <h4
-              class="_label_54cfce"
+              class="_label_8f9b4a"
             >
               Unit Weight:
             </h4>
             <p
-              class="_value_54cfce"
+              class="_value_8f9b4a"
             >
               0.3
             </p>

--- a/src/components/wishListItemCreateForm/__snapshots__/wishListItemCreateForm.test.tsx.snap
+++ b/src/components/wishListItemCreateForm/__snapshots__/wishListItemCreateForm.test.tsx.snap
@@ -6,16 +6,16 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_8112da _collapsed_8112da"
+        class="_root_1a276c _collapsed_1a276c"
         style="--base-color: #ffcb32; --hover-color: #ffc519; --body-color: #fff2cc; --border-color: #cc9800; --text-color-main: #4c3900; --text-color-secondary: #7f5700;"
       >
         <div
-          class="_triggerContainer_8112da"
+          class="_triggerContainer_1a276c"
         >
           <button
             aria-controls="addItemToWishList4"
             aria-expanded="false"
-            class="_trigger_8112da"
+            class="_trigger_1a276c"
           >
             Add item to list...
           </button>
@@ -31,14 +31,14 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
           >
             <form
               aria-label="Wish list item creation form"
-              class="_form_8112da"
+              class="_form_1a276c"
             >
               <label
-                class="_label_8112da"
+                class="_label_1a276c"
               >
                 Description
                 <input
-                  class="_input_8112da"
+                  class="_input_1a276c"
                   name="description"
                   placeholder="Description"
                   required=""
@@ -46,11 +46,11 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
                 />
               </label>
               <label
-                class="_label_8112da"
+                class="_label_1a276c"
               >
                 Quantity
                 <input
-                  class="_input_8112da"
+                  class="_input_1a276c"
                   inputmode="numeric"
                   min="1"
                   name="quantity"
@@ -63,11 +63,11 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
                 />
               </label>
               <label
-                class="_label_8112da"
+                class="_label_1a276c"
               >
                 Unit Weight
                 <input
-                  class="_input_8112da"
+                  class="_input_1a276c"
                   inputmode="decimal"
                   min="0"
                   name="unit_weight"
@@ -77,18 +77,18 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
                 />
               </label>
               <label
-                class="_label_8112da"
+                class="_label_1a276c"
               >
                 Notes
                 <input
-                  class="_input_8112da"
+                  class="_input_1a276c"
                   name="notes"
                   placeholder="Notes"
                   type="text"
                 />
               </label>
               <button
-                class="_submit_8112da"
+                class="_submit_1a276c"
                 type="submit"
               >
                 Add to List
@@ -101,16 +101,16 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_8112da _collapsed_8112da"
+      class="_root_1a276c _collapsed_1a276c"
       style="--base-color: #ffcb32; --hover-color: #ffc519; --body-color: #fff2cc; --border-color: #cc9800; --text-color-main: #4c3900; --text-color-secondary: #7f5700;"
     >
       <div
-        class="_triggerContainer_8112da"
+        class="_triggerContainer_1a276c"
       >
         <button
           aria-controls="addItemToWishList4"
           aria-expanded="false"
-          class="_trigger_8112da"
+          class="_trigger_1a276c"
         >
           Add item to list...
         </button>
@@ -126,14 +126,14 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
         >
           <form
             aria-label="Wish list item creation form"
-            class="_form_8112da"
+            class="_form_1a276c"
           >
             <label
-              class="_label_8112da"
+              class="_label_1a276c"
             >
               Description
               <input
-                class="_input_8112da"
+                class="_input_1a276c"
                 name="description"
                 placeholder="Description"
                 required=""
@@ -141,11 +141,11 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
               />
             </label>
             <label
-              class="_label_8112da"
+              class="_label_1a276c"
             >
               Quantity
               <input
-                class="_input_8112da"
+                class="_input_1a276c"
                 inputmode="numeric"
                 min="1"
                 name="quantity"
@@ -158,11 +158,11 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
               />
             </label>
             <label
-              class="_label_8112da"
+              class="_label_1a276c"
             >
               Unit Weight
               <input
-                class="_input_8112da"
+                class="_input_1a276c"
                 inputmode="decimal"
                 min="0"
                 name="unit_weight"
@@ -172,18 +172,18 @@ exports[`WishListItemCreateForm > matches snapshot 1`] = `
               />
             </label>
             <label
-              class="_label_8112da"
+              class="_label_1a276c"
             >
               Notes
               <input
-                class="_input_8112da"
+                class="_input_1a276c"
                 name="notes"
                 placeholder="Notes"
                 type="text"
               />
             </label>
             <button
-              class="_submit_8112da"
+              class="_submit_1a276c"
               type="submit"
             >
               Add to List

--- a/src/components/wishListItemEditForm/__snapshots__/wishListItemEditForm.test.tsx.snap
+++ b/src/components/wishListItemEditForm/__snapshots__/wishListItemEditForm.test.tsx.snap
@@ -6,16 +6,16 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_33b39d"
+        class="_root_c7828a"
         style="--button-background-color: #2274a5; --button-text-color: #fff; --button-hover-color: #1e6894; --button-border-color: #1b5c84;"
       >
         <h3
-          class="_header_33b39d"
+          class="_header_c7828a"
         >
           Health potion ingredients
         </h3>
         <p
-          class="_subheader_33b39d"
+          class="_subheader_c7828a"
         >
           On list "Alchemy Ingredients"
         </p>
@@ -23,14 +23,14 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
           data-testid="editWishListItem6Form"
         >
           <fieldset
-            class="_fieldset_33b39d"
+            class="_fieldset_c7828a"
           >
             <label
-              class="_label_33b39d"
+              class="_label_c7828a"
             >
               Quantity
               <input
-                class="_input_33b39d"
+                class="_input_c7828a"
                 inputmode="numeric"
                 min="1"
                 name="quantity"
@@ -44,14 +44,14 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
             </label>
           </fieldset>
           <fieldset
-            class="_fieldset_33b39d"
+            class="_fieldset_c7828a"
           >
             <label
-              class="_label_33b39d"
+              class="_label_c7828a"
             >
               Unit Weight
               <input
-                class="_input_33b39d"
+                class="_input_c7828a"
                 inputmode="decimal"
                 min="0"
                 name="unit_weight"
@@ -63,14 +63,14 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
             </label>
           </fieldset>
           <fieldset
-            class="_fieldset_33b39d"
+            class="_fieldset_c7828a"
           >
             <label
-              class="_label_33b39d"
+              class="_label_c7828a"
             >
               Notes
               <input
-                class="_input_33b39d"
+                class="_input_c7828a"
                 name="notes"
                 placeholder="Notes"
                 type="text"
@@ -78,7 +78,7 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
             </label>
           </fieldset>
           <button
-            class="_submit_33b39d"
+            class="_submit_c7828a"
             type="submit"
           >
             Update Item
@@ -89,16 +89,16 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_33b39d"
+      class="_root_c7828a"
       style="--button-background-color: #2274a5; --button-text-color: #fff; --button-hover-color: #1e6894; --button-border-color: #1b5c84;"
     >
       <h3
-        class="_header_33b39d"
+        class="_header_c7828a"
       >
         Health potion ingredients
       </h3>
       <p
-        class="_subheader_33b39d"
+        class="_subheader_c7828a"
       >
         On list "Alchemy Ingredients"
       </p>
@@ -106,14 +106,14 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
         data-testid="editWishListItem6Form"
       >
         <fieldset
-          class="_fieldset_33b39d"
+          class="_fieldset_c7828a"
         >
           <label
-            class="_label_33b39d"
+            class="_label_c7828a"
           >
             Quantity
             <input
-              class="_input_33b39d"
+              class="_input_c7828a"
               inputmode="numeric"
               min="1"
               name="quantity"
@@ -127,14 +127,14 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
           </label>
         </fieldset>
         <fieldset
-          class="_fieldset_33b39d"
+          class="_fieldset_c7828a"
         >
           <label
-            class="_label_33b39d"
+            class="_label_c7828a"
           >
             Unit Weight
             <input
-              class="_input_33b39d"
+              class="_input_c7828a"
               inputmode="decimal"
               min="0"
               name="unit_weight"
@@ -146,14 +146,14 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
           </label>
         </fieldset>
         <fieldset
-          class="_fieldset_33b39d"
+          class="_fieldset_c7828a"
         >
           <label
-            class="_label_33b39d"
+            class="_label_c7828a"
           >
             Notes
             <input
-              class="_input_33b39d"
+              class="_input_c7828a"
               name="notes"
               placeholder="Notes"
               type="text"
@@ -161,7 +161,7 @@ exports[`WishListItemEditForm > displaying the form > matches snapshot 1`] = `
           </label>
         </fieldset>
         <button
-          class="_submit_33b39d"
+          class="_submit_c7828a"
           type="submit"
         >
           Update Item

--- a/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
+++ b/src/layouts/dashboardLayout/__snapshots__/dashboardLayout.test.tsx.snap
@@ -6,49 +6,49 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Page Title
             </h2>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           Hello World
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -56,18 +56,18 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -79,29 +79,29 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -120,7 +120,7 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -130,18 +130,18 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -150,49 +150,49 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Page Title
           </h2>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         Hello World
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -200,18 +200,18 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -223,29 +223,29 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -264,7 +264,7 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -274,18 +274,18 @@ exports[`<DashboardLayout> > when a title is given > matches snapshot 1`] = `
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -351,16 +351,16 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <div
-              class="_root_0a8ecf _select_03d657"
+              class="_root_706192 _select_78663b"
               data-testid="styledSelect"
               style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
             >
@@ -369,19 +369,19 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-owns="selectListbox"
-                class="_header_0a8ecf"
+                class="_header_706192"
                 role="combobox"
               >
                 <input
                   aria-label="Add or Select Option"
-                  class="_headerText_0a8ecf"
+                  class="_headerText_706192"
                 />
                 <button
-                  class="_trigger_0a8ecf"
+                  class="_trigger_706192"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                    class="svg-inline--fa fa-angle-down _fa_706192"
                     data-icon="angle-down"
                     data-prefix="fas"
                     role="img"
@@ -395,27 +395,27 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 </button>
               </div>
               <ul
-                class="_dropdown_0a8ecf _hidden_0a8ecf"
+                class="_dropdown_706192 _hidden_706192"
                 id="selectListbox"
                 role="listbox"
               >
                 <li
                   aria-selected="false"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="32"
                   role="option"
                   tabindex="0"
                 />
                 <li
                   aria-selected="true"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="51"
                   role="option"
                   tabindex="0"
                 />
                 <li
                   aria-selected="false"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="77"
                   role="option"
                   tabindex="0"
@@ -424,34 +424,34 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
             </div>
           </div>
           <hr
-            class="_hr_03d657 _hiddenDivider_03d657"
+            class="_hr_78663b _hiddenDivider_78663b"
           />
           Hello World
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -459,18 +459,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -482,29 +482,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -523,7 +523,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -533,18 +533,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -553,16 +553,16 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <div
-            class="_root_0a8ecf _select_03d657"
+            class="_root_706192 _select_78663b"
             data-testid="styledSelect"
             style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
           >
@@ -571,19 +571,19 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-owns="selectListbox"
-              class="_header_0a8ecf"
+              class="_header_706192"
               role="combobox"
             >
               <input
                 aria-label="Add or Select Option"
-                class="_headerText_0a8ecf"
+                class="_headerText_706192"
               />
               <button
-                class="_trigger_0a8ecf"
+                class="_trigger_706192"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                  class="svg-inline--fa fa-angle-down _fa_706192"
                   data-icon="angle-down"
                   data-prefix="fas"
                   role="img"
@@ -597,27 +597,27 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               </button>
             </div>
             <ul
-              class="_dropdown_0a8ecf _hidden_0a8ecf"
+              class="_dropdown_706192 _hidden_706192"
               id="selectListbox"
               role="listbox"
             >
               <li
                 aria-selected="false"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="32"
                 role="option"
                 tabindex="0"
               />
               <li
                 aria-selected="true"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="51"
                 role="option"
                 tabindex="0"
               />
               <li
                 aria-selected="false"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="77"
                 role="option"
                 tabindex="0"
@@ -626,34 +626,34 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
           </div>
         </div>
         <hr
-          class="_hr_03d657 _hiddenDivider_03d657"
+          class="_hr_78663b _hiddenDivider_78663b"
         />
         Hello World
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -661,18 +661,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -684,29 +684,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -725,7 +725,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -735,18 +735,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -812,16 +812,16 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <div
-              class="_root_0a8ecf _select_03d657"
+              class="_root_706192 _select_78663b"
               data-testid="styledSelect"
               style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
             >
@@ -830,19 +830,19 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-owns="selectListbox"
-                class="_header_0a8ecf"
+                class="_header_706192"
                 role="combobox"
               >
                 <input
                   aria-label="Add or Select Option"
-                  class="_headerText_0a8ecf"
+                  class="_headerText_706192"
                 />
                 <button
-                  class="_trigger_0a8ecf"
+                  class="_trigger_706192"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                    class="svg-inline--fa fa-angle-down _fa_706192"
                     data-icon="angle-down"
                     data-prefix="fas"
                     role="img"
@@ -856,27 +856,27 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                 </button>
               </div>
               <ul
-                class="_dropdown_0a8ecf _hidden_0a8ecf"
+                class="_dropdown_706192 _hidden_706192"
                 id="selectListbox"
                 role="listbox"
               >
                 <li
                   aria-selected="false"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="32"
                   role="option"
                   tabindex="0"
                 />
                 <li
                   aria-selected="false"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="51"
                   role="option"
                   tabindex="0"
                 />
                 <li
                   aria-selected="false"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="77"
                   role="option"
                   tabindex="0"
@@ -885,34 +885,34 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
             </div>
           </div>
           <hr
-            class="_hr_03d657 _hiddenDivider_03d657"
+            class="_hr_78663b _hiddenDivider_78663b"
           />
           Hello World
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -920,18 +920,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -943,29 +943,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -984,7 +984,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -994,18 +994,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -1014,16 +1014,16 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <div
-            class="_root_0a8ecf _select_03d657"
+            class="_root_706192 _select_78663b"
             data-testid="styledSelect"
             style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
           >
@@ -1032,19 +1032,19 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-owns="selectListbox"
-              class="_header_0a8ecf"
+              class="_header_706192"
               role="combobox"
             >
               <input
                 aria-label="Add or Select Option"
-                class="_headerText_0a8ecf"
+                class="_headerText_706192"
               />
               <button
-                class="_trigger_0a8ecf"
+                class="_trigger_706192"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                  class="svg-inline--fa fa-angle-down _fa_706192"
                   data-icon="angle-down"
                   data-prefix="fas"
                   role="img"
@@ -1058,27 +1058,27 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
               </button>
             </div>
             <ul
-              class="_dropdown_0a8ecf _hidden_0a8ecf"
+              class="_dropdown_706192 _hidden_706192"
               id="selectListbox"
               role="listbox"
             >
               <li
                 aria-selected="false"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="32"
                 role="option"
                 tabindex="0"
               />
               <li
                 aria-selected="false"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="51"
                 role="option"
                 tabindex="0"
               />
               <li
                 aria-selected="false"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="77"
                 role="option"
                 tabindex="0"
@@ -1087,34 +1087,34 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
           </div>
         </div>
         <hr
-          class="_hr_03d657 _hiddenDivider_03d657"
+          class="_hr_78663b _hiddenDivider_78663b"
         />
         Hello World
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -1122,18 +1122,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -1145,29 +1145,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -1186,7 +1186,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -1196,18 +1196,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when a ga
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -1273,21 +1273,21 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Your Games
             </h2>
             <div
-              class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
+              class="_root_706192 _select_78663b _disabled_706192"
               data-testid="styledSelect"
               style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
             >
@@ -1296,20 +1296,20 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-owns="selectListbox"
-                class="_header_0a8ecf"
+                class="_header_706192"
                 role="combobox"
               >
                 <input
                   aria-label="Add or Select Option"
-                  class="_headerText_0a8ecf"
+                  class="_headerText_706192"
                 />
                 <button
-                  class="_trigger_0a8ecf"
+                  class="_trigger_706192"
                   disabled=""
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                    class="svg-inline--fa fa-angle-down _fa_706192"
                     data-icon="angle-down"
                     data-prefix="fas"
                     role="img"
@@ -1323,41 +1323,41 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                 </button>
               </div>
               <ul
-                class="_dropdown_0a8ecf _hidden_0a8ecf"
+                class="_dropdown_706192 _hidden_706192"
                 id="selectListbox"
                 role="listbox"
               />
             </div>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           Hello World
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -1365,18 +1365,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -1388,29 +1388,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -1429,7 +1429,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -1439,18 +1439,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -1459,21 +1459,21 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Your Games
           </h2>
           <div
-            class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
+            class="_root_706192 _select_78663b _disabled_706192"
             data-testid="styledSelect"
             style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
           >
@@ -1482,20 +1482,20 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-owns="selectListbox"
-              class="_header_0a8ecf"
+              class="_header_706192"
               role="combobox"
             >
               <input
                 aria-label="Add or Select Option"
-                class="_headerText_0a8ecf"
+                class="_headerText_706192"
               />
               <button
-                class="_trigger_0a8ecf"
+                class="_trigger_706192"
                 disabled=""
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                  class="svg-inline--fa fa-angle-down _fa_706192"
                   data-icon="angle-down"
                   data-prefix="fas"
                   role="img"
@@ -1509,41 +1509,41 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
               </button>
             </div>
             <ul
-              class="_dropdown_0a8ecf _hidden_0a8ecf"
+              class="_dropdown_706192 _hidden_706192"
               id="selectListbox"
               role="listbox"
             />
           </div>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         Hello World
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -1551,18 +1551,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -1574,29 +1574,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -1615,7 +1615,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -1625,18 +1625,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when game
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -1702,16 +1702,16 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <div
-              class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
+              class="_root_706192 _select_78663b _disabled_706192"
               data-testid="styledSelect"
               style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
             >
@@ -1720,20 +1720,20 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-owns="selectListbox"
-                class="_header_0a8ecf"
+                class="_header_706192"
                 role="combobox"
               >
                 <input
                   aria-label="Add or Select Option"
-                  class="_headerText_0a8ecf"
+                  class="_headerText_706192"
                 />
                 <button
-                  class="_trigger_0a8ecf"
+                  class="_trigger_706192"
                   disabled=""
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                    class="svg-inline--fa fa-angle-down _fa_706192"
                     data-icon="angle-down"
                     data-prefix="fas"
                     role="img"
@@ -1747,41 +1747,41 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                 </button>
               </div>
               <ul
-                class="_dropdown_0a8ecf _hidden_0a8ecf"
+                class="_dropdown_706192 _hidden_706192"
                 id="selectListbox"
                 role="listbox"
               />
             </div>
           </div>
           <hr
-            class="_hr_03d657 _hiddenDivider_03d657"
+            class="_hr_78663b _hiddenDivider_78663b"
           />
           Hello World
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -1789,18 +1789,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -1812,29 +1812,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -1853,7 +1853,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -1863,18 +1863,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -1883,16 +1883,16 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <div
-            class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
+            class="_root_706192 _select_78663b _disabled_706192"
             data-testid="styledSelect"
             style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
           >
@@ -1901,20 +1901,20 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-owns="selectListbox"
-              class="_header_0a8ecf"
+              class="_header_706192"
               role="combobox"
             >
               <input
                 aria-label="Add or Select Option"
-                class="_headerText_0a8ecf"
+                class="_headerText_706192"
               />
               <button
-                class="_trigger_0a8ecf"
+                class="_trigger_706192"
                 disabled=""
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                  class="svg-inline--fa fa-angle-down _fa_706192"
                   data-icon="angle-down"
                   data-prefix="fas"
                   role="img"
@@ -1928,41 +1928,41 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
               </button>
             </div>
             <ul
-              class="_dropdown_0a8ecf _hidden_0a8ecf"
+              class="_dropdown_706192 _hidden_706192"
               id="selectListbox"
               role="listbox"
             />
           </div>
         </div>
         <hr
-          class="_hr_03d657 _hiddenDivider_03d657"
+          class="_hr_78663b _hiddenDivider_78663b"
         />
         Hello World
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -1970,18 +1970,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -1993,29 +1993,29 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -2034,7 +2034,7 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -2044,18 +2044,18 @@ exports[`<DashboardLayout> > when includeGameSelector is set to true > when ther
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -2121,37 +2121,37 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           Hello World
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -2159,18 +2159,18 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -2182,29 +2182,29 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -2223,7 +2223,7 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -2233,18 +2233,18 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -2253,37 +2253,37 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         Hello World
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -2291,18 +2291,18 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -2314,29 +2314,29 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -2355,7 +2355,7 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -2365,18 +2365,18 @@ exports[`<DashboardLayout> > when no title is given > matches snapshot 1`] = `
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>

--- a/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
+++ b/src/pages/dashboardPage/__snapshots__/dashboardPage.test.tsx.snap
@@ -6,22 +6,22 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_root_30a763"
+            class="_root_2a6a55"
           >
             <div
-              class="_root_dcf87f"
+              class="_root_55a329"
             >
               <div
-                class="_card_dcf87f"
+                class="_card_55a329"
               >
                 <a
-                  class="_root_396ea1"
+                  class="_root_c08070"
                   href="/games"
                   style="--background-color: #ffbf00; --hover-color: #e5ab00; --text-color: #4c3900;"
                 >
@@ -29,10 +29,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                 </a>
               </div>
               <div
-                class="_card_dcf87f"
+                class="_card_55a329"
               >
                 <a
-                  class="_root_396ea1"
+                  class="_root_c08070"
                   href="/wish_lists"
                   style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
                 >
@@ -40,10 +40,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                 </a>
               </div>
               <div
-                class="_card_dcf87f"
+                class="_card_55a329"
               >
                 <a
-                  class="_root_396ea1"
+                  class="_root_c08070"
                   href="/"
                   style="--background-color: #2274a5; --hover-color: #1e6894; --text-color: #fff;"
                 >
@@ -51,10 +51,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                 </a>
               </div>
               <div
-                class="_card_dcf87f"
+                class="_card_55a329"
               >
                 <a
-                  class="_root_396ea1"
+                  class="_root_c08070"
                   href="/"
                   style="--background-color: #00a323; --hover-color: #00921f; --text-color: #fff;"
                 >
@@ -62,10 +62,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                 </a>
               </div>
               <div
-                class="_card_dcf87f"
+                class="_card_55a329"
               >
                 <a
-                  class="_root_396ea1"
+                  class="_root_c08070"
                   href="/"
                   style="--background-color: #20e2e9; --hover-color: #11cbd1; --text-color: #094345;"
                 >
@@ -76,29 +76,29 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
           </div>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -106,18 +106,18 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -129,29 +129,29 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -170,7 +170,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -180,18 +180,18 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -200,22 +200,22 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_root_30a763"
+          class="_root_2a6a55"
         >
           <div
-            class="_root_dcf87f"
+            class="_root_55a329"
           >
             <div
-              class="_card_dcf87f"
+              class="_card_55a329"
             >
               <a
-                class="_root_396ea1"
+                class="_root_c08070"
                 href="/games"
                 style="--background-color: #ffbf00; --hover-color: #e5ab00; --text-color: #4c3900;"
               >
@@ -223,10 +223,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               </a>
             </div>
             <div
-              class="_card_dcf87f"
+              class="_card_55a329"
             >
               <a
-                class="_root_396ea1"
+                class="_root_c08070"
                 href="/wish_lists"
                 style="--background-color: #e83f6f; --hover-color: #d03863; --text-color: #fff;"
               >
@@ -234,10 +234,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               </a>
             </div>
             <div
-              class="_card_dcf87f"
+              class="_card_55a329"
             >
               <a
-                class="_root_396ea1"
+                class="_root_c08070"
                 href="/"
                 style="--background-color: #2274a5; --hover-color: #1e6894; --text-color: #fff;"
               >
@@ -245,10 +245,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               </a>
             </div>
             <div
-              class="_card_dcf87f"
+              class="_card_55a329"
             >
               <a
-                class="_root_396ea1"
+                class="_root_c08070"
                 href="/"
                 style="--background-color: #00a323; --hover-color: #00921f; --text-color: #fff;"
               >
@@ -256,10 +256,10 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
               </a>
             </div>
             <div
-              class="_card_dcf87f"
+              class="_card_55a329"
             >
               <a
-                class="_root_396ea1"
+                class="_root_c08070"
                 href="/"
                 style="--background-color: #20e2e9; --hover-color: #11cbd1; --text-color: #094345;"
               >
@@ -270,29 +270,29 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
         </div>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -300,18 +300,18 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -323,29 +323,29 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -364,7 +364,7 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -374,18 +374,18 @@ exports[`<DashboardPage /> > matches snapshot 1`] = `
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -451,13 +451,13 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_root_30a763"
+            class="_root_2a6a55"
           >
             <span
               data-testid="pulseLoader"
@@ -476,29 +476,29 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
           </div>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -506,14 +506,14 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
               </h1>
             </span>
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -526,7 +526,7 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
                 </svg>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   src="/src/components/userInfo/anonymousAvatar.jpg"
                 />
               </div>
@@ -534,18 +534,18 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -554,13 +554,13 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_root_30a763"
+          class="_root_2a6a55"
         >
           <span
             data-testid="pulseLoader"
@@ -579,29 +579,29 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
         </div>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -609,14 +609,14 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
             </h1>
           </span>
           <div
-            class="_main_d263fb"
+            class="_main_658745"
           >
             <div
-              class="_button_d263fb"
+              class="_button_658745"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-bars _hamburger_d263fb"
+                class="svg-inline--fa fa-bars _hamburger_658745"
                 data-icon="bars"
                 data-prefix="fas"
                 role="img"
@@ -629,7 +629,7 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
               </svg>
               <img
                 alt="User profile image"
-                class="_img_d263fb"
+                class="_img_658745"
                 src="/src/components/userInfo/anonymousAvatar.jpg"
               />
             </div>
@@ -637,18 +637,18 @@ exports[`<DashboardPage /> > when auth is loading > matches snapshot 1`] = `
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>

--- a/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
+++ b/src/pages/gamesPage/__snapshots__/gamesPage.test.tsx.snap
@@ -6,22 +6,22 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Your Games
             </h2>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           <div>
             <span
@@ -41,29 +41,29 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
           </div>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -71,14 +71,14 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
               </h1>
             </span>
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -91,7 +91,7 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
                 </svg>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   src="/src/components/userInfo/anonymousAvatar.jpg"
                 />
               </div>
@@ -99,18 +99,18 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -119,22 +119,22 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Your Games
           </h2>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         <div>
           <span
@@ -154,29 +154,29 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
         </div>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -184,14 +184,14 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
             </h1>
           </span>
           <div
-            class="_main_d263fb"
+            class="_main_658745"
           >
             <div
-              class="_button_d263fb"
+              class="_button_658745"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-bars _hamburger_d263fb"
+                class="svg-inline--fa fa-bars _hamburger_658745"
                 data-icon="bars"
                 data-prefix="fas"
                 role="img"
@@ -204,7 +204,7 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
               </svg>
               <img
                 alt="User profile image"
-                class="_img_d263fb"
+                class="_img_658745"
                 src="/src/components/userInfo/anonymousAvatar.jpg"
               />
             </div>
@@ -212,18 +212,18 @@ exports[`<GamesPage /> > viewing games > when loading > matches snapshot 1`] = `
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -289,22 +289,22 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Your Games
             </h2>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           <div>
             <span
@@ -324,29 +324,29 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
           </div>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -354,18 +354,18 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -377,29 +377,29 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -418,7 +418,7 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -428,18 +428,18 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -448,22 +448,22 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Your Games
           </h2>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         <div>
           <span
@@ -483,29 +483,29 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
         </div>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -513,18 +513,18 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -536,29 +536,29 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -577,7 +577,7 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -587,18 +587,18 @@ exports[`<GamesPage /> > viewing games > when the server returns an error > matc
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -664,22 +664,22 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Your Games
             </h2>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           <div>
             <span
@@ -699,29 +699,29 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
           </div>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -729,18 +729,18 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -752,29 +752,29 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -793,7 +793,7 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -803,18 +803,18 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -823,22 +823,22 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Your Games
           </h2>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         <div>
           <span
@@ -858,29 +858,29 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
         </div>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -888,18 +888,18 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -911,29 +911,29 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -952,7 +952,7 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -962,18 +962,18 @@ exports[`<GamesPage /> > viewing games > when there are multiple games > matches
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -1039,22 +1039,22 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Your Games
             </h2>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           <div>
             <span
@@ -1074,29 +1074,29 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
           </div>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -1104,18 +1104,18 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -1127,29 +1127,29 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -1168,7 +1168,7 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -1178,18 +1178,18 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -1198,22 +1198,22 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Your Games
           </h2>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         <div>
           <span
@@ -1233,29 +1233,29 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
         </div>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -1263,18 +1263,18 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -1286,29 +1286,29 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -1327,7 +1327,7 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -1337,18 +1337,18 @@ exports[`<GamesPage /> > viewing games > when there are no games > matches snaps
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>

--- a/src/pages/homePage/__snapshots__/homePage.test.tsx.snap
+++ b/src/pages/homePage/__snapshots__/homePage.test.tsx.snap
@@ -6,25 +6,25 @@ exports[`<HomePage /> > when unauthenticated > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_d1e903"
+        class="_root_1d9dec"
       >
         <div
-          class="_container_d1e903"
+          class="_container_1d9dec"
         >
           <h1
-            class="_header_d1e903"
+            class="_header_1d9dec"
           >
             Skyrim Inventory Management
           </h1>
           <div
-            class="_login_d1e903"
+            class="_login_1d9dec"
           >
             <button
-              class="_root_7e43e6"
+              class="_root_913e3c"
               value="Sign in with Google"
             >
               <div
-                class="_background_7e43e6"
+                class="_background_913e3c"
               />
             </button>
           </div>
@@ -34,25 +34,25 @@ exports[`<HomePage /> > when unauthenticated > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_d1e903"
+      class="_root_1d9dec"
     >
       <div
-        class="_container_d1e903"
+        class="_container_1d9dec"
       >
         <h1
-          class="_header_d1e903"
+          class="_header_1d9dec"
         >
           Skyrim Inventory Management
         </h1>
         <div
-          class="_login_d1e903"
+          class="_login_1d9dec"
         >
           <button
-            class="_root_7e43e6"
+            class="_root_913e3c"
             value="Sign in with Google"
           >
             <div
-              class="_background_7e43e6"
+              class="_background_913e3c"
             />
           </button>
         </div>

--- a/src/pages/notFoundPage/__snapshots__/notFoundPage.test.tsx.snap
+++ b/src/pages/notFoundPage/__snapshots__/notFoundPage.test.tsx.snap
@@ -6,18 +6,18 @@ exports[`<NotFoundPage /> > matches snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="_root_5d635c"
+        class="_root_9c76bb"
       >
         <div
-          class="_container_5d635c"
+          class="_container_9c76bb"
         >
           <h1
-            class="_header_5d635c"
+            class="_header_9c76bb"
           >
             SIM: Page Not Found
           </h1>
           <a
-            class="_link_5d635c"
+            class="_link_9c76bb"
             href="/"
           >
             Go Back
@@ -28,18 +28,18 @@ exports[`<NotFoundPage /> > matches snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="_root_5d635c"
+      class="_root_9c76bb"
     >
       <div
-        class="_container_5d635c"
+        class="_container_9c76bb"
       >
         <h1
-          class="_header_5d635c"
+          class="_header_9c76bb"
         >
           SIM: Page Not Found
         </h1>
         <a
-          class="_link_5d635c"
+          class="_link_9c76bb"
           href="/"
         >
           Go Back

--- a/src/pages/wishListsPage/__snapshots__/wishListsPage.test.tsx.snap
+++ b/src/pages/wishListsPage/__snapshots__/wishListsPage.test.tsx.snap
@@ -6,21 +6,21 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Your Wish Lists
             </h2>
             <div
-              class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
+              class="_root_706192 _select_78663b _disabled_706192"
               data-testid="styledSelect"
               style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
             >
@@ -29,20 +29,20 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-owns="selectListbox"
-                class="_header_0a8ecf"
+                class="_header_706192"
                 role="combobox"
               >
                 <input
                   aria-label="Add or Select Option"
-                  class="_headerText_0a8ecf"
+                  class="_headerText_706192"
                 />
                 <button
-                  class="_trigger_0a8ecf"
+                  class="_trigger_706192"
                   disabled=""
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                    class="svg-inline--fa fa-angle-down _fa_706192"
                     data-icon="angle-down"
                     data-prefix="fas"
                     role="img"
@@ -56,25 +56,25 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
                 </button>
               </div>
               <ul
-                class="_dropdown_0a8ecf _hidden_0a8ecf"
+                class="_dropdown_706192 _hidden_706192"
                 id="selectListbox"
                 role="listbox"
               />
             </div>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           <form
-            class="_root_15ecd1"
+            class="_root_f9e5f5"
             style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
           >
             <fieldset
-              class="_fieldset_15ecd1"
+              class="_fieldset_f9e5f5"
             >
               <input
                 aria-label="Title"
-                class="_input_15ecd1"
+                class="_input_f9e5f5"
                 disabled=""
                 name="title"
                 pattern="\\s*[A-Za-z0-9 \\-',]*\\s*"
@@ -83,7 +83,7 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
                 type="text"
               />
               <button
-                class="_button_15ecd1"
+                class="_button_f9e5f5"
                 disabled=""
                 type="submit"
               >
@@ -107,29 +107,29 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
           </span>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -137,14 +137,14 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
               </h1>
             </span>
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -157,7 +157,7 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
                 </svg>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   src="/src/components/userInfo/anonymousAvatar.jpg"
                 />
               </div>
@@ -165,18 +165,18 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -185,21 +185,21 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Your Wish Lists
           </h2>
           <div
-            class="_root_0a8ecf _select_03d657 _disabled_0a8ecf"
+            class="_root_706192 _select_78663b _disabled_706192"
             data-testid="styledSelect"
             style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
           >
@@ -208,20 +208,20 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-owns="selectListbox"
-              class="_header_0a8ecf"
+              class="_header_706192"
               role="combobox"
             >
               <input
                 aria-label="Add or Select Option"
-                class="_headerText_0a8ecf"
+                class="_headerText_706192"
               />
               <button
-                class="_trigger_0a8ecf"
+                class="_trigger_706192"
                 disabled=""
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                  class="svg-inline--fa fa-angle-down _fa_706192"
                   data-icon="angle-down"
                   data-prefix="fas"
                   role="img"
@@ -235,25 +235,25 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
               </button>
             </div>
             <ul
-              class="_dropdown_0a8ecf _hidden_0a8ecf"
+              class="_dropdown_706192 _hidden_706192"
               id="selectListbox"
               role="listbox"
             />
           </div>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         <form
-          class="_root_15ecd1"
+          class="_root_f9e5f5"
           style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
         >
           <fieldset
-            class="_fieldset_15ecd1"
+            class="_fieldset_f9e5f5"
           >
             <input
               aria-label="Title"
-              class="_input_15ecd1"
+              class="_input_f9e5f5"
               disabled=""
               name="title"
               pattern="\\s*[A-Za-z0-9 \\-',]*\\s*"
@@ -262,7 +262,7 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
               type="text"
             />
             <button
-              class="_button_15ecd1"
+              class="_button_f9e5f5"
               disabled=""
               type="submit"
             >
@@ -286,29 +286,29 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
         </span>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -316,14 +316,14 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
             </h1>
           </span>
           <div
-            class="_main_d263fb"
+            class="_main_658745"
           >
             <div
-              class="_button_d263fb"
+              class="_button_658745"
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-bars _hamburger_d263fb"
+                class="svg-inline--fa fa-bars _hamburger_658745"
                 data-icon="bars"
                 data-prefix="fas"
                 role="img"
@@ -336,7 +336,7 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
               </svg>
               <img
                 alt="User profile image"
-                class="_img_d263fb"
+                class="_img_658745"
                 src="/src/components/userInfo/anonymousAvatar.jpg"
               />
             </div>
@@ -344,18 +344,18 @@ exports[`WishListsPage > viewing wish lists > when loading > matches snapshot 1`
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>
@@ -421,21 +421,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
   "baseElement": <body>
     <div>
       <main
-        class="_root_03d657"
+        class="_root_78663b"
       >
         <section
-          class="_container_03d657"
+          class="_container_78663b"
         >
           <div
-            class="_titleContainer_03d657"
+            class="_titleContainer_78663b"
           >
             <h2
-              class="_title_03d657"
+              class="_title_78663b"
             >
               Your Wish Lists
             </h2>
             <div
-              class="_root_0a8ecf _select_03d657"
+              class="_root_706192 _select_78663b"
               data-testid="styledSelect"
               style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
             >
@@ -444,19 +444,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-owns="selectListbox"
-                class="_header_0a8ecf"
+                class="_header_706192"
                 role="combobox"
               >
                 <input
                   aria-label="Add or Select Option"
-                  class="_headerText_0a8ecf"
+                  class="_headerText_706192"
                 />
                 <button
-                  class="_trigger_0a8ecf"
+                  class="_trigger_706192"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                    class="svg-inline--fa fa-angle-down _fa_706192"
                     data-icon="angle-down"
                     data-prefix="fas"
                     role="img"
@@ -470,27 +470,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                 </button>
               </div>
               <ul
-                class="_dropdown_0a8ecf _hidden_0a8ecf"
+                class="_dropdown_706192 _hidden_706192"
                 id="selectListbox"
                 role="listbox"
               >
                 <li
                   aria-selected="false"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="32"
                   role="option"
                   tabindex="0"
                 />
                 <li
                   aria-selected="false"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="51"
                   role="option"
                   tabindex="0"
                 />
                 <li
                   aria-selected="true"
-                  class="_root_b75fe4"
+                  class="_root_6af4e6"
                   data-option-value="77"
                   role="option"
                   tabindex="0"
@@ -499,18 +499,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
             </div>
           </div>
           <hr
-            class="_hr_03d657"
+            class="_hr_78663b"
           />
           <form
-            class="_root_15ecd1"
+            class="_root_f9e5f5"
             style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
           >
             <fieldset
-              class="_fieldset_15ecd1"
+              class="_fieldset_f9e5f5"
             >
               <input
                 aria-label="Title"
-                class="_input_15ecd1"
+                class="_input_f9e5f5"
                 name="title"
                 pattern="\\s*[A-Za-z0-9 \\-',]*\\s*"
                 placeholder="Title"
@@ -518,7 +518,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                 type="text"
               />
               <button
-                class="_button_15ecd1"
+                class="_button_f9e5f5"
                 type="submit"
               >
                 Create
@@ -526,23 +526,23 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
             </fieldset>
           </form>
           <div
-            class="_root_da4596"
+            class="_root_8bc9d7"
           >
             <div
-              class="_wishList_da4596"
+              class="_wishList_8bc9d7"
             >
               <div
-                class="_root_ec6c68"
+                class="_root_015e9f"
                 style="--scheme-color: #ffbf00; --border-color: #cc9800; --text-color-primary: #4c3900; --text-color-secondary: #4c3900; --hover-color: #e5ab00; --scheme-color-lighter: #ffcb32; --scheme-color-lightest: #fff2cc; --max-title-width: -32px;"
               >
                 <div
                   aria-controls="list3Details"
                   aria-expanded="false"
-                  class="_trigger_ec6c68"
+                  class="_trigger_015e9f"
                   role="button"
                 >
                   <h3
-                    class="_title_ec6c68"
+                    class="_title_015e9f"
                   >
                     All Items
                   </h3>
@@ -557,31 +557,31 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     style="display: none;"
                   >
                     <div
-                      class="_details_ec6c68"
+                      class="_details_015e9f"
                     >
                       <div
-                        class="_root_54cfce"
+                        class="_root_8f9b4a"
                         style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                       >
                         <div
                           aria-controls="wishListItem6Details"
                           aria-expanded="false"
-                          class="_trigger_54cfce"
+                          class="_trigger_8f9b4a"
                         >
                           <span
-                            class="_descriptionContainer_54cfce"
+                            class="_descriptionContainer_8f9b4a"
                           >
                             <h3
-                              class="_description_54cfce"
+                              class="_description_8f9b4a"
                             >
                               Dwarven Cog
                             </h3>
                           </span>
                           <span
-                            class="_quantity_54cfce"
+                            class="_quantity_8f9b4a"
                           >
                             <span
-                              class="_quantityContent_54cfce"
+                              class="_quantityContent_8f9b4a"
                             >
                               11
                             </span>
@@ -597,15 +597,15 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             style="display: none;"
                           >
                             <div
-                              class="_details_54cfce"
+                              class="_details_8f9b4a"
                             >
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Unit Weight:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 10
                               </p>
@@ -614,28 +614,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                         </div>
                       </div>
                       <div
-                        class="_root_54cfce"
+                        class="_root_8f9b4a"
                         style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                       >
                         <div
                           aria-controls="wishListItem9Details"
                           aria-expanded="false"
-                          class="_trigger_54cfce"
+                          class="_trigger_8f9b4a"
                         >
                           <span
-                            class="_descriptionContainer_54cfce"
+                            class="_descriptionContainer_8f9b4a"
                           >
                             <h3
-                              class="_description_54cfce"
+                              class="_description_8f9b4a"
                             >
                               This item has a really really really really really long description for testing purposes
                             </h3>
                           </span>
                           <span
-                            class="_quantity_54cfce"
+                            class="_quantity_8f9b4a"
                           >
                             <span
-                              class="_quantityContent_54cfce"
+                              class="_quantityContent_8f9b4a"
                             >
                               200000000000
                             </span>
@@ -651,15 +651,15 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             style="display: none;"
                           >
                             <div
-                              class="_details_54cfce"
+                              class="_details_8f9b4a"
                             >
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Unit Weight:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 400000000000
                               </p>
@@ -673,28 +673,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
               </div>
             </div>
             <div
-              class="_wishList_da4596"
+              class="_wishList_8bc9d7"
             >
               <div
-                class="_root_ec6c68"
+                class="_root_015e9f"
                 style="--scheme-color: #e83f6f; --border-color: #b93258; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #d03863; --scheme-color-lighter: #ec658b; --scheme-color-lightest: #fad8e2; --max-title-width: -16px;"
               >
                 <div
                   aria-controls="list4Details"
                   aria-expanded="false"
-                  class="_trigger_ec6c68"
+                  class="_trigger_015e9f"
                   role="button"
                 >
                   <span
-                    class="_icons_ec6c68"
+                    class="_icons_015e9f"
                   >
                     <button
-                      class="_icon_ec6c68"
+                      class="_icon_015e9f"
                       data-testid="destroyWishList4"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-xmark _fa_ec6c68"
+                        class="svg-inline--fa fa-xmark _fa_015e9f"
                         data-icon="xmark"
                         data-prefix="fas"
                         role="img"
@@ -707,12 +707,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                       </svg>
                     </button>
                     <button
-                      class="_icon_ec6c68"
+                      class="_icon_015e9f"
                       data-testid="editWishList4"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                        class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                         data-icon="pen-to-square"
                         data-prefix="fas"
                         role="img"
@@ -726,7 +726,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     </button>
                   </span>
                   <h3
-                    class="_title_ec6c68"
+                    class="_title_015e9f"
                   >
                     Honeyside
                   </h3>
@@ -741,19 +741,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     style="display: none;"
                   >
                     <div
-                      class="_details_ec6c68"
+                      class="_details_015e9f"
                     >
                       <div
-                        class="_root_8112da _collapsed_8112da"
+                        class="_root_1a276c _collapsed_1a276c"
                         style="--base-color: #ec658b; --hover-color: #ea527d; --body-color: #fad8e2; --border-color: #b93258; --text-color-main: #fff; --text-color-secondary: #451221;"
                       >
                         <div
-                          class="_triggerContainer_8112da"
+                          class="_triggerContainer_1a276c"
                         >
                           <button
                             aria-controls="addItemToWishList4"
                             aria-expanded="false"
-                            class="_trigger_8112da"
+                            class="_trigger_1a276c"
                           >
                             Add item to list...
                           </button>
@@ -769,14 +769,14 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           >
                             <form
                               aria-label="Wish list item creation form"
-                              class="_form_8112da"
+                              class="_form_1a276c"
                             >
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Description
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   name="description"
                                   placeholder="Description"
                                   required=""
@@ -784,11 +784,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Quantity
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   inputmode="numeric"
                                   min="1"
                                   name="quantity"
@@ -801,11 +801,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Unit Weight
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   inputmode="decimal"
                                   min="0"
                                   name="unit_weight"
@@ -815,18 +815,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Notes
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   name="notes"
                                   placeholder="Notes"
                                   type="text"
                                 />
                               </label>
                               <button
-                                class="_submit_8112da"
+                                class="_submit_1a276c"
                                 type="submit"
                               >
                                 Add to List
@@ -836,27 +836,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                         </div>
                       </div>
                       <div
-                        class="_root_54cfce"
+                        class="_root_8f9b4a"
                         style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                       >
                         <div
                           aria-controls="wishListItem8Details"
                           aria-expanded="false"
-                          class="_trigger_54cfce"
+                          class="_trigger_8f9b4a"
                         >
                           <span
-                            class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                            class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                           >
                             <span
-                              class="_editIcons_54cfce"
+                              class="_editIcons_8f9b4a"
                             >
                               <button
-                                class="_icon_54cfce"
+                                class="_icon_8f9b4a"
                                 data-testid="destroyWishListItem8"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="svg-inline--fa fa-xmark _fa_54cfce"
+                                  class="svg-inline--fa fa-xmark _fa_8f9b4a"
                                   data-icon="xmark"
                                   data-prefix="fas"
                                   role="img"
@@ -869,12 +869,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 </svg>
                               </button>
                               <button
-                                class="_icon_54cfce"
+                                class="_icon_8f9b4a"
                                 data-testid="editWishListItem8"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                                  class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                                   data-icon="pen-to-square"
                                   data-prefix="fas"
                                   role="img"
@@ -888,21 +888,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </button>
                             </span>
                             <h3
-                              class="_description_54cfce"
+                              class="_description_8f9b4a"
                             >
                               This item has a really really really really really long description for testing purposes
                             </h3>
                           </span>
                           <span
-                            class="_quantityEditable_54cfce"
+                            class="_quantityEditable_8f9b4a"
                           >
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="incrementWishListItem8"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                                class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                                 data-icon="chevron-up"
                                 data-prefix="fas"
                                 role="img"
@@ -915,17 +915,17 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </svg>
                             </button>
                             <span
-                              class="_quantityContent_54cfce"
+                              class="_quantityContent_8f9b4a"
                             >
                               200000000000
                             </span>
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="decrementWishListItem8"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                                class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                                 data-icon="chevron-down"
                                 data-prefix="fas"
                                 role="img"
@@ -949,25 +949,25 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             style="display: none;"
                           >
                             <div
-                              class="_details_54cfce"
+                              class="_details_8f9b4a"
                             >
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Unit Weight:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 400000000000
                               </p>
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Notes:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 -
                               </p>
@@ -976,27 +976,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                         </div>
                       </div>
                       <div
-                        class="_root_54cfce"
+                        class="_root_8f9b4a"
                         style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                       >
                         <div
                           aria-controls="wishListItem5Details"
                           aria-expanded="false"
-                          class="_trigger_54cfce"
+                          class="_trigger_8f9b4a"
                         >
                           <span
-                            class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                            class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                           >
                             <span
-                              class="_editIcons_54cfce"
+                              class="_editIcons_8f9b4a"
                             >
                               <button
-                                class="_icon_54cfce"
+                                class="_icon_8f9b4a"
                                 data-testid="destroyWishListItem5"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="svg-inline--fa fa-xmark _fa_54cfce"
+                                  class="svg-inline--fa fa-xmark _fa_8f9b4a"
                                   data-icon="xmark"
                                   data-prefix="fas"
                                   role="img"
@@ -1009,12 +1009,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 </svg>
                               </button>
                               <button
-                                class="_icon_54cfce"
+                                class="_icon_8f9b4a"
                                 data-testid="editWishListItem5"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                                  class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                                   data-icon="pen-to-square"
                                   data-prefix="fas"
                                   role="img"
@@ -1028,21 +1028,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </button>
                             </span>
                             <h3
-                              class="_description_54cfce"
+                              class="_description_8f9b4a"
                             >
                               Dwarven Cog
                             </h3>
                           </span>
                           <span
-                            class="_quantityEditable_54cfce"
+                            class="_quantityEditable_8f9b4a"
                           >
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="incrementWishListItem5"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                                class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                                 data-icon="chevron-up"
                                 data-prefix="fas"
                                 role="img"
@@ -1055,17 +1055,17 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </svg>
                             </button>
                             <span
-                              class="_quantityContent_54cfce"
+                              class="_quantityContent_8f9b4a"
                             >
                               1
                             </span>
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="decrementWishListItem5"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                                class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                                 data-icon="chevron-down"
                                 data-prefix="fas"
                                 role="img"
@@ -1089,25 +1089,25 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             style="display: none;"
                           >
                             <div
-                              class="_details_54cfce"
+                              class="_details_8f9b4a"
                             >
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Unit Weight:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 10
                               </p>
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Notes:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 For trophy room
                               </p>
@@ -1121,28 +1121,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
               </div>
             </div>
             <div
-              class="_wishList_da4596"
+              class="_wishList_8bc9d7"
             >
               <div
-                class="_root_ec6c68"
+                class="_root_015e9f"
                 style="--scheme-color: #2274a5; --border-color: #1b5c84; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #1e6894; --scheme-color-lighter: #4e8fb7; --scheme-color-lightest: #d2e3ed; --max-title-width: -16px;"
               >
                 <div
                   aria-controls="list5Details"
                   aria-expanded="false"
-                  class="_trigger_ec6c68"
+                  class="_trigger_015e9f"
                   role="button"
                 >
                   <span
-                    class="_icons_ec6c68"
+                    class="_icons_015e9f"
                   >
                     <button
-                      class="_icon_ec6c68"
+                      class="_icon_015e9f"
                       data-testid="destroyWishList5"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-xmark _fa_ec6c68"
+                        class="svg-inline--fa fa-xmark _fa_015e9f"
                         data-icon="xmark"
                         data-prefix="fas"
                         role="img"
@@ -1155,12 +1155,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                       </svg>
                     </button>
                     <button
-                      class="_icon_ec6c68"
+                      class="_icon_015e9f"
                       data-testid="editWishList5"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                        class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                         data-icon="pen-to-square"
                         data-prefix="fas"
                         role="img"
@@ -1174,7 +1174,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     </button>
                   </span>
                   <h3
-                    class="_title_ec6c68"
+                    class="_title_015e9f"
                   >
                     Breezehome
                   </h3>
@@ -1189,19 +1189,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     style="display: none;"
                   >
                     <div
-                      class="_details_ec6c68"
+                      class="_details_015e9f"
                     >
                       <div
-                        class="_root_8112da _collapsed_8112da"
+                        class="_root_1a276c _collapsed_1a276c"
                         style="--base-color: #4e8fb7; --hover-color: #3881ae; --body-color: #d2e3ed; --border-color: #1b5c84; --text-color-main: #fff; --text-color-secondary: #0d2e42;"
                       >
                         <div
-                          class="_triggerContainer_8112da"
+                          class="_triggerContainer_1a276c"
                         >
                           <button
                             aria-controls="addItemToWishList5"
                             aria-expanded="false"
-                            class="_trigger_8112da"
+                            class="_trigger_1a276c"
                           >
                             Add item to list...
                           </button>
@@ -1217,14 +1217,14 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           >
                             <form
                               aria-label="Wish list item creation form"
-                              class="_form_8112da"
+                              class="_form_1a276c"
                             >
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Description
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   name="description"
                                   placeholder="Description"
                                   required=""
@@ -1232,11 +1232,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Quantity
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   inputmode="numeric"
                                   min="1"
                                   name="quantity"
@@ -1249,11 +1249,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Unit Weight
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   inputmode="decimal"
                                   min="0"
                                   name="unit_weight"
@@ -1263,18 +1263,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Notes
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   name="notes"
                                   placeholder="Notes"
                                   type="text"
                                 />
                               </label>
                               <button
-                                class="_submit_8112da"
+                                class="_submit_1a276c"
                                 type="submit"
                               >
                                 Add to List
@@ -1284,27 +1284,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                         </div>
                       </div>
                       <div
-                        class="_root_54cfce"
+                        class="_root_8f9b4a"
                         style="--main-color: #4e8fb7; --title-text-color: #fff; --border-color: #1b5c84; --body-background-color: #d2e3ed; --body-text-color: #0d2e42; --hover-color: #3881ae;"
                       >
                         <div
                           aria-controls="wishListItem7Details"
                           aria-expanded="false"
-                          class="_trigger_54cfce"
+                          class="_trigger_8f9b4a"
                         >
                           <span
-                            class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                            class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                           >
                             <span
-                              class="_editIcons_54cfce"
+                              class="_editIcons_8f9b4a"
                             >
                               <button
-                                class="_icon_54cfce"
+                                class="_icon_8f9b4a"
                                 data-testid="destroyWishListItem7"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="svg-inline--fa fa-xmark _fa_54cfce"
+                                  class="svg-inline--fa fa-xmark _fa_8f9b4a"
                                   data-icon="xmark"
                                   data-prefix="fas"
                                   role="img"
@@ -1317,12 +1317,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 </svg>
                               </button>
                               <button
-                                class="_icon_54cfce"
+                                class="_icon_8f9b4a"
                                 data-testid="editWishListItem7"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                                  class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                                   data-icon="pen-to-square"
                                   data-prefix="fas"
                                   role="img"
@@ -1336,21 +1336,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </button>
                             </span>
                             <h3
-                              class="_description_54cfce"
+                              class="_description_8f9b4a"
                             >
                               Dwarven Cog
                             </h3>
                           </span>
                           <span
-                            class="_quantityEditable_54cfce"
+                            class="_quantityEditable_8f9b4a"
                           >
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="incrementWishListItem7"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                                class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                                 data-icon="chevron-up"
                                 data-prefix="fas"
                                 role="img"
@@ -1363,17 +1363,17 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </svg>
                             </button>
                             <span
-                              class="_quantityContent_54cfce"
+                              class="_quantityContent_8f9b4a"
                             >
                               10
                             </span>
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="decrementWishListItem7"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                                class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                                 data-icon="chevron-down"
                                 data-prefix="fas"
                                 role="img"
@@ -1397,25 +1397,25 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             style="display: none;"
                           >
                             <div
-                              class="_details_54cfce"
+                              class="_details_8f9b4a"
                             >
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Unit Weight:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 10
                               </p>
                               <h4
-                                class="_label_54cfce"
+                                class="_label_8f9b4a"
                               >
                                 Notes:
                               </h4>
                               <p
-                                class="_value_54cfce"
+                                class="_value_8f9b4a"
                               >
                                 For Arniel Gane
                               </p>
@@ -1429,28 +1429,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
               </div>
             </div>
             <div
-              class="_wishList_da4596"
+              class="_wishList_8bc9d7"
             >
               <div
-                class="_root_ec6c68"
+                class="_root_015e9f"
                 style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
               >
                 <div
                   aria-controls="list6Details"
                   aria-expanded="false"
-                  class="_trigger_ec6c68"
+                  class="_trigger_015e9f"
                   role="button"
                 >
                   <span
-                    class="_icons_ec6c68"
+                    class="_icons_015e9f"
                   >
                     <button
-                      class="_icon_ec6c68"
+                      class="_icon_015e9f"
                       data-testid="destroyWishList6"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-xmark _fa_ec6c68"
+                        class="svg-inline--fa fa-xmark _fa_015e9f"
                         data-icon="xmark"
                         data-prefix="fas"
                         role="img"
@@ -1463,12 +1463,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                       </svg>
                     </button>
                     <button
-                      class="_icon_ec6c68"
+                      class="_icon_015e9f"
                       data-testid="editWishList6"
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                        class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                         data-icon="pen-to-square"
                         data-prefix="fas"
                         role="img"
@@ -1482,7 +1482,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     </button>
                   </span>
                   <h3
-                    class="_title_ec6c68"
+                    class="_title_015e9f"
                   >
                     Hjerim
                   </h3>
@@ -1497,19 +1497,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     style="display: none;"
                   >
                     <div
-                      class="_details_ec6c68"
+                      class="_details_015e9f"
                     >
                       <div
-                        class="_root_8112da _collapsed_8112da"
+                        class="_root_1a276c _collapsed_1a276c"
                         style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
                       >
                         <div
-                          class="_triggerContainer_8112da"
+                          class="_triggerContainer_1a276c"
                         >
                           <button
                             aria-controls="addItemToWishList6"
                             aria-expanded="false"
-                            class="_trigger_8112da"
+                            class="_trigger_1a276c"
                           >
                             Add item to list...
                           </button>
@@ -1525,14 +1525,14 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           >
                             <form
                               aria-label="Wish list item creation form"
-                              class="_form_8112da"
+                              class="_form_1a276c"
                             >
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Description
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   name="description"
                                   placeholder="Description"
                                   required=""
@@ -1540,11 +1540,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Quantity
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   inputmode="numeric"
                                   min="1"
                                   name="quantity"
@@ -1557,11 +1557,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Unit Weight
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   inputmode="decimal"
                                   min="0"
                                   name="unit_weight"
@@ -1571,18 +1571,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                                 />
                               </label>
                               <label
-                                class="_label_8112da"
+                                class="_label_1a276c"
                               >
                                 Notes
                                 <input
-                                  class="_input_8112da"
+                                  class="_input_1a276c"
                                   name="notes"
                                   placeholder="Notes"
                                   type="text"
                                 />
                               </label>
                               <button
-                                class="_submit_8112da"
+                                class="_submit_1a276c"
                                 type="submit"
                               >
                                 Add to List
@@ -1599,29 +1599,29 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
           </div>
         </section>
         <header
-          class="_root_c29812"
+          class="_root_faea2d"
         >
           <div
-            class="_bar_c29812"
+            class="_bar_faea2d"
           >
             <span
-              class="_headerContainer_c29812"
+              class="_headerContainer_faea2d"
             >
               <h1
-                class="_header_c29812"
+                class="_header_faea2d"
               >
                 <a
-                  class="_headerLinkLarge_c29812"
+                  class="_headerLinkLarge_faea2d"
                   href="/dashboard"
                 >
                   Skyrim Inventory
                   <br
-                    class="_bp_c29812"
+                    class="_bp_faea2d"
                   />
                    Management
                 </a>
                 <a
-                  class="_headerLinkSmall_c29812"
+                  class="_headerLinkSmall_faea2d"
                   href="/dashboard"
                 >
                   S. I. M.
@@ -1629,18 +1629,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
               </h1>
             </span>
             <span
-              class="_root_d263fb"
+              class="_root_658745"
             >
               <div
-                class="_main_d263fb"
+                class="_main_658745"
               >
                 <div
-                  class="_button_d263fb"
+                  class="_button_658745"
                   role="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="svg-inline--fa fa-bars _hamburger_d263fb"
+                    class="svg-inline--fa fa-bars _hamburger_658745"
                     data-icon="bars"
                     data-prefix="fas"
                     role="img"
@@ -1652,29 +1652,29 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     />
                   </svg>
                   <span
-                    class="_info_d263fb"
+                    class="_info_658745"
                   >
                     <p
-                      class="_name_d263fb"
+                      class="_name_658745"
                     >
                       Edna St. Vincent Millay
                     </p>
                     <p
-                      class="_email_d263fb"
+                      class="_email_658745"
                     >
                       edna@gmail.com
                     </p>
                   </span>
                   <img
                     alt="User profile image"
-                    class="_img_d263fb"
+                    class="_img_658745"
                     referrerpolicy="no-referrer"
                     src="/src/support/testProfileImg.png"
                   />
                 </div>
               </div>
               <menu
-                class="_dropdown_d263fb"
+                class="_dropdown_658745"
               >
                 <div
                   role="button"
@@ -1693,7 +1693,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     />
                   </svg>
                   <p
-                    class="_signOutText_d263fb"
+                    class="_signOutText_658745"
                   >
                     Sign Out
                   </p>
@@ -1703,18 +1703,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
           </div>
         </header>
         <div
-          class="_root_91d025 _hidden_91d025"
+          class="_root_ca8db5 _hidden_ca8db5"
           style="--text-color: #4e6d83;"
         />
         <div
-          class="_root_753dd0 _hidden_753dd0"
+          class="_root_c33b14 _hidden_c33b14"
           data-testid="modal"
         >
           <div
-            class="_container_753dd0"
+            class="_container_c33b14"
           >
             <div
-              class="_content_753dd0"
+              class="_content_c33b14"
             />
           </div>
         </div>
@@ -1723,21 +1723,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
   </body>,
   "container": <div>
     <main
-      class="_root_03d657"
+      class="_root_78663b"
     >
       <section
-        class="_container_03d657"
+        class="_container_78663b"
       >
         <div
-          class="_titleContainer_03d657"
+          class="_titleContainer_78663b"
         >
           <h2
-            class="_title_03d657"
+            class="_title_78663b"
           >
             Your Wish Lists
           </h2>
           <div
-            class="_root_0a8ecf _select_03d657"
+            class="_root_706192 _select_78663b"
             data-testid="styledSelect"
             style="--button-background-color: #2274a5; --button-hover-color: #1e6894; --button-text-color: #fff; --button-border-color: #1b5c84;"
           >
@@ -1746,19 +1746,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-owns="selectListbox"
-              class="_header_0a8ecf"
+              class="_header_706192"
               role="combobox"
             >
               <input
                 aria-label="Add or Select Option"
-                class="_headerText_0a8ecf"
+                class="_headerText_706192"
               />
               <button
-                class="_trigger_0a8ecf"
+                class="_trigger_706192"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-angle-down _fa_0a8ecf"
+                  class="svg-inline--fa fa-angle-down _fa_706192"
                   data-icon="angle-down"
                   data-prefix="fas"
                   role="img"
@@ -1772,27 +1772,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
               </button>
             </div>
             <ul
-              class="_dropdown_0a8ecf _hidden_0a8ecf"
+              class="_dropdown_706192 _hidden_706192"
               id="selectListbox"
               role="listbox"
             >
               <li
                 aria-selected="false"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="32"
                 role="option"
                 tabindex="0"
               />
               <li
                 aria-selected="false"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="51"
                 role="option"
                 tabindex="0"
               />
               <li
                 aria-selected="true"
-                class="_root_b75fe4"
+                class="_root_6af4e6"
                 data-option-value="77"
                 role="option"
                 tabindex="0"
@@ -1801,18 +1801,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
           </div>
         </div>
         <hr
-          class="_hr_03d657"
+          class="_hr_78663b"
         />
         <form
-          class="_root_15ecd1"
+          class="_root_f9e5f5"
           style="--button-color: #4e8fb7; --button-text-color: #fff; --button-border-color: #1b5c84; --button-hover-color: #3881ae;"
         >
           <fieldset
-            class="_fieldset_15ecd1"
+            class="_fieldset_f9e5f5"
           >
             <input
               aria-label="Title"
-              class="_input_15ecd1"
+              class="_input_f9e5f5"
               name="title"
               pattern="\\s*[A-Za-z0-9 \\-',]*\\s*"
               placeholder="Title"
@@ -1820,7 +1820,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
               type="text"
             />
             <button
-              class="_button_15ecd1"
+              class="_button_f9e5f5"
               type="submit"
             >
               Create
@@ -1828,23 +1828,23 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
           </fieldset>
         </form>
         <div
-          class="_root_da4596"
+          class="_root_8bc9d7"
         >
           <div
-            class="_wishList_da4596"
+            class="_wishList_8bc9d7"
           >
             <div
-              class="_root_ec6c68"
+              class="_root_015e9f"
               style="--scheme-color: #ffbf00; --border-color: #cc9800; --text-color-primary: #4c3900; --text-color-secondary: #4c3900; --hover-color: #e5ab00; --scheme-color-lighter: #ffcb32; --scheme-color-lightest: #fff2cc; --max-title-width: -32px;"
             >
               <div
                 aria-controls="list3Details"
                 aria-expanded="false"
-                class="_trigger_ec6c68"
+                class="_trigger_015e9f"
                 role="button"
               >
                 <h3
-                  class="_title_ec6c68"
+                  class="_title_015e9f"
                 >
                   All Items
                 </h3>
@@ -1859,31 +1859,31 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   style="display: none;"
                 >
                   <div
-                    class="_details_ec6c68"
+                    class="_details_015e9f"
                   >
                     <div
-                      class="_root_54cfce"
+                      class="_root_8f9b4a"
                       style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                     >
                       <div
                         aria-controls="wishListItem6Details"
                         aria-expanded="false"
-                        class="_trigger_54cfce"
+                        class="_trigger_8f9b4a"
                       >
                         <span
-                          class="_descriptionContainer_54cfce"
+                          class="_descriptionContainer_8f9b4a"
                         >
                           <h3
-                            class="_description_54cfce"
+                            class="_description_8f9b4a"
                           >
                             Dwarven Cog
                           </h3>
                         </span>
                         <span
-                          class="_quantity_54cfce"
+                          class="_quantity_8f9b4a"
                         >
                           <span
-                            class="_quantityContent_54cfce"
+                            class="_quantityContent_8f9b4a"
                           >
                             11
                           </span>
@@ -1899,15 +1899,15 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           style="display: none;"
                         >
                           <div
-                            class="_details_54cfce"
+                            class="_details_8f9b4a"
                           >
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Unit Weight:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               10
                             </p>
@@ -1916,28 +1916,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                       </div>
                     </div>
                     <div
-                      class="_root_54cfce"
+                      class="_root_8f9b4a"
                       style="--main-color: #ffcb32; --title-text-color: #4c3900; --border-color: #cc9800; --body-background-color: #fff2cc; --body-text-color: #7f5700; --hover-color: #ffc519;"
                     >
                       <div
                         aria-controls="wishListItem9Details"
                         aria-expanded="false"
-                        class="_trigger_54cfce"
+                        class="_trigger_8f9b4a"
                       >
                         <span
-                          class="_descriptionContainer_54cfce"
+                          class="_descriptionContainer_8f9b4a"
                         >
                           <h3
-                            class="_description_54cfce"
+                            class="_description_8f9b4a"
                           >
                             This item has a really really really really really long description for testing purposes
                           </h3>
                         </span>
                         <span
-                          class="_quantity_54cfce"
+                          class="_quantity_8f9b4a"
                         >
                           <span
-                            class="_quantityContent_54cfce"
+                            class="_quantityContent_8f9b4a"
                           >
                             200000000000
                           </span>
@@ -1953,15 +1953,15 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           style="display: none;"
                         >
                           <div
-                            class="_details_54cfce"
+                            class="_details_8f9b4a"
                           >
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Unit Weight:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               400000000000
                             </p>
@@ -1975,28 +1975,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
             </div>
           </div>
           <div
-            class="_wishList_da4596"
+            class="_wishList_8bc9d7"
           >
             <div
-              class="_root_ec6c68"
+              class="_root_015e9f"
               style="--scheme-color: #e83f6f; --border-color: #b93258; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #d03863; --scheme-color-lighter: #ec658b; --scheme-color-lightest: #fad8e2; --max-title-width: -16px;"
             >
               <div
                 aria-controls="list4Details"
                 aria-expanded="false"
-                class="_trigger_ec6c68"
+                class="_trigger_015e9f"
                 role="button"
               >
                 <span
-                  class="_icons_ec6c68"
+                  class="_icons_015e9f"
                 >
                   <button
-                    class="_icon_ec6c68"
+                    class="_icon_015e9f"
                     data-testid="destroyWishList4"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-xmark _fa_ec6c68"
+                      class="svg-inline--fa fa-xmark _fa_015e9f"
                       data-icon="xmark"
                       data-prefix="fas"
                       role="img"
@@ -2009,12 +2009,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     </svg>
                   </button>
                   <button
-                    class="_icon_ec6c68"
+                    class="_icon_015e9f"
                     data-testid="editWishList4"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                      class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                       data-icon="pen-to-square"
                       data-prefix="fas"
                       role="img"
@@ -2028,7 +2028,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   </button>
                 </span>
                 <h3
-                  class="_title_ec6c68"
+                  class="_title_015e9f"
                 >
                   Honeyside
                 </h3>
@@ -2043,19 +2043,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   style="display: none;"
                 >
                   <div
-                    class="_details_ec6c68"
+                    class="_details_015e9f"
                   >
                     <div
-                      class="_root_8112da _collapsed_8112da"
+                      class="_root_1a276c _collapsed_1a276c"
                       style="--base-color: #ec658b; --hover-color: #ea527d; --body-color: #fad8e2; --border-color: #b93258; --text-color-main: #fff; --text-color-secondary: #451221;"
                     >
                       <div
-                        class="_triggerContainer_8112da"
+                        class="_triggerContainer_1a276c"
                       >
                         <button
                           aria-controls="addItemToWishList4"
                           aria-expanded="false"
-                          class="_trigger_8112da"
+                          class="_trigger_1a276c"
                         >
                           Add item to list...
                         </button>
@@ -2071,14 +2071,14 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                         >
                           <form
                             aria-label="Wish list item creation form"
-                            class="_form_8112da"
+                            class="_form_1a276c"
                           >
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Description
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 name="description"
                                 placeholder="Description"
                                 required=""
@@ -2086,11 +2086,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Quantity
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 inputmode="numeric"
                                 min="1"
                                 name="quantity"
@@ -2103,11 +2103,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Unit Weight
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 inputmode="decimal"
                                 min="0"
                                 name="unit_weight"
@@ -2117,18 +2117,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Notes
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 name="notes"
                                 placeholder="Notes"
                                 type="text"
                               />
                             </label>
                             <button
-                              class="_submit_8112da"
+                              class="_submit_1a276c"
                               type="submit"
                             >
                               Add to List
@@ -2138,27 +2138,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                       </div>
                     </div>
                     <div
-                      class="_root_54cfce"
+                      class="_root_8f9b4a"
                       style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                     >
                       <div
                         aria-controls="wishListItem8Details"
                         aria-expanded="false"
-                        class="_trigger_54cfce"
+                        class="_trigger_8f9b4a"
                       >
                         <span
-                          class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                          class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                         >
                           <span
-                            class="_editIcons_54cfce"
+                            class="_editIcons_8f9b4a"
                           >
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="destroyWishListItem8"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-xmark _fa_54cfce"
+                                class="svg-inline--fa fa-xmark _fa_8f9b4a"
                                 data-icon="xmark"
                                 data-prefix="fas"
                                 role="img"
@@ -2171,12 +2171,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </svg>
                             </button>
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="editWishListItem8"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                                class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                                 data-icon="pen-to-square"
                                 data-prefix="fas"
                                 role="img"
@@ -2190,21 +2190,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             </button>
                           </span>
                           <h3
-                            class="_description_54cfce"
+                            class="_description_8f9b4a"
                           >
                             This item has a really really really really really long description for testing purposes
                           </h3>
                         </span>
                         <span
-                          class="_quantityEditable_54cfce"
+                          class="_quantityEditable_8f9b4a"
                         >
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="incrementWishListItem8"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                              class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                               data-icon="chevron-up"
                               data-prefix="fas"
                               role="img"
@@ -2217,17 +2217,17 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             </svg>
                           </button>
                           <span
-                            class="_quantityContent_54cfce"
+                            class="_quantityContent_8f9b4a"
                           >
                             200000000000
                           </span>
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="decrementWishListItem8"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                              class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                               data-icon="chevron-down"
                               data-prefix="fas"
                               role="img"
@@ -2251,25 +2251,25 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           style="display: none;"
                         >
                           <div
-                            class="_details_54cfce"
+                            class="_details_8f9b4a"
                           >
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Unit Weight:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               400000000000
                             </p>
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Notes:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               -
                             </p>
@@ -2278,27 +2278,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                       </div>
                     </div>
                     <div
-                      class="_root_54cfce"
+                      class="_root_8f9b4a"
                       style="--main-color: #ec658b; --title-text-color: #fff; --border-color: #b93258; --body-background-color: #fad8e2; --body-text-color: #451221; --hover-color: #ea527d;"
                     >
                       <div
                         aria-controls="wishListItem5Details"
                         aria-expanded="false"
-                        class="_trigger_54cfce"
+                        class="_trigger_8f9b4a"
                       >
                         <span
-                          class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                          class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                         >
                           <span
-                            class="_editIcons_54cfce"
+                            class="_editIcons_8f9b4a"
                           >
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="destroyWishListItem5"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-xmark _fa_54cfce"
+                                class="svg-inline--fa fa-xmark _fa_8f9b4a"
                                 data-icon="xmark"
                                 data-prefix="fas"
                                 role="img"
@@ -2311,12 +2311,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </svg>
                             </button>
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="editWishListItem5"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                                class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                                 data-icon="pen-to-square"
                                 data-prefix="fas"
                                 role="img"
@@ -2330,21 +2330,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             </button>
                           </span>
                           <h3
-                            class="_description_54cfce"
+                            class="_description_8f9b4a"
                           >
                             Dwarven Cog
                           </h3>
                         </span>
                         <span
-                          class="_quantityEditable_54cfce"
+                          class="_quantityEditable_8f9b4a"
                         >
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="incrementWishListItem5"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                              class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                               data-icon="chevron-up"
                               data-prefix="fas"
                               role="img"
@@ -2357,17 +2357,17 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             </svg>
                           </button>
                           <span
-                            class="_quantityContent_54cfce"
+                            class="_quantityContent_8f9b4a"
                           >
                             1
                           </span>
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="decrementWishListItem5"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                              class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                               data-icon="chevron-down"
                               data-prefix="fas"
                               role="img"
@@ -2391,25 +2391,25 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           style="display: none;"
                         >
                           <div
-                            class="_details_54cfce"
+                            class="_details_8f9b4a"
                           >
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Unit Weight:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               10
                             </p>
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Notes:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               For trophy room
                             </p>
@@ -2423,28 +2423,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
             </div>
           </div>
           <div
-            class="_wishList_da4596"
+            class="_wishList_8bc9d7"
           >
             <div
-              class="_root_ec6c68"
+              class="_root_015e9f"
               style="--scheme-color: #2274a5; --border-color: #1b5c84; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #1e6894; --scheme-color-lighter: #4e8fb7; --scheme-color-lightest: #d2e3ed; --max-title-width: -16px;"
             >
               <div
                 aria-controls="list5Details"
                 aria-expanded="false"
-                class="_trigger_ec6c68"
+                class="_trigger_015e9f"
                 role="button"
               >
                 <span
-                  class="_icons_ec6c68"
+                  class="_icons_015e9f"
                 >
                   <button
-                    class="_icon_ec6c68"
+                    class="_icon_015e9f"
                     data-testid="destroyWishList5"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-xmark _fa_ec6c68"
+                      class="svg-inline--fa fa-xmark _fa_015e9f"
                       data-icon="xmark"
                       data-prefix="fas"
                       role="img"
@@ -2457,12 +2457,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     </svg>
                   </button>
                   <button
-                    class="_icon_ec6c68"
+                    class="_icon_015e9f"
                     data-testid="editWishList5"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                      class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                       data-icon="pen-to-square"
                       data-prefix="fas"
                       role="img"
@@ -2476,7 +2476,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   </button>
                 </span>
                 <h3
-                  class="_title_ec6c68"
+                  class="_title_015e9f"
                 >
                   Breezehome
                 </h3>
@@ -2491,19 +2491,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   style="display: none;"
                 >
                   <div
-                    class="_details_ec6c68"
+                    class="_details_015e9f"
                   >
                     <div
-                      class="_root_8112da _collapsed_8112da"
+                      class="_root_1a276c _collapsed_1a276c"
                       style="--base-color: #4e8fb7; --hover-color: #3881ae; --body-color: #d2e3ed; --border-color: #1b5c84; --text-color-main: #fff; --text-color-secondary: #0d2e42;"
                     >
                       <div
-                        class="_triggerContainer_8112da"
+                        class="_triggerContainer_1a276c"
                       >
                         <button
                           aria-controls="addItemToWishList5"
                           aria-expanded="false"
-                          class="_trigger_8112da"
+                          class="_trigger_1a276c"
                         >
                           Add item to list...
                         </button>
@@ -2519,14 +2519,14 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                         >
                           <form
                             aria-label="Wish list item creation form"
-                            class="_form_8112da"
+                            class="_form_1a276c"
                           >
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Description
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 name="description"
                                 placeholder="Description"
                                 required=""
@@ -2534,11 +2534,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Quantity
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 inputmode="numeric"
                                 min="1"
                                 name="quantity"
@@ -2551,11 +2551,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Unit Weight
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 inputmode="decimal"
                                 min="0"
                                 name="unit_weight"
@@ -2565,18 +2565,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Notes
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 name="notes"
                                 placeholder="Notes"
                                 type="text"
                               />
                             </label>
                             <button
-                              class="_submit_8112da"
+                              class="_submit_1a276c"
                               type="submit"
                             >
                               Add to List
@@ -2586,27 +2586,27 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                       </div>
                     </div>
                     <div
-                      class="_root_54cfce"
+                      class="_root_8f9b4a"
                       style="--main-color: #4e8fb7; --title-text-color: #fff; --border-color: #1b5c84; --body-background-color: #d2e3ed; --body-text-color: #0d2e42; --hover-color: #3881ae;"
                     >
                       <div
                         aria-controls="wishListItem7Details"
                         aria-expanded="false"
-                        class="_trigger_54cfce"
+                        class="_trigger_8f9b4a"
                       >
                         <span
-                          class="_descriptionContainer_54cfce _descriptionContainerEditable_54cfce"
+                          class="_descriptionContainer_8f9b4a _descriptionContainerEditable_8f9b4a"
                         >
                           <span
-                            class="_editIcons_54cfce"
+                            class="_editIcons_8f9b4a"
                           >
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="destroyWishListItem7"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-xmark _fa_54cfce"
+                                class="svg-inline--fa fa-xmark _fa_8f9b4a"
                                 data-icon="xmark"
                                 data-prefix="fas"
                                 role="img"
@@ -2619,12 +2619,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               </svg>
                             </button>
                             <button
-                              class="_icon_54cfce"
+                              class="_icon_8f9b4a"
                               data-testid="editWishListItem7"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="svg-inline--fa fa-pen-to-square _fa_54cfce"
+                                class="svg-inline--fa fa-pen-to-square _fa_8f9b4a"
                                 data-icon="pen-to-square"
                                 data-prefix="fas"
                                 role="img"
@@ -2638,21 +2638,21 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             </button>
                           </span>
                           <h3
-                            class="_description_54cfce"
+                            class="_description_8f9b4a"
                           >
                             Dwarven Cog
                           </h3>
                         </span>
                         <span
-                          class="_quantityEditable_54cfce"
+                          class="_quantityEditable_8f9b4a"
                         >
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="incrementWishListItem7"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-chevron-up _fa_54cfce"
+                              class="svg-inline--fa fa-chevron-up _fa_8f9b4a"
                               data-icon="chevron-up"
                               data-prefix="fas"
                               role="img"
@@ -2665,17 +2665,17 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                             </svg>
                           </button>
                           <span
-                            class="_quantityContent_54cfce"
+                            class="_quantityContent_8f9b4a"
                           >
                             10
                           </span>
                           <button
-                            class="_icon_54cfce"
+                            class="_icon_8f9b4a"
                             data-testid="decrementWishListItem7"
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-chevron-down _fa_54cfce"
+                              class="svg-inline--fa fa-chevron-down _fa_8f9b4a"
                               data-icon="chevron-down"
                               data-prefix="fas"
                               role="img"
@@ -2699,25 +2699,25 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                           style="display: none;"
                         >
                           <div
-                            class="_details_54cfce"
+                            class="_details_8f9b4a"
                           >
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Unit Weight:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               10
                             </p>
                             <h4
-                              class="_label_54cfce"
+                              class="_label_8f9b4a"
                             >
                               Notes:
                             </h4>
                             <p
-                              class="_value_54cfce"
+                              class="_value_8f9b4a"
                             >
                               For Arniel Gane
                             </p>
@@ -2731,28 +2731,28 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
             </div>
           </div>
           <div
-            class="_wishList_da4596"
+            class="_wishList_8bc9d7"
           >
             <div
-              class="_root_ec6c68"
+              class="_root_015e9f"
               style="--scheme-color: #00a323; --border-color: #00821c; --text-color-primary: #fff; --text-color-secondary: #fff; --hover-color: #00921f; --scheme-color-lighter: #32b54e; --scheme-color-lightest: #ccecd3; --max-title-width: -16px;"
             >
               <div
                 aria-controls="list6Details"
                 aria-expanded="false"
-                class="_trigger_ec6c68"
+                class="_trigger_015e9f"
                 role="button"
               >
                 <span
-                  class="_icons_ec6c68"
+                  class="_icons_015e9f"
                 >
                   <button
-                    class="_icon_ec6c68"
+                    class="_icon_015e9f"
                     data-testid="destroyWishList6"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-xmark _fa_ec6c68"
+                      class="svg-inline--fa fa-xmark _fa_015e9f"
                       data-icon="xmark"
                       data-prefix="fas"
                       role="img"
@@ -2765,12 +2765,12 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                     </svg>
                   </button>
                   <button
-                    class="_icon_ec6c68"
+                    class="_icon_015e9f"
                     data-testid="editWishList6"
                   >
                     <svg
                       aria-hidden="true"
-                      class="svg-inline--fa fa-pen-to-square _fa_ec6c68"
+                      class="svg-inline--fa fa-pen-to-square _fa_015e9f"
                       data-icon="pen-to-square"
                       data-prefix="fas"
                       role="img"
@@ -2784,7 +2784,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   </button>
                 </span>
                 <h3
-                  class="_title_ec6c68"
+                  class="_title_015e9f"
                 >
                   Hjerim
                 </h3>
@@ -2799,19 +2799,19 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   style="display: none;"
                 >
                   <div
-                    class="_details_ec6c68"
+                    class="_details_015e9f"
                   >
                     <div
-                      class="_root_8112da _collapsed_8112da"
+                      class="_root_1a276c _collapsed_1a276c"
                       style="--base-color: #32b54e; --hover-color: #19ac38; --body-color: #ccecd3; --border-color: #00821c; --text-color-main: #fff; --text-color-secondary: #00410e;"
                     >
                       <div
-                        class="_triggerContainer_8112da"
+                        class="_triggerContainer_1a276c"
                       >
                         <button
                           aria-controls="addItemToWishList6"
                           aria-expanded="false"
-                          class="_trigger_8112da"
+                          class="_trigger_1a276c"
                         >
                           Add item to list...
                         </button>
@@ -2827,14 +2827,14 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                         >
                           <form
                             aria-label="Wish list item creation form"
-                            class="_form_8112da"
+                            class="_form_1a276c"
                           >
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Description
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 name="description"
                                 placeholder="Description"
                                 required=""
@@ -2842,11 +2842,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Quantity
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 inputmode="numeric"
                                 min="1"
                                 name="quantity"
@@ -2859,11 +2859,11 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Unit Weight
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 inputmode="decimal"
                                 min="0"
                                 name="unit_weight"
@@ -2873,18 +2873,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                               />
                             </label>
                             <label
-                              class="_label_8112da"
+                              class="_label_1a276c"
                             >
                               Notes
                               <input
-                                class="_input_8112da"
+                                class="_input_1a276c"
                                 name="notes"
                                 placeholder="Notes"
                                 type="text"
                               />
                             </label>
                             <button
-                              class="_submit_8112da"
+                              class="_submit_1a276c"
                               type="submit"
                             >
                               Add to List
@@ -2901,29 +2901,29 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
         </div>
       </section>
       <header
-        class="_root_c29812"
+        class="_root_faea2d"
       >
         <div
-          class="_bar_c29812"
+          class="_bar_faea2d"
         >
           <span
-            class="_headerContainer_c29812"
+            class="_headerContainer_faea2d"
           >
             <h1
-              class="_header_c29812"
+              class="_header_faea2d"
             >
               <a
-                class="_headerLinkLarge_c29812"
+                class="_headerLinkLarge_faea2d"
                 href="/dashboard"
               >
                 Skyrim Inventory
                 <br
-                  class="_bp_c29812"
+                  class="_bp_faea2d"
                 />
                  Management
               </a>
               <a
-                class="_headerLinkSmall_c29812"
+                class="_headerLinkSmall_faea2d"
                 href="/dashboard"
               >
                 S. I. M.
@@ -2931,18 +2931,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
             </h1>
           </span>
           <span
-            class="_root_d263fb"
+            class="_root_658745"
           >
             <div
-              class="_main_d263fb"
+              class="_main_658745"
             >
               <div
-                class="_button_d263fb"
+                class="_button_658745"
                 role="button"
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-bars _hamburger_d263fb"
+                  class="svg-inline--fa fa-bars _hamburger_658745"
                   data-icon="bars"
                   data-prefix="fas"
                   role="img"
@@ -2954,29 +2954,29 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   />
                 </svg>
                 <span
-                  class="_info_d263fb"
+                  class="_info_658745"
                 >
                   <p
-                    class="_name_d263fb"
+                    class="_name_658745"
                   >
                     Edna St. Vincent Millay
                   </p>
                   <p
-                    class="_email_d263fb"
+                    class="_email_658745"
                   >
                     edna@gmail.com
                   </p>
                 </span>
                 <img
                   alt="User profile image"
-                  class="_img_d263fb"
+                  class="_img_658745"
                   referrerpolicy="no-referrer"
                   src="/src/support/testProfileImg.png"
                 />
               </div>
             </div>
             <menu
-              class="_dropdown_d263fb"
+              class="_dropdown_658745"
             >
               <div
                 role="button"
@@ -2995,7 +2995,7 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
                   />
                 </svg>
                 <p
-                  class="_signOutText_d263fb"
+                  class="_signOutText_658745"
                 >
                   Sign Out
                 </p>
@@ -3005,18 +3005,18 @@ exports[`WishListsPage > viewing wish lists > when the game is set in the query 
         </div>
       </header>
       <div
-        class="_root_91d025 _hidden_91d025"
+        class="_root_ca8db5 _hidden_ca8db5"
         style="--text-color: #4e6d83;"
       />
       <div
-        class="_root_753dd0 _hidden_753dd0"
+        class="_root_c33b14 _hidden_c33b14"
         data-testid="modal"
       >
         <div
-          class="_container_753dd0"
+          class="_container_c33b14"
         >
           <div
-            class="_content_753dd0"
+            class="_content_c33b14"
           />
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,6 +2331,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@standard-schema/spec@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 6245ebef5e698bb04752a22e996a7cc40406a404d9f68a9d4e1a7a10f2422da287247508e7b495a2f32bb38f3d57b4daf2c9ab4bf22d9bca13e20a3dc5ec575e
+  languageName: node
+  linkType: hard
+
 "@storybook/addon-docs@npm:10.2.16":
   version: 10.2.16
   resolution: "@storybook/addon-docs@npm:10.2.16"
@@ -2957,18 +2964,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@vitest/expect@npm:3.1.4"
-  dependencies:
-    "@vitest/spy": 3.1.4
-    "@vitest/utils": 3.1.4
-    chai: ^5.2.0
-    tinyrainbow: ^2.0.0
-  checksum: 996f67c0608fce0176283cb629b9f15d39781840a3b8ba026baa2f86762559373a963cec14e6eec42c5a6655b3152705319dccefce8014b42cbd42c968ad03e5
-  languageName: node
-  linkType: hard
-
 "@vitest/expect@npm:3.2.4":
   version: 3.2.4
   resolution: "@vitest/expect@npm:3.2.4"
@@ -2982,22 +2977,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@vitest/mocker@npm:3.1.4"
+"@vitest/expect@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vitest/expect@npm:4.0.18"
   dependencies:
-    "@vitest/spy": 3.1.4
-    estree-walker: ^3.0.3
-    magic-string: ^0.30.17
-  peerDependencies:
-    msw: ^2.4.9
-    vite: ^5.0.0 || ^6.0.0
-  peerDependenciesMeta:
-    msw:
-      optional: true
-    vite:
-      optional: true
-  checksum: 8b96137af3575e71369e84b0b1f000a801e8ccf5649495e9d86a1c93a7e5cbec3660553cba5d7450b443212d7c93039530b210b7ede07f1f017f7ad2d8fa7857
+    "@standard-schema/spec": ^1.0.0
+    "@types/chai": ^5.2.2
+    "@vitest/spy": 4.0.18
+    "@vitest/utils": 4.0.18
+    chai: ^6.2.1
+    tinyrainbow: ^3.0.3
+  checksum: 839e8fd3acb5e107d057c0712c9ede8839fdd46fe42c2b5d37fe6aa31f9bc8f171be7edd4e1ee8a043b914ba358ffb0ed08fa5111522873286eff9cbc95a9d87
   languageName: node
   linkType: hard
 
@@ -3020,16 +3010,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@vitest/pretty-format@npm:3.1.4"
+"@vitest/mocker@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vitest/mocker@npm:4.0.18"
   dependencies:
-    tinyrainbow: ^2.0.0
-  checksum: 5468fd433e59c12d11dee36f507360da6b5032ef061c6b4bf8f97d7339f9a488e3de46aaaf3c75fb6044f5faa36fae51436b102b67e60ad74b26abfc48536119
+    "@vitest/spy": 4.0.18
+    estree-walker: ^3.0.3
+    magic-string: ^0.30.21
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0-0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 27d4af8cf6f58ae4f1e3887b82a365a1b1ac23ea76f9043e29eb285eb10419debff4684c218bf51df21ae8b4ec147b3f559718ef29d12c36acdcc3bcaaa04fd2
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.2.4, @vitest/pretty-format@npm:^3.1.4":
+"@vitest/pretty-format@npm:3.2.4":
   version: 3.2.4
   resolution: "@vitest/pretty-format@npm:3.2.4"
   dependencies:
@@ -3038,33 +3038,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@vitest/runner@npm:3.1.4"
+"@vitest/pretty-format@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vitest/pretty-format@npm:4.0.18"
   dependencies:
-    "@vitest/utils": 3.1.4
-    pathe: ^2.0.3
-  checksum: 9e2b25d7eafd04171ee9b2609e3435998fe4d0c82122b426a576504c3c2937a20460f8f8ee8a4cfd267620fcc4d4c7bfb8bfc6610288b5ca5f252ad6c5bae6f4
+    tinyrainbow: ^3.0.3
+  checksum: 7e095a69badfec07db5dc374c9d7f7aa4d0cd9795b508b23c989dbcb7c0d6a06acb35ed01a0f777ab297a99aa6c6a09b4dcca53c097429184ad93606166ec261
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@vitest/snapshot@npm:3.1.4"
+"@vitest/runner@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vitest/runner@npm:4.0.18"
   dependencies:
-    "@vitest/pretty-format": 3.1.4
-    magic-string: ^0.30.17
+    "@vitest/utils": 4.0.18
     pathe: ^2.0.3
-  checksum: 4893c5c64518659db31d8b5e6e1bf0fedd320fbc26b9173004a733ad99cb2db8978e83ee7e0b8f81fed36668f6b5b22ed709ab4437a6803451dd541d07b16f3f
+  checksum: ca2f11607bed545736ca5ecc210144e2442b13af1f85d2640ccf8b37436c4b880886e6bd5a6f7fa6b8b2a2e13ceeee3827068dc928a4e312a2e9eca47ca6f428
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@vitest/spy@npm:3.1.4"
+"@vitest/snapshot@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vitest/snapshot@npm:4.0.18"
   dependencies:
-    tinyspy: ^3.0.2
-  checksum: ea957b3b1afe9d33f445b91b446aeffa6e55f57d25801754e3d0206db045405dd6013545d2cb11ab6febd3dcbb3adc9580ec20f0d08ca458d21cfc7eebf9caa8
+    "@vitest/pretty-format": 4.0.18
+    magic-string: ^0.30.21
+    pathe: ^2.0.3
+  checksum: 660a2de2735fa2aea0f95b2939e7f367f9a4225bcc280de55f32a1f1ade9e898edc76763f573112071ac0d7f9c708e0459be6224cb8bab47a9f418be0f22698e
   languageName: node
   linkType: hard
 
@@ -3077,14 +3077,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@vitest/utils@npm:3.1.4"
-  dependencies:
-    "@vitest/pretty-format": 3.1.4
-    loupe: ^3.1.3
-    tinyrainbow: ^2.0.0
-  checksum: 51939f0f1a50dc277f10c81a944a104cdaf7c0cde4c3e192d5605ac34115debf0f8fca1c031483c77fb430595883324a86810070533a5623c0fd95bb4bf0259c
+"@vitest/spy@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vitest/spy@npm:4.0.18"
+  checksum: c2cd7532c5e63d39f92e9cbd19748a56746d3b8154328ad71c600b0bf51dc3f6797b4ac0c5466732fe834e5fabcd68e50939ee6dfe48680167e112031ab5df89
   languageName: node
   linkType: hard
 
@@ -3096,6 +3092,16 @@ __metadata:
     loupe: ^3.1.4
     tinyrainbow: ^2.0.0
   checksum: 6b0fd0075c23b8e3f17ecf315adc1e565e5a9e7d1b8ad78bbccf2505e399855d176254d974587c00bc4396a0e348bae1380e780a1e7f6b97ea6399a9ab665ba7
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vitest/utils@npm:4.0.18"
+  dependencies:
+    "@vitest/pretty-format": 4.0.18
+    tinyrainbow: ^3.0.3
+  checksum: f536bf5700cbf72703b6cd17083f321fef16ce40910c8a7e6a5939bac8dac2a421518ffa0ea825b18d002bb4f0f62c697e971e725cbf55744b56ea748e424c35
   languageName: node
   linkType: hard
 
@@ -3366,13 +3372,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cac@npm:^6.7.14":
-  version: 6.7.14
-  resolution: "cac@npm:6.7.14"
-  checksum: 45a2496a9443abbe7f52a49b22fbe51b1905eff46e03fd5e6c98e3f85077be3f8949685a1849b1a9cd2bc3e5567dfebcf64f01ce01847baf918f1b37c839791a
-  languageName: node
-  linkType: hard
-
 "cacache@npm:^18.0.0":
   version: 18.0.4
   resolution: "cacache@npm:18.0.4"
@@ -3420,6 +3419,13 @@ __metadata:
     loupe: ^3.1.0
     pathval: ^2.0.0
   checksum: bc4091f1cccfee63f6a3d02ce477fe847f5c57e747916a11bd72675c9459125084e2e55dc2363ee2b82b088a878039ee7ee27c75d6d90f7de9202bf1b12ce573
+  languageName: node
+  linkType: hard
+
+"chai@npm:^6.2.1":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: c8c94857745b673dae22a7b25053a41a931848e2c20d1acb6838cf99b7d57b0e66b9eb878c6308534b2965c11ae1a66f8c58066f368c91a07797bb8ee881a733
   languageName: node
   linkType: hard
 
@@ -3690,7 +3696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -3932,6 +3938,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0":
+  version: 0.25.12
+  resolution: "esbuild@npm:0.25.12"
+  dependencies:
+    "@esbuild/aix-ppc64": 0.25.12
+    "@esbuild/android-arm": 0.25.12
+    "@esbuild/android-arm64": 0.25.12
+    "@esbuild/android-x64": 0.25.12
+    "@esbuild/darwin-arm64": 0.25.12
+    "@esbuild/darwin-x64": 0.25.12
+    "@esbuild/freebsd-arm64": 0.25.12
+    "@esbuild/freebsd-x64": 0.25.12
+    "@esbuild/linux-arm": 0.25.12
+    "@esbuild/linux-arm64": 0.25.12
+    "@esbuild/linux-ia32": 0.25.12
+    "@esbuild/linux-loong64": 0.25.12
+    "@esbuild/linux-mips64el": 0.25.12
+    "@esbuild/linux-ppc64": 0.25.12
+    "@esbuild/linux-riscv64": 0.25.12
+    "@esbuild/linux-s390x": 0.25.12
+    "@esbuild/linux-x64": 0.25.12
+    "@esbuild/netbsd-arm64": 0.25.12
+    "@esbuild/netbsd-x64": 0.25.12
+    "@esbuild/openbsd-arm64": 0.25.12
+    "@esbuild/openbsd-x64": 0.25.12
+    "@esbuild/openharmony-arm64": 0.25.12
+    "@esbuild/sunos-x64": 0.25.12
+    "@esbuild/win32-arm64": 0.25.12
+    "@esbuild/win32-ia32": 0.25.12
+    "@esbuild/win32-x64": 0.25.12
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 3d1dc181338e2c44f4374508e9d0da3e7ae90f65d7f3f5d8076ff401a1726c5c9ecc86cfc825249349f1652e12d5ae13f02bcaa4d9487c88c7a11167f52ba353
+  languageName: node
+  linkType: hard
+
 "esbuild@npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0, esbuild@npm:^0.27.0":
   version: 0.27.3
   resolution: "esbuild@npm:0.27.3"
@@ -4018,95 +4113,6 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 3a45334b00ca235ad96843738c4698970aacde92058aee28ab1fa57ad823c29667070af90b6071cc876e492bebdeed79f593a273c39b419097afd2a772296085
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0, esbuild@npm:^0.25.0":
-  version: 0.25.12
-  resolution: "esbuild@npm:0.25.12"
-  dependencies:
-    "@esbuild/aix-ppc64": 0.25.12
-    "@esbuild/android-arm": 0.25.12
-    "@esbuild/android-arm64": 0.25.12
-    "@esbuild/android-x64": 0.25.12
-    "@esbuild/darwin-arm64": 0.25.12
-    "@esbuild/darwin-x64": 0.25.12
-    "@esbuild/freebsd-arm64": 0.25.12
-    "@esbuild/freebsd-x64": 0.25.12
-    "@esbuild/linux-arm": 0.25.12
-    "@esbuild/linux-arm64": 0.25.12
-    "@esbuild/linux-ia32": 0.25.12
-    "@esbuild/linux-loong64": 0.25.12
-    "@esbuild/linux-mips64el": 0.25.12
-    "@esbuild/linux-ppc64": 0.25.12
-    "@esbuild/linux-riscv64": 0.25.12
-    "@esbuild/linux-s390x": 0.25.12
-    "@esbuild/linux-x64": 0.25.12
-    "@esbuild/netbsd-arm64": 0.25.12
-    "@esbuild/netbsd-x64": 0.25.12
-    "@esbuild/openbsd-arm64": 0.25.12
-    "@esbuild/openbsd-x64": 0.25.12
-    "@esbuild/openharmony-arm64": 0.25.12
-    "@esbuild/sunos-x64": 0.25.12
-    "@esbuild/win32-arm64": 0.25.12
-    "@esbuild/win32-ia32": 0.25.12
-    "@esbuild/win32-x64": 0.25.12
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-arm64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/openharmony-arm64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 3d1dc181338e2c44f4374508e9d0da3e7ae90f65d7f3f5d8076ff401a1726c5c9ecc86cfc825249349f1652e12d5ae13f02bcaa4d9487c88c7a11167f52ba353
   languageName: node
   linkType: hard
 
@@ -4282,7 +4288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^1.2.1":
+"expect-type@npm:^1.2.2":
   version: 1.3.0
   resolution: "expect-type@npm:1.3.0"
   checksum: 60476b4f4c0c88bf24db0735faa7d1d0c9120c21e5b78781c0fea0d4a95838f2db0c919a055aa4bb185ccbf38e37fa3000d3bb05500ceafcc7c469955c5a4f84
@@ -4348,7 +4354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.4.4, fdir@npm:^6.5.0":
+"fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
   peerDependencies:
@@ -5216,7 +5222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loupe@npm:^3.1.3, loupe@npm:^3.1.4":
+"loupe@npm:^3.1.4":
   version: 3.2.1
   resolution: "loupe@npm:3.2.1"
   checksum: 3ce9ecc5b2c56ffc073bf065ad3a4644cccce3eac81e61a8732e9c8ebfe05513ed478592d25f9dba24cfe82766913be045ab384c04711c7c6447deaf800ad94c
@@ -5264,7 +5270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.17":
+"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -5629,6 +5635,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "obug@npm:2.1.1"
+  checksum: 73e54095e977bc85611351a78d31061cf1eccd7173562e7b72afad63dcb924709a6fc5d6f43868edea424b1038e0f45edad1bf07ec37a559c96b81c89b663a71
+  languageName: node
+  linkType: hard
+
 "once@npm:^1.3.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -5879,7 +5892,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.3, postcss@npm:^8.5.6":
+"postcss@npm:^8.5.6":
   version: 8.5.8
   resolution: "postcss@npm:8.5.8"
   dependencies:
@@ -6214,7 +6227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.34.9, rollup@npm:^4.43.0":
+"rollup@npm:^4.43.0":
   version: 4.59.0
   resolution: "rollup@npm:4.59.0"
   dependencies:
@@ -6492,7 +6505,7 @@ __metadata:
     typescript-eslint: ^8.56.1
     unplugin-fonts: ^1.4.0
     vite: ^7.3.1
-    vitest: 3.1.4
+    vitest: ^4.0.18
   languageName: unknown
   linkType: soft
 
@@ -6578,7 +6591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.9.0":
+"std-env@npm:^3.10.0":
   version: 3.10.0
   resolution: "std-env@npm:3.10.0"
   checksum: 51d641b36b0fae494a546fb8446d39a837957fbf902c765c62bd12af8e50682d141c4087ca032f1192fa90330c4f6ff23fd6c9795324efacd1684e814471e0e0
@@ -6810,10 +6823,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "tinyexec@npm:0.3.2"
-  checksum: bd491923020610bdeadb0d8cf5d70e7cbad5a3201620fd01048c9bf3b31ffaa75c33254e1540e13b993ce4e8187852b0b5a93057bb598e7a57afa2ca2048a35c
+"tinyexec@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "tinyexec@npm:1.0.2"
+  checksum: af22de2191cc70bb782eef29bbba7cf6ac16664e550b547b0db68804f988eeb2c70e12fbb7d2d688ee994b28ba831d746e9eded98c3d10042fd3a9b8de208514
   languageName: node
   linkType: hard
 
@@ -6827,13 +6840,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinypool@npm:^1.0.2":
-  version: 1.1.1
-  resolution: "tinypool@npm:1.1.1"
-  checksum: 0258abe108df8be395a2cbdc8b4390c94908850250530f7bea83a129fa33d49a8c93246f76bf81cd458534abd81322f4d4cb3a40690254f8d9044ff449f328a8
-  languageName: node
-  linkType: hard
-
 "tinyrainbow@npm:^2.0.0":
   version: 2.0.0
   resolution: "tinyrainbow@npm:2.0.0"
@@ -6841,10 +6847,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyspy@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "tinyspy@npm:3.0.2"
-  checksum: 5db671b2ff5cd309de650c8c4761ca945459d7204afb1776db9a04fb4efa28a75f08517a8620c01ee32a577748802231ad92f7d5b194dc003ee7f987a2a06337
+"tinyrainbow@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "tinyrainbow@npm:3.0.3"
+  checksum: e1de26bd599703a6ee5c69e8b66384fa1ef05b26cbb005ad438169f1858d199c98946fb5ec4b7862313bfcf9affd9fb8aaf8c0a42cc953acba8bbcbe739b016c
   languageName: node
   linkType: hard
 
@@ -7145,77 +7151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:3.1.4":
-  version: 3.1.4
-  resolution: "vite-node@npm:3.1.4"
-  dependencies:
-    cac: ^6.7.14
-    debug: ^4.4.0
-    es-module-lexer: ^1.7.0
-    pathe: ^2.0.3
-    vite: ^5.0.0 || ^6.0.0
-  bin:
-    vite-node: vite-node.mjs
-  checksum: b3103543b1f7d9ab85a321b771954657931ceb0b4f9f7de62694d2f2c26aeed850e707314d5ffede5d62fa7cec10ba47be8855eee4597c3dce1edf9f2c3cfb26
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.0.0 || ^6.0.0":
-  version: 6.4.1
-  resolution: "vite@npm:6.4.1"
-  dependencies:
-    esbuild: ^0.25.0
-    fdir: ^6.4.4
-    fsevents: ~2.3.3
-    picomatch: ^4.0.2
-    postcss: ^8.5.3
-    rollup: ^4.34.9
-    tinyglobby: ^0.2.13
-  peerDependencies:
-    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-    jiti: ">=1.21.0"
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 7a939dbd6569ba829a7c21a18f8eca395a3a13cb93ce0fec02e8aa462e127a8daac81d00f684086648d905786056bba1ad931f51d88f06835d3b972bc9fbddda
-  languageName: node
-  linkType: hard
-
-"vite@npm:^7.3.1":
+"vite@npm:^6.0.0 || ^7.0.0, vite@npm:^7.3.1":
   version: 7.3.1
   resolution: "vite@npm:7.3.1"
   dependencies:
@@ -7270,47 +7206,52 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:3.1.4":
-  version: 3.1.4
-  resolution: "vitest@npm:3.1.4"
+"vitest@npm:^4.0.18":
+  version: 4.0.18
+  resolution: "vitest@npm:4.0.18"
   dependencies:
-    "@vitest/expect": 3.1.4
-    "@vitest/mocker": 3.1.4
-    "@vitest/pretty-format": ^3.1.4
-    "@vitest/runner": 3.1.4
-    "@vitest/snapshot": 3.1.4
-    "@vitest/spy": 3.1.4
-    "@vitest/utils": 3.1.4
-    chai: ^5.2.0
-    debug: ^4.4.0
-    expect-type: ^1.2.1
-    magic-string: ^0.30.17
+    "@vitest/expect": 4.0.18
+    "@vitest/mocker": 4.0.18
+    "@vitest/pretty-format": 4.0.18
+    "@vitest/runner": 4.0.18
+    "@vitest/snapshot": 4.0.18
+    "@vitest/spy": 4.0.18
+    "@vitest/utils": 4.0.18
+    es-module-lexer: ^1.7.0
+    expect-type: ^1.2.2
+    magic-string: ^0.30.21
+    obug: ^2.1.1
     pathe: ^2.0.3
-    std-env: ^3.9.0
+    picomatch: ^4.0.3
+    std-env: ^3.10.0
     tinybench: ^2.9.0
-    tinyexec: ^0.3.2
-    tinyglobby: ^0.2.13
-    tinypool: ^1.0.2
-    tinyrainbow: ^2.0.0
-    vite: ^5.0.0 || ^6.0.0
-    vite-node: 3.1.4
+    tinyexec: ^1.0.2
+    tinyglobby: ^0.2.15
+    tinyrainbow: ^3.0.3
+    vite: ^6.0.0 || ^7.0.0
     why-is-node-running: ^2.3.0
   peerDependencies:
     "@edge-runtime/vm": "*"
-    "@types/debug": ^4.1.12
-    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-    "@vitest/browser": 3.1.4
-    "@vitest/ui": 3.1.4
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.0.18
+    "@vitest/browser-preview": 4.0.18
+    "@vitest/browser-webdriverio": 4.0.18
+    "@vitest/ui": 4.0.18
     happy-dom: "*"
     jsdom: "*"
   peerDependenciesMeta:
     "@edge-runtime/vm":
       optional: true
-    "@types/debug":
+    "@opentelemetry/api":
       optional: true
     "@types/node":
       optional: true
-    "@vitest/browser":
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
       optional: true
     "@vitest/ui":
       optional: true
@@ -7320,7 +7261,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: 72002a50ea9f86f37c0f96d6e61029d0fe973cc11010d3f75c73168a552d5e52149148542af07f4880bbadc177baeeb13d08422c99d6ecb26202a481be14b534
+  checksum: 338169512fbf450e8204ddfa40807f8556d96e083a891f40fcb28780ebb450ab7d12cfb1c23fcb0481ccff1e40699abf9c442e8a4e6104d5d00b794a2cb6eeed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR upgrades Vitest to 4.0.18. Because snapshots changed with the upgrade, they also needed to be updated.