### PR TITLE
Add inventory list routes to frontend API wrapper

### DIFF
--- a/src/contexts/pageContext.tsx
+++ b/src/contexts/pageContext.tsx
@@ -28,6 +28,8 @@ const defaultApiCallStatus: ApiCalls = {
   playthroughs: [],
   wishLists: [],
   wishListItems: [],
+  inventoryLists: [],
+  inventoryItems: [],
 }
 
 const PageContext = createContext<PageContextType>({

--- a/src/types/apiCalls.d.ts
+++ b/src/types/apiCalls.d.ts
@@ -1,6 +1,6 @@
 export type HttpVerb = 'get' | 'post' | 'patch' | 'delete'
 
-export type Resource = 'playthroughs' | 'wishLists' | 'wishListItems'
+export type Resource = 'playthroughs' | 'wishLists' | 'wishListItems' | 'inventoryLists' | 'inventoryItems'
 
 export interface ApiCalls {
   playthroughs: HttpVerb[]

--- a/src/types/apiCalls.d.ts
+++ b/src/types/apiCalls.d.ts
@@ -6,4 +6,6 @@ export interface ApiCalls {
   playthroughs: HttpVerb[]
   wishLists: HttpVerb[]
   wishListItems: HttpVerb[]
+  inventoryLists: HttpVerb[]
+  inventoryItems: HttpVerb[]
 }

--- a/src/types/apiData.d.ts
+++ b/src/types/apiData.d.ts
@@ -73,3 +73,48 @@ export interface ResponseWishListItem {
   created_at: Date
   updated_at: Date
 }
+
+/**
+ * 
+ * Inventory Lists
+ * 
+ */
+
+export interface RequestInventoryList {
+  title?: string
+}
+
+export interface ResponseInventoryList {
+  id: number
+  playthrough_id: number
+  aggregate_list_id: number | null
+  aggregate: boolean
+  title: string
+  list_items: ResponseInventoryItem[]
+  created_at: Date
+  updated_at: Date
+}
+
+/**
+ * 
+ * Inventory Items
+ * 
+ */
+
+export interface RequestInventoryItem {
+  quantity?: number
+  description?: string
+  unit_weight?: number | null
+  notes?: string | null
+}
+
+export interface ResponseInventoryItem {
+  id: number
+  list_id: number
+  description: string
+  quantity: number
+  unit_weight: number | null
+  notes: string | null
+  created_at: Date
+  updated_at: Date
+}

--- a/src/utils/api/returnValues/inventoryItems.d.ts
+++ b/src/utils/api/returnValues/inventoryItems.d.ts
@@ -111,3 +111,52 @@ export type PatchInventoryItemResponse =
 export type PatchInventoryItemReturnValue =
   | { status: 200; json: ResponseInventoryItem[] }
   | { status: 405 | 422 | 500; json: ErrorObject }
+
+/**
+ * 
+ * Types used for DELETE /inventory_items/:id endpoint
+ * 
+ */
+
+class DeleteInventoryItemSuccessResponse extends ApiResponse {
+  status: 200
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 200; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteInventoryItemNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteInventoryItemErrorResponse extends ApiResponse {
+  status: 405 | 500
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 405 | 500; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+export type DeleteInventoryItemResponse =
+  | UnauthorizedResponse
+  | DeleteInventoryItemSuccessResponse
+  | DeleteInventoryItemNotFoundResponse
+  | DeleteInventoryItemErrorResponse
+
+export type DeleteInventoryItemReturnValue =
+  | { status: 200; json: ResponseInventoryList[] }
+  | { status: 405 | 500; json: ErrorObject }

--- a/src/utils/api/returnValues/inventoryItems.d.ts
+++ b/src/utils/api/returnValues/inventoryItems.d.ts
@@ -58,3 +58,56 @@ export type PostInventoryItemsResponse =
 export type PostInventoryItemsReturnValue =
   | { status: 200 | 201; json: ResponseInventoryList[] }
   | { status: 405 | 422 | 500; json: ErrorObject }
+
+/**
+ * 
+ * Types used for PATCH /inventory_items/:id endpoint
+ * 
+ */
+
+class PatchInventoryItemSuccessResponse extends ApiResponse {
+  status: 200
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 200; statusText?; string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PatchInventoryItemNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PatchInventoryItemErrorResponse extends ApiResponse {
+  status: 405 | 422 | 500
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: {
+      status: 405 | 422 | 500
+      statusText?: string
+      headers?: HTTPHeaders
+    }
+  ) {
+    super(body, options)
+  }
+}
+
+export type PatchInventoryItemResponse =
+  | UnauthorizedResponse
+  | PatchInventoryItemSuccessResponse
+  | PatchInventoryItemNotFoundResponse
+  | PatchInventoryItemErrorResponse
+
+export type PatchInventoryItemReturnValue =
+  | { status: 200; json: ResponseInventoryItem[] }
+  | { status: 405 | 422 | 500; json: ErrorObject }

--- a/src/utils/api/returnValues/inventoryItems.d.ts
+++ b/src/utils/api/returnValues/inventoryItems.d.ts
@@ -1,0 +1,60 @@
+import { ApiResponse, type HTTPBody, type HTTPHeaders } from '../http'
+import {
+  type ErrorObject,
+  type ResponseInventoryList,
+  type ResponseInventoryItem,
+} from '../../../types/apiData'
+import { UnauthorizedResponse } from './shared'
+
+/**
+ * 
+ * Types used for POST /inventory_lists/:list_id/list_items endpoint
+ * 
+ */
+
+class PostInventoryItemsSuccessResponse extends ApiResponse {
+  status: 200 | 201
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 200 | 201; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PostInventoryItemsNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PostInventoryItemsErrorResponse extends ApiResponse {
+  status: 405 | 422 | 500
+
+  construtor(
+    body: HTTPBody | undefined,
+    options: {
+      status: 405 | 422 | 500
+      statusText?: string
+      headers?: HTTPHeaders
+    }
+  ) {
+    super(body, options)
+  }
+}
+
+export type PostInventoryItemsResponse =
+  | UnauthorizedResponse
+  | PostInventoryItemsSuccessResponse
+  | PostInventoryItemsNotFoundResponse
+  | PostInventoryItemsErrorResponse
+
+export type PostInventoryItemsReturnValue =
+  | { status: 200 | 201; json: ResponseInventoryList[] }
+  | { status: 405 | 422 | 500; json: ErrorObject }

--- a/src/utils/api/returnValues/inventoryItems.d.ts
+++ b/src/utils/api/returnValues/inventoryItems.d.ts
@@ -37,7 +37,7 @@ class PostInventoryItemsNotFoundResponse extends ApiResponse {
 class PostInventoryItemsErrorResponse extends ApiResponse {
   status: 405 | 422 | 500
 
-  construtor(
+  constructor(
     body: HTTPBody | undefined,
     options: {
       status: 405 | 422 | 500

--- a/src/utils/api/returnValues/inventoryLists.d.ts
+++ b/src/utils/api/returnValues/inventoryLists.d.ts
@@ -1,5 +1,6 @@
 import { ApiResponse, type HTTPBody, type HTTPHeaders } from '../http'
 import {
+    ResponseWishList,
   type ErrorObject,
   type ResponseInventoryList
 } from '../../../types/apiData'
@@ -155,4 +156,57 @@ export type PatchInventoryListResponse =
 export type PatchInventoryListReturnValue =
   | { status: 200; json: ResponseInventoryList }
   | { status: 405 | 422 | 500; json: ErrorObject }
-  
+
+/**
+ * 
+ * Types used for DELETE /inventory_lists/:id endpoint
+ *
+ */
+
+class DeleteInventoryListSuccessResponse extends ApiResponse {
+  status: 200
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 200; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteInventoryListNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class DeleteInventoryListErrorResponse extends ApiResponse {
+  status: 405 | 500
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 405 | 500; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+export type DeleteInventoryListSuccessResponseBody = {
+  deleted: number[]
+  aggregate?: ResponseInventoryList
+}
+
+export type DeleteInventoryListResponse =
+  | UnauthorizedResponse
+  | DeleteInventoryListSuccessResponse
+  | DeleteInventoryListNotFoundResponse
+  | DeleteInventoryListErrorResponse
+
+export type DeleteInventoryListReturnValue =
+  | { status: 200; json: DeleteInventoryListSuccessResponseBody }
+  | { status: 405 | 500; json: ErrorObject }

--- a/src/utils/api/returnValues/inventoryLists.d.ts
+++ b/src/utils/api/returnValues/inventoryLists.d.ts
@@ -102,3 +102,57 @@ export type GetInventoryListsResponse =
 export type GetInventoryListsReturnValue =
   | { status: 200; json: ResponseInventoryList[] }
   | { status: 500; json: ErrorObject }
+
+/**
+ * 
+ * Types used for PATCH /inventory_lists/:id endpoint
+ * 
+ */
+
+class PatchInventoryListSuccessResponse extends ApiResponse {
+  status: 200
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 200; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PatchInventoryListNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PatchInventoryListErrorResponse extends ApiResponse {
+  status: 405 | 422 | 500
+
+  construtor(
+    body: HTTPBody | undefined,
+    options: {
+      status: 405 | 422 | 500
+      statusText?: string
+      headers?: HTTPHeaders
+    }
+  ) {
+    super(body, options)
+  }
+}
+
+export type PatchInventoryListResponse =
+  | UnauthorizedResponse
+  | PatchInventoryListSuccessResponse
+  | PatchInventoryListNotFoundResponse
+  | PatchInventoryListErrorResponse
+
+export type PatchInventoryListReturnValue =
+  | { status: 200; json: ResponseInventoryList }
+  | { status: 405 | 422 | 500; json: ErrorObject }
+  

--- a/src/utils/api/returnValues/inventoryLists.d.ts
+++ b/src/utils/api/returnValues/inventoryLists.d.ts
@@ -53,3 +53,52 @@ export type PostInventoryListsResponse =
 export type PostInventoryListsReturnValue =
   | { status: 201; json: ResponseInventoryList[] }
   | { status: 422 | 500; json: ErrorObject }
+
+/**
+ * 
+ * Types used for GET /playthroughs/:playthrough_id/inventory_lists endpoint
+ * 
+ */
+
+class GetInventoryListsSuccessResponse extends ApiResponse {
+  status: 200
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 200; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class GetInventoryListsNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class GetInventoryListsServerErrorResponse extends ApiResponse {
+  status: 500
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 500; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+export type GetInventoryListsResponse =
+  | UnauthorizedResponse
+  | GetInventoryListsSuccessResponse
+  | GetInventoryListsNotFoundResponse
+  | GetInventoryListsServerErrorResponse
+
+export type GetInventoryListsReturnValue =
+  | { status: 200; json: ResponseInventoryList[] }
+  | { status: 500; json: ErrorObject }

--- a/src/utils/api/returnValues/inventoryLists.d.ts
+++ b/src/utils/api/returnValues/inventoryLists.d.ts
@@ -1,0 +1,55 @@
+import { ApiResponse, type HTTPBody, type HTTPHeaders } from '../http'
+import {
+  type ErrorObject,
+  type ResponseInventoryList
+} from '../../../types/apiData'
+import { UnauthorizedResponse } from './shared'
+
+/**
+ * 
+ * Types used for POST /playthroughs/:playthrough_id/inventory_lists endpoint
+ * 
+ */
+
+class PostInventoryListsSuccessResponse extends ApiResponse {
+  status: 201
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 201; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PostInventoryListsNotFoundResponse extends ApiResponse {
+  status: 404
+
+  constructor(
+    body?: null,
+    options: { status: 404; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+class PostInventoryListsErrorResponse extends ApiResponse {
+  status: 422 | 500
+
+  constructor(
+    body: HTTPBody | undefined,
+    options: { status: 422 | 500; statusText?: string; headers?: HTTPHeaders }
+  ) {
+    super(body, options)
+  }
+}
+
+export type PostInventoryListsResponse =
+  | UnauthorizedResponse
+  | PostInventoryListsSuccessResponse
+  | PostInventoryListsNotFoundResponse
+  | PostInventoryListsErrorResponse
+
+export type PostInventoryListsReturnValue =
+  | { status: 201; json: ResponseInventoryList[] }
+  | { status: 422 | 500; json: ErrorObject }

--- a/src/utils/api/returnValues/inventoryLists.d.ts
+++ b/src/utils/api/returnValues/inventoryLists.d.ts
@@ -1,6 +1,5 @@
 import { ApiResponse, type HTTPBody, type HTTPHeaders } from '../http'
 import {
-    ResponseWishList,
   type ErrorObject,
   type ResponseInventoryList
 } from '../../../types/apiData'
@@ -135,7 +134,7 @@ class PatchInventoryListNotFoundResponse extends ApiResponse {
 class PatchInventoryListErrorResponse extends ApiResponse {
   status: 405 | 422 | 500
 
-  construtor(
+  constructor(
     body: HTTPBody | undefined,
     options: {
       status: 405 | 422 | 500

--- a/src/utils/api/returnValues/wishLists.d.ts
+++ b/src/utils/api/returnValues/wishLists.d.ts
@@ -195,7 +195,7 @@ class DeleteWishListErrorResponse extends ApiResponse {
   }
 }
 
-interface DeleteWishListSuccessResponseBody {
+export type DeleteWishListSuccessResponseBody = {
   deleted: number[]
   aggregate?: ResponseWishList
 }

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -17,6 +17,7 @@ import {
 } from './wrapper/wishListItemEndpoints'
 import {
   postInventoryLists,
+  getInventoryLists,
 } from './wrapper/inventoryListEndpoints'
 
 export {
@@ -32,4 +33,5 @@ export {
   patchWishListItem,
   deleteWishListItem,
   postInventoryLists,
+  getInventoryLists,
 }

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -20,6 +20,9 @@ import {
   getInventoryLists,
   patchInventoryList
 } from './wrapper/inventoryListEndpoints'
+import {
+  postInventoryItems,
+} from './wrapper/inventoryItemEndpoints'
 
 export {
   postPlaythroughs,
@@ -35,5 +38,6 @@ export {
   deleteWishListItem,
   postInventoryLists,
   getInventoryLists,
-  patchInventoryList
+  patchInventoryList,
+  postInventoryItems,
 }

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -23,6 +23,7 @@ import {
 import {
   postInventoryItems,
   patchInventoryItem,
+  deleteInventoryItem,
 } from './wrapper/inventoryItemEndpoints'
 
 export {
@@ -42,4 +43,5 @@ export {
   patchInventoryList,
   postInventoryItems,
   patchInventoryItem,
+  deleteInventoryItem,
 }

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -22,6 +22,7 @@ import {
 } from './wrapper/inventoryListEndpoints'
 import {
   postInventoryItems,
+  patchInventoryItem,
 } from './wrapper/inventoryItemEndpoints'
 
 export {
@@ -40,4 +41,5 @@ export {
   getInventoryLists,
   patchInventoryList,
   postInventoryItems,
+  patchInventoryItem,
 }

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -15,6 +15,9 @@ import {
   patchWishListItem,
   deleteWishListItem,
 } from './wrapper/wishListItemEndpoints'
+import {
+  postInventoryLists,
+} from './wrapper/inventoryListEndpoints'
 
 export {
   postPlaythroughs,
@@ -28,4 +31,5 @@ export {
   postWishListItems,
   patchWishListItem,
   deleteWishListItem,
+  postInventoryLists,
 }

--- a/src/utils/api/simApi.ts
+++ b/src/utils/api/simApi.ts
@@ -18,6 +18,7 @@ import {
 import {
   postInventoryLists,
   getInventoryLists,
+  patchInventoryList
 } from './wrapper/inventoryListEndpoints'
 
 export {
@@ -34,4 +35,5 @@ export {
   deleteWishListItem,
   postInventoryLists,
   getInventoryLists,
+  patchInventoryList
 }

--- a/src/utils/api/wrapper/inventoryItemEndpoints.ts
+++ b/src/utils/api/wrapper/inventoryItemEndpoints.ts
@@ -10,6 +10,8 @@ import {
   type PostInventoryItemsReturnValue,
   type PatchInventoryItemResponse,
   type PatchInventoryItemReturnValue,
+  type DeleteInventoryItemResponse,
+  type DeleteInventoryItemReturnValue,
 } from '../returnValues/inventoryItems'
 import {
   AuthorizationError,
@@ -104,5 +106,41 @@ export const patchInventoryItem = (
         
         return returnValue as PatchInventoryItemReturnValue
       })
+  })
+}
+
+/**
+ * 
+ * DELETE /inventory_items/:id endpoint
+ * 
+ */
+
+export const deleteInventoryItem = (
+  itemId: number,
+  token: string
+): Promise<DeleteInventoryItemReturnValue> | never => {
+  const uri = `${BASE_URI}/inventory_items/${itemId}`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, { method: 'DELETE', headers }).then((res) => {
+    const response = res as DeleteInventoryItemResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+    
+    return response.json().then((json: ResponseInventoryList[] | ErrorObject) => {
+      const returnValue = { status: response.status, json }
+
+      if (returnValue.status === 405)
+        throw new MethodNotAllowedError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      if (returnValue.status === 500)
+        throw new InternalServerError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      
+      return returnValue as DeleteInventoryItemReturnValue
+    })
   })
 }

--- a/src/utils/api/wrapper/inventoryItemEndpoints.ts
+++ b/src/utils/api/wrapper/inventoryItemEndpoints.ts
@@ -1,0 +1,61 @@
+import {
+  type RequestInventoryItem,
+  type ResponseInventoryList,
+  type ResponseInventoryItem,
+  type ErrorObject,
+} from '../../../types/apiData'
+import { BASE_URI, combinedHeaders } from '../sharedUtils'
+import {
+  type PostInventoryItemsResponse,
+  type PostInventoryItemsReturnValue,
+} from '../returnValues/inventoryItems'
+import {
+  AuthorizationError,
+  NotFoundError,
+  MethodNotAllowedError,
+  UnprocessableEntityError,
+  InternalServerError,
+} from '../apiErrors'
+
+/**
+ * 
+ * POST /inventory_lists/:list_id/inventory_items endpoint
+ * 
+ */
+
+export const postInventoryItems = (
+  listId: number,
+  attributes: RequestInventoryItem,
+  token: string
+): Promise<PostInventoryItemsReturnValue> | never => {
+  const uri = `${BASE_URI}/inventory_lists/${listId}/inventory_items`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, {
+    method: 'POST',
+    body: JSON.stringify(attributes),
+    headers
+  }).then((res) => {
+    const response = res as PostInventoryItemsResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+    
+    return response.json().then((json: ResponseInventoryList[] | ErrorObject) => {
+      const returnValue = { status: response.status, json }
+
+      if (returnValue.status === 405)
+        throw new MethodNotAllowedError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      if (returnValue.status === 422)
+        throw new UnprocessableEntityError((json as ErrorObject).errors)
+      if (returnValue.status === 500)
+        throw new InternalServerError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      
+      return returnValue as PostInventoryItemsReturnValue
+    })
+  })
+}

--- a/src/utils/api/wrapper/inventoryItemEndpoints.ts
+++ b/src/utils/api/wrapper/inventoryItemEndpoints.ts
@@ -8,6 +8,8 @@ import { BASE_URI, combinedHeaders } from '../sharedUtils'
 import {
   type PostInventoryItemsResponse,
   type PostInventoryItemsReturnValue,
+  type PatchInventoryItemResponse,
+  type PatchInventoryItemReturnValue,
 } from '../returnValues/inventoryItems'
 import {
   AuthorizationError,
@@ -57,5 +59,50 @@ export const postInventoryItems = (
       
       return returnValue as PostInventoryItemsReturnValue
     })
+  })
+}
+
+/**
+ * 
+ * PATCH /inventory_items/:id endpoint
+ * 
+ */
+
+export const patchInventoryItem = (
+  itemId: number,
+  attributes: RequestInventoryItem,
+  token: string
+): Promise<PatchInventoryItemReturnValue> | never => {
+  const uri = `${BASE_URI}/inventory_items/${itemId}`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, {
+    method: 'PATCH',
+    body: JSON.stringify(attributes),
+    headers,
+  }).then((res) => {
+    const response = res as PatchInventoryItemResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+    
+    return response
+      .json()
+      .then((json: ResponseInventoryItem[] | ErrorObject) => {
+        const returnValue = { status: response.status, json }
+
+        if (returnValue.status === 405)
+          throw new MethodNotAllowedError(
+            (json as ErrorObject).errors.join(', ')
+          )
+        if (returnValue.status === 422)
+          throw new UnprocessableEntityError((json as ErrorObject).errors)
+        if (returnValue.status === 500)
+          throw new InternalServerError(
+            (json as ErrorObject).errors.join(', ')
+          )
+        
+        return returnValue as PatchInventoryItemReturnValue
+      })
   })
 }

--- a/src/utils/api/wrapper/inventoryListEndpoints.ts
+++ b/src/utils/api/wrapper/inventoryListEndpoints.ts
@@ -1,0 +1,55 @@
+import {
+  type RequestInventoryList,
+  type ResponseInventoryList,
+  type ErrorObject,
+} from '../../../types/apiData'
+import { BASE_URI, combinedHeaders } from '../sharedUtils'
+import {
+  type PostInventoryListsResponse,
+  type PostInventoryListsReturnValue
+} from '../returnValues/inventoryLists'
+import {
+  AuthorizationError,
+  NotFoundError,
+  UnprocessableEntityError,
+  InternalServerError
+} from '../apiErrors'
+
+/**
+ * 
+ * POST /playthroughs/:playthrough_id/inventory_lists endpoint
+ * 
+ */
+
+export const postInventoryLists = (
+  playthroughId: number,
+  attributes: RequestInventoryList,
+  token: string
+): Promise<PostInventoryListsReturnValue> | never => {
+  const uri = `${BASE_URI}/playthroughs/${playthroughId}/inventory_lists`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, {
+    method: 'POST',
+    body: JSON.stringify(attributes),
+    headers
+  }).then((res) => {
+    const response = res as PostInventoryListsResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+
+    return response.json().then((json: ResponseInventoryList[] | ErrorObject) => {
+      const returnValue = { status: response.status, json }
+
+      if (returnValue.status === 422)
+        throw new UnprocessableEntityError((json as ErrorObject).errors)
+      if (returnValue.status === 500)
+        throw new InternalServerError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      
+      return returnValue as PostInventoryListsReturnValue
+    })
+  })
+}

--- a/src/utils/api/wrapper/inventoryListEndpoints.ts
+++ b/src/utils/api/wrapper/inventoryListEndpoints.ts
@@ -11,6 +11,9 @@ import {
   type GetInventoryListsReturnValue,
   type PatchInventoryListResponse,
   type PatchInventoryListReturnValue,
+  type DeleteInventoryListResponse,
+  type DeleteInventoryListReturnValue,
+  type DeleteInventoryListSuccessResponseBody,
 } from '../returnValues/inventoryLists'
 import {
   AuthorizationError,
@@ -131,5 +134,43 @@ export const patchInventoryList = (
       
       return returnValue as PatchInventoryListReturnValue
     })
+  })
+}
+
+/**
+ * 
+ * DELETE /inventory_lists/:id endpoint
+ * 
+ */
+
+export const deleteInventoryList = (
+  listId: number,
+  token: string
+): Promise<DeleteInventoryListReturnValue> | never => {
+  const uri = `${BASE_URI}/inventory_lists/${listId}`
+  const headers = combinedHeaders(token)
+  
+  return fetch(uri, { method: 'DELETE', headers }).then((res) => {
+    const response = res as DeleteInventoryListResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+    
+    return response
+      .json()
+      .then((json: DeleteInventoryListSuccessResponseBody | ErrorObject) => {
+        const returnValue = { status: response.status, json }
+
+        if (returnValue.status === 405)
+          throw new MethodNotAllowedError(
+            (json as ErrorObject).errors.join(', ')
+          )
+        if (returnValue.status === 500)
+          throw new InternalServerError(
+            (json as ErrorObject).errors.join(', ')
+          )
+        
+        return returnValue as DeleteInventoryListReturnValue
+      })
   })
 }

--- a/src/utils/api/wrapper/inventoryListEndpoints.ts
+++ b/src/utils/api/wrapper/inventoryListEndpoints.ts
@@ -9,12 +9,15 @@ import {
   type PostInventoryListsReturnValue,
   type GetInventoryListsResponse,
   type GetInventoryListsReturnValue,
+  type PatchInventoryListResponse,
+  type PatchInventoryListReturnValue,
 } from '../returnValues/inventoryLists'
 import {
   AuthorizationError,
   NotFoundError,
   UnprocessableEntityError,
-  InternalServerError
+  InternalServerError,
+  MethodNotAllowedError
 } from '../apiErrors'
 
 /**
@@ -84,6 +87,49 @@ export const getInventoryLists = (
         )
       
       return returnValue as GetInventoryListsReturnValue
+    })
+  })
+}
+
+/**
+ * 
+ * PATCH /inventory_lists/:id endpoint
+ * 
+ */
+
+export const patchInventoryList = (
+  listId: number,
+  attributes: RequestInventoryList,
+  token: string
+): Promise<PatchInventoryListReturnValue> | never => {
+  const uri = `${BASE_URI}/inventory_lists/${listId}`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, {
+    method: 'PATCH',
+    body: JSON.stringify(attributes),
+    headers,
+  }).then((res) => {
+    const response = res as PatchInventoryListResponse
+    
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+    
+    return response.json().then((json: ResponseInventoryList | ErrorObject) => {
+      const returnValue = { status: response.status, json }
+
+      if (returnValue.status === 405)
+        throw new MethodNotAllowedError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      if (returnValue.status === 422)
+        throw new UnprocessableEntityError((json as ErrorObject).errors)
+      if (returnValue.status === 500)
+        throw new InternalServerError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      
+      return returnValue as PatchInventoryListReturnValue
     })
   })
 }

--- a/src/utils/api/wrapper/inventoryListEndpoints.ts
+++ b/src/utils/api/wrapper/inventoryListEndpoints.ts
@@ -6,7 +6,9 @@ import {
 import { BASE_URI, combinedHeaders } from '../sharedUtils'
 import {
   type PostInventoryListsResponse,
-  type PostInventoryListsReturnValue
+  type PostInventoryListsReturnValue,
+  type GetInventoryListsResponse,
+  type GetInventoryListsReturnValue,
 } from '../returnValues/inventoryLists'
 import {
   AuthorizationError,
@@ -50,6 +52,38 @@ export const postInventoryLists = (
         )
       
       return returnValue as PostInventoryListsReturnValue
+    })
+  })
+}
+
+/**
+ * 
+ * GET /playthroughs/:playthrough_id/inventory_lists endpoint
+ * 
+ */
+
+export const getInventoryLists = (
+  playthroughId: number,
+  token: string
+): Promise<GetInventoryListsReturnValue> | never => {
+  const uri = `${BASE_URI}/playthroughs/${playthroughId}/inventory_lists`
+  const headers = combinedHeaders(token)
+
+  return fetch(uri, { headers }).then((res) => {
+    const response = res as GetInventoryListsResponse
+
+    if (response.status === 401) throw new AuthorizationError()
+    if (response.status === 404) throw new NotFoundError()
+    
+    return response.json().then((json: ResponseInventoryList[] | ErrorObject) => {
+      const returnValue = { status: response.status, json }
+
+      if (returnValue.status === 500)
+        throw new InternalServerError(
+          (json as ErrorObject).errors.join(', ')
+        )
+      
+      return returnValue as GetInventoryListsReturnValue
     })
   })
 }

--- a/src/utils/api/wrapper/wishListEndpoints.ts
+++ b/src/utils/api/wrapper/wishListEndpoints.ts
@@ -13,6 +13,7 @@ import {
   type PatchWishListReturnValue,
   type DeleteWishListResponse,
   type DeleteWishListReturnValue,
+  type DeleteWishListSuccessResponseBody
 } from '../returnValues/wishLists'
 import {
   AuthorizationError,
@@ -142,11 +143,6 @@ export const patchWishList = (
  *
  */
 
-interface DeleteWishListSuccessBody {
-  deleted: number[]
-  aggregate?: ResponseWishList
-}
-
 export const deleteWishList = (
   listId: number,
   token: string
@@ -162,7 +158,7 @@ export const deleteWishList = (
 
     return response
       .json()
-      .then((json: DeleteWishListSuccessBody | ErrorObject) => {
+      .then((json: DeleteWishListSuccessResponseBody | ErrorObject) => {
         const returnValue = { status: response.status, json }
 
         if (returnValue.status === 405)

--- a/src/utils/api/wrapper/wishListItemEndpoints.ts
+++ b/src/utils/api/wrapper/wishListItemEndpoints.ts
@@ -23,7 +23,7 @@ import {
 
 /**
  *
- * POST /wish_lists/:list_id/list_items endpoint
+ * POST /wish_lists/:list_id/wish_list_items endpoint
  *
  */
 


### PR DESCRIPTION
## Context

[**Add inventory list routes to frontend API wrapper**](https://trello.com/c/zaT9JcTb/421-add-inventory-list-routes-to-frontend-api-module)

Inventory list functionality is fully implemented on the backend, but the frontend still doesn't have an inventory list page or context.

## Changes

* Add routes for inventory lists to the API wrapper
* Add routes for inventory items to the API wrapper

## Required Tasks

- [ ] ~~Add/update automated tests~~
- [ ] ~~Add/update Storybook stories~~
- [ ] ~~Comprehensively test final changes in local environment~~
- [ ] Add/update docs
- [ ] Run formatter on final changes
- [x] Verify TypeScript compiles

## Manual Test Cases

There are no changes that can be tested manually until we implement the inventory lists page.

## Screenshots and GIFs

This PR includes no visible changes.
