### PR TITLE
Direct blue nav mosaic link to inventory page instead of dashboard

### DIFF
--- a/src/pages/dashboardPage/dashboardPage.tsx
+++ b/src/pages/dashboardPage/dashboardPage.tsx
@@ -25,7 +25,7 @@ const navigationCards = [
   },
   {
     colorScheme: BLUE,
-    href: PLACEHOLDER_HREF,
+    href: paths.dashboard.inventory,
     children: 'Your Inventory',
     key: 'inventory',
   },


### PR DESCRIPTION
## Context

While testing yesterday's [nomenclature changes](https://github.com/oscaralanpierce/skyrim_inventory_management_frontend/pull/1070) in prod, I noticed that the blue nav mosaic tile, which is supposed to point to the inventory lists page, actually points to the dashboard. This PR fixes that.

## Changes

* Update href of blue nav mosaic link from `wish_lists` to `inventory`