### PR TITLE
Fix nitpicks from previous PR

### DIFF
--- a/src/components/listItemCreateForm/listItemCreateForm.test.tsx
+++ b/src/components/listItemCreateForm/listItemCreateForm.test.tsx
@@ -4,8 +4,8 @@ import { render } from '../../support/testUtils'
 import { YELLOW } from '../../utils/colorSchemes'
 import { ColorProvider } from '../../contexts/colorContext'
 import { type RequestWishListItem, type RequestInventoryItem } from '../../types/apiData'
+import { CallbackFunction } from '../../types/functions'
 import ListItemCreateForm from './listItemCreateForm'
-import { CallbackFunction } from '../../types/functions';
 
 describe('ListItemCreateForm', () => {
   describe('for wish list item', () => {

--- a/src/components/listItemCreateForm/listItemCreateForm.tsx
+++ b/src/components/listItemCreateForm/listItemCreateForm.tsx
@@ -6,11 +6,11 @@ import {
   useRef,
   useState
 } from 'react'
+import classNames from 'classnames'
+import AnimateHeight from 'react-animate-height'
 import { type RequestWishListItem, type RequestInventoryItem } from '../../types/apiData'
 import { type CallbackFunction } from '../../types/functions'
 import { useColorScheme } from '../../hooks/contexts'
-import classNames from 'classnames'
-import AnimateHeight from 'react-animate-height'
 import styles from './listItemCreateForm.module.css'
 
 export type SubmitHandlerType =


### PR DESCRIPTION
## Context

I forgot to actually review the previous PR before merging - just checked if it passed CI. Fortunately, the only issues I found were some out-of-order imports. The order doesn't strictly matter, but for style reasons we try to put third-party packages first, then imports from within this codebase, with the CSS module import last.

## Changes

* Fix order of imports to be in line with informal style guidelines for this repo.