### PR TITLE
Update Node to 26.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
-        node-version: "23.2.0"
+        node-version: "26.5.0"
     - name: Install Node Modules
       run: yarn
     - name: Compile Production Build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 23.2.0
+nodejs 26.5.0

--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,7 @@
   "hosting": {
     "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "nodeVersion": 21,
+    "nodeVersion": 26,
     "rewrites": [
       {
         "source": "**",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": "23.2.0"
+    "node": "26.5.0"
   },
   "scripts": {
     "build": "tsc && vite build",


### PR DESCRIPTION
## Context

We are three major Node versions behind.

## Changes

* Update Node version to 26.5.0 in `.tool-versions`
* Update Node version to 26.5.0 in `package.json`
* Update Node version to 26 in Firebase
* Update Node version to 26.5.0 in GitHub Actions